### PR TITLE
[REF] comply with PEP 8 and typo fixes

### DIFF
--- a/openerp/addons/base/migrations/8.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/8.0.1.3/pre-migration.py
@@ -28,6 +28,7 @@ column_renames = {
     ]
 }
 
+
 @openupgrade.migrate()
 def migrate(cr, version):
     openupgrade.check_values_selection_field(

--- a/openerp/addons/openupgrade_records/lib/compare.py
+++ b/openerp/addons/openupgrade_records/lib/compare.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     from openupgrade_records.lib import apriori
 
+
 def module_map(module):
     return apriori.renamed_modules.get(
         module, module)
@@ -68,7 +69,7 @@ def search(item, item_list, fields):
         if not compare_records(item, i, fields):
             continue
         return i
-    #search for renamed fields
+    # search for renamed fields
     if 'field' in fields:
         for i in item_list:
             if not item['field'] or item['field'] != i.get('oldname'):

--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -141,7 +141,7 @@ def load_module_graph(cr, graph, status=None, perform_checks=True, skip_modules=
     for field in cr.dictfetchall():
         registry.fields_by_model.setdefault(field['model'], []).append(field)
 
-    #suppress commits to have the upgrade of one module in just one transation
+    # suppress commits to have the upgrade of one module in just one transaction
     cr.commit_org = cr.commit
     cr.commit = lambda *args: None
     cr.rollback_org = cr.rollback
@@ -201,8 +201,9 @@ def load_module_graph(cr, graph, status=None, perform_checks=True, skip_modules=
             # as errors in post scripts seem to be dropped
             try:
                 migrations.migrate_module(package, 'post')
-            except Exception, e:
-                _logger.error('Error executing post migration script for module %s: %s', package, e)
+            except Exception as exc:
+                _logger.error('Error executing post migration script for module %s: %s',
+                              package, exc)
                 raise
 
             registry._init_modules.add(package.name)

--- a/openerp/modules/migration.py
+++ b/openerp/modules/migration.py
@@ -164,17 +164,21 @@ class MigrationManager(object):
                         fp2.seek(0)
                         try:
                             mod = imp.load_source(name, pyfile, fp2)
-                            _logger.info('module %(addon)s: Running migration %(version)s %(name)s' % mergedict({'name': mod.__name__}, strfmt))
+                            _logger.info('module %(addon)s: Running migration %(version)s %(name)s',
+                                         mergedict({'name': mod.__name__}, strfmt))
                         except ImportError:
-                            _logger.exception('module %(addon)s: Unable to load %(stage)s-migration file %(file)s' % mergedict({'file': pyfile}, strfmt))
+                            _logger.exception('module %(addon)s: Unable to load %(stage)s-migration file %(file)s',
+                                              mergedict({'file': pyfile}, strfmt))
                             raise
 
-                        _logger.info('module %(addon)s: Running migration %(version)s %(name)s' % mergedict({'name': mod.__name__}, strfmt))
+                        _logger.info('module %(addon)s: Running migration %(version)s %(name)s',
+                                     mergedict({'name': mod.__name__}, strfmt))
 
                         if hasattr(mod, 'migrate'):
                             mod.migrate(self.cr, pkg.installed_version)
                         else:
-                            _logger.error('module %(addon)s: Each %(stage)s-migration file must have a "migrate(cr, installed_version)" function' % strfmt)
+                            _logger.error('module %(addon)s: Each %(stage)s-migration file must have a "migrate(cr, installed_version)" function',
+                                          strfmt)
                     finally:
                         if fp:
                             fp.close()

--- a/openerp/openupgrade/doc/source/conf.py
+++ b/openerp/openupgrade/doc/source/conf.py
@@ -53,31 +53,31 @@ release = '8.0'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
 today_fmt = '%B %d, %Y'
 
 # List of documents that shouldn't be included in the build.
-#unused_docs = []
+# unused_docs = []
 
 # List of directories, relative to source directories, that shouldn't be
 # searched for source files.
-#exclude_dirs = []
+# exclude_dirs = []
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'
@@ -93,19 +93,19 @@ html_style = 'default.css'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (within the static path) to place at the top of
 # the sidebar.
-#html_logo = None
+# html_logo = None
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-#html_favicon = None
+# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -118,34 +118,34 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, maps document names to template names.
-#html_sidebars = {}
+# html_sidebars = {}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_use_modindex = True
+# html_use_modindex = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
-#html_copy_source = True
+# html_copy_source = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = ''
+# html_file_suffix = ''
 
 # Output file base name for HTML help builder.
 htmlhelp_basename = 'OpenUpgradedoc'
@@ -155,10 +155,10 @@ htmlhelp_basename = 'OpenUpgradedoc'
 # ------------------------
 
 # The paper size ('letter' or 'a4').
-#latex_paper_size = 'letter'
+# latex_paper_size = 'letter'
 
 # The font size ('10pt', '11pt' or '12pt').
-#latex_font_size = '10pt'
+# latex_font_size = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class
@@ -170,20 +170,20 @@ latex_documents = [
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # Additional stuff for the LaTeX preamble.
-#latex_preamble = ''
+# latex_preamble = ''
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_use_modindex = True
+# latex_use_modindex = True
 
 
 # Use Mock classes for building on readthedocs.org

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -52,7 +52,7 @@ __all__ = [
     'get_legacy_name',
     'm2o_to_m2m',
     'message',
-    'check_values_fields_selection',
+    'check_values_selection_field',
 ]
 
 
@@ -64,18 +64,17 @@ def check_values_selection_field(cr, table_name, field_name, allowed_values):
         If yes, return True.
     """
     res = True
-    cr.execute(
-        "SELECT %s, count(*) FROM %s GROUP BY %s;" % (
-            field_name,table_name, field_name,
-            ))
+    cr.execute("SELECT %s, count(*) FROM %s GROUP BY %s;" %
+               (field_name, table_name, field_name))
     for row in cr.fetchall():
         if row[0] not in allowed_values:
             logger.error(
                 "Invalid value '%s' in the table '%s' "
-                "for the field '%s'. (%s rows)." % (
-                    row[0], table_name, field_name, row[1]))
+                "for the field '%s'. (%s rows).",
+                row[0], table_name, field_name, row[1])
             res = False
     return res
+
 
 def load_data(cr, module_name, filename, idref=None, mode='init'):
     """

--- a/openerp/openupgrade/openupgrade_loading.py
+++ b/openerp/openupgrade/openupgrade_loading.py
@@ -163,9 +163,9 @@ def compare_registries(cr, module, registry, local_registry):
     """
     if not table_exists(cr, 'openupgrade_record'):
         return
-    for model, fields in local_registry.items():
+    for model, flds in local_registry.items():
         registry.setdefault(model, {})
-        for field, attributes in fields.items():
+        for field, attributes in flds.items():
             old_field = registry[model].setdefault(field, {})
             mode = old_field and 'modify' or 'create'
             record_id = False

--- a/openerp/openupgrade/openupgrade_log.py
+++ b/openerp/openupgrade/openupgrade_log.py
@@ -54,7 +54,7 @@ def log_xml_id(cr, module, xml_id):
     """
     if not table_exists(cr, 'openupgrade_record'):
         return
-    if not '.' in xml_id:
+    if '.' not in xml_id:
         xml_id = '%s.%s' % (module, xml_id)
     cr.execute(
         "SELECT model FROM ir_model_data "

--- a/openerp/openupgrade/openupgrade_tools.py
+++ b/openerp/openupgrade/openupgrade_tools.py
@@ -20,7 +20,7 @@
 ##############################################################################
 
 # A collection of functions split off from openupgrade.py
-# with have no or only minimal dependencies
+# with no or only minimal dependencies
 
 
 def table_exists(cr, table):

--- a/openerp/openupgrade/openupgrade_tools.py
+++ b/openerp/openupgrade/openupgrade_tools.py
@@ -20,12 +20,10 @@
 ##############################################################################
 
 # A collection of functions split off from openupgrade.py
-# with no or only minimal dependencies
+# with have no or only minimal dependencies
 
 
 def table_exists(cr, table):
     """ Check whether a certain table or view exists """
-    cr.execute(
-        'SELECT count(relname) FROM pg_class WHERE relname = %s',
-        (table,))
-    return cr.fetchone()[0] == 1
+    cr.execute('SELECT 1 FROM pg_class WHERE relname = %s', (table,))
+    return cr.fetchone()

--- a/scripts/compare_noupdate_xml_records.py
+++ b/scripts/compare_noupdate_xml_records.py
@@ -20,14 +20,18 @@
 #
 ##############################################################################
 
-import sys, os, ast, argparse
+import argparse
+import ast
+import os
 from copy import deepcopy
 from lxml import etree
+
 
 def read_manifest(addon_dir):
     with open(os.path.join(addon_dir, '__openerp__.py'), 'r') as f:
         manifest_string = f.read()
     return ast.literal_eval(manifest_string)
+
 
 # from openerp.tools
 def nodeattr2bool(node, attr, default=False):
@@ -38,6 +42,7 @@ def nodeattr2bool(node, attr, default=False):
         return default
     return val.lower() not in ('0', 'false', 'off')
 
+
 def get_node_dict(element):
     res = {}
     for child in element:
@@ -47,6 +52,7 @@ def get_node_dict(element):
             res[key] = child
     return res
 
+
 def get_node_value(element):
     if 'eval' in element.attrib.keys():
         return element.attrib['eval']
@@ -55,6 +61,7 @@ def get_node_value(element):
     if not len(element):
         return element.text
     return etree.tostring(element)
+
 
 def update_node(target, source):
     for element in source:
@@ -68,12 +75,13 @@ def update_node(target, source):
             target.remove(existing)
         target.append(element)
 
+
 def get_records(addon_dir):
     addon_dir = addon_dir.rstrip(os.sep)
     addon_name = os.path.basename(addon_dir)
     manifest = read_manifest(addon_dir)
     # The order of the keys are important.
-    # Load files in the same order as in 
+    # Load files in the same order as in
     # module/loading.py:load_module_graph
     keys = ['init_xml', 'update_xml', 'data']
     records_update = {}
@@ -115,6 +123,7 @@ def get_records(addon_dir):
                 process_data_node(data_node)
     return records_update, records_noupdate
 
+
 def main(argv=None):
     """
     Attempt to represent the differences in data records flagged with
@@ -136,7 +145,7 @@ def main(argv=None):
       email templates)
     - Does not handle the shorthand records <menu>, <act_window> etc.,
       although that could be done using the same expansion logic as
-      is used in their parsers in openerp/tools/convert.py 
+      is used in their parsers in openerp/tools/convert.py
     """
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -156,7 +165,7 @@ def main(argv=None):
             record_old = old_update[xml_id]
         elif xml_id in old_noupdate:
             record_old = old_noupdate[xml_id]
-    
+
         if record_old is None:
             continue
 
@@ -178,7 +187,7 @@ def main(argv=None):
             else:
                 oldrepr = get_node_value(record_old_dict[key])
                 newrepr = get_node_value(record_new_dict[key])
-            
+
                 if oldrepr != newrepr:
                     element.append(deepcopy(record_new_dict[key]))
 
@@ -198,4 +207,3 @@ def main(argv=None):
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
Minor changes to be compliant with PEP8, and fix a typo in `__all__` of `openerp/openupgrade/openupgrade.py`
