### PR TITLE
[FIX] remove raised error if obsolete fields are in old views

### DIFF
--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -1577,7 +1577,7 @@ class BaseModel(object):
         if error_msgs:
             # OpenUpgrade: do not raise for obsolete fields
             # raise except_orm('ValidateError', '\n'.join(error_msgs))
-            _logger.debug('OpenUpgrade: View error has not been raised. %s', msg)
+            _logger.debug('OpenUpgrade: View error has not been raised. %s', '\n'.join(error_msgs))
             pass
 
     def default_get(self, cr, uid, fields_list, context=None):

--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -1578,7 +1578,6 @@ class BaseModel(object):
             # OpenUpgrade: do not raise for obsolete fields
             # raise except_orm('ValidateError', '\n'.join(error_msgs))
             _logger.debug('OpenUpgrade: View error has not been raised. %s', '\n'.join(error_msgs))
-            pass
 
     def default_get(self, cr, uid, fields_list, context=None):
         """

--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -1575,7 +1575,9 @@ class BaseModel(object):
                         _("The field(s) `%s` failed against a constraint: %s") % (', '.join(fields), translated_msg)
                 )
         if error_msgs:
-            raise except_orm('ValidateError', '\n'.join(error_msgs))
+            # OpenUpgrade: do not raise for obsolete fields
+            # raise except_orm('ValidateError', '\n'.join(error_msgs))
+            pass
 
     def default_get(self, cr, uid, fields_list, context=None):
         """

--- a/openerp/osv/orm.py
+++ b/openerp/osv/orm.py
@@ -1577,6 +1577,7 @@ class BaseModel(object):
         if error_msgs:
             # OpenUpgrade: do not raise for obsolete fields
             # raise except_orm('ValidateError', '\n'.join(error_msgs))
+            _logger.debug('OpenUpgrade: View error has not been raised. %s', msg)
             pass
 
     def default_get(self, cr, uid, fields_list, context=None):


### PR DESCRIPTION
Do not raise an error if obsolete fields are presents in old views.
