### PR TITLE
[ADD] add argument no_version for migrate decorator to force loading ...

### DIFF
--- a/openerp/modules/migration.py
+++ b/openerp/modules/migration.py
@@ -90,7 +90,7 @@ class MigrationManager(object):
             'post': '[%s>]',
         }
 
-        if not (hasattr(pkg, 'update') or pkg.state == 'to upgrade') or pkg.installed_version is None:
+        if not (hasattr(pkg, 'update') or pkg.state == 'to upgrade'):
             return
 
         def convert_version(version):

--- a/openerp/modules/migration.py
+++ b/openerp/modules/migration.py
@@ -89,7 +89,11 @@ class MigrationManager(object):
             'pre': '[>%s]',
             'post': '[%s>]',
         }
-
+        # In openupgrade, remove 'or pkg.installed_version is None'
+        # We want to always pass in pre and post migration files and use a new
+        # argument in the migrate decorator (explained in the docstring)
+        # to decide if we want to do something if a new module is installed
+        # during the migration.
         if not (hasattr(pkg, 'update') or pkg.state == 'to upgrade'):
             return
 

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -485,7 +485,7 @@ def message(cr, module, table, column,
     logger.warn(prefix + message, *argslist, **kwargs)
 
 
-def migrate():
+def migrate(no_version=False):
     """
     This is the decorator for the migrate() function
     in migration scripts.
@@ -509,8 +509,9 @@ def migrate():
                     "'migrate' decorator: failed to inspect "
                     "the frame above: %s" % e)
                 pass
-            if not version:
+            if not version and not no_version:
                 return
+            print 'lalalal'
             logger.info(
                 "%s: %s-migration script called with version %s" %
                 (module, stage, version))

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -511,7 +511,6 @@ def migrate(no_version=False):
                 pass
             if not version and not no_version:
                 return
-            print 'lalalal'
             logger.info(
                 "%s: %s-migration script called with version %s" %
                 (module, stage, version))

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -489,7 +489,9 @@ def migrate(no_version=False):
     """
     This is the decorator for the migrate() function
     in migration scripts.
-    Return when the 'version' argument is not defined,
+    Set argument 'no_version' to True if the method as to be taken into account
+    if the module is installed during a migration.
+    Return when the 'version' argument is not defined and no_version is False,
     and log execeptions.
     Retrieve debug context data from the frame above for
     logging purposes.


### PR DESCRIPTION
In version 8.0, during a migration, if a new module has to be installed (due to new dependency for instance), pre- and post- migration files are not loaded anymore. 

It can be usefull to pass sometimes in those files, for instance to not create a new ir_model_data that have been move to the new module (that will be installed).

This pull request revert this change (so pre- and post- migration files will be taken into account as before v 8.0) and adds a new argument 'no_version' in the decorator 'migrate'.
If no_version is True, it will pass threw the method wrap in the decorator. By default it's False to keep the "official" behaviour.
