### PR TITLE
[PORT] forward port from v 7.0 to handle installing dependencies during migration

### DIFF
--- a/openerp/openupgrade/openupgrade_loading.py
+++ b/openerp/openupgrade/openupgrade_loading.py
@@ -32,6 +32,7 @@ from openerp.tools import config, safe_eval
 
 logger = logging.getLogger('OpenUpgrade')
 
+
 def add_module_dependencies(cr, module_list):
     """
     Select (new) dependencies from the modules in the list
@@ -103,6 +104,7 @@ def add_module_dependencies(cr, module_list):
         module_list += auto_modules
 
     return module_list
+
 
 def log_model(model, local_registry):
     """

--- a/openerp/openupgrade/openupgrade_loading.py
+++ b/openerp/openupgrade/openupgrade_loading.py
@@ -20,6 +20,7 @@
 ##############################################################################
 
 import types
+import logging
 from openerp import release
 from openerp.osv.orm import TransientModel
 from openerp.osv import fields
@@ -29,6 +30,7 @@ from openerp.tools import config, safe_eval
 # A collection of functions used in
 # openerp/modules/loading.py
 
+logger = logging.getLogger('OpenUpgrade')
 
 def add_module_dependencies(cr, module_list):
     """
@@ -60,18 +62,47 @@ def add_module_dependencies(cr, module_list):
         module_list += forced_deps.get(module, [])
         module_list += autoinstall.get(module, [])
 
+    module_list = list(set(module_list))
+
+    dependencies = module_list
+    while dependencies:
+        cr.execute("""
+            SELECT DISTINCT dep.name
+            FROM
+                ir_module_module,
+                ir_module_module_dependency dep
+            WHERE
+                module_id = ir_module_module.id
+                AND ir_module_module.name in %s
+                AND dep.name not in %s
+            """, (tuple(dependencies), tuple(module_list),))
+
+        dependencies = [x[0] for x in cr.fetchall()]
+        module_list += dependencies
+
+    # Select auto_install modules of which all dependencies
+    # are fulfilled based on the modules we know are to be
+    # installed
     cr.execute("""
-        SELECT ir_module_module_dependency.name
-        FROM
-            ir_module_module,
-            ir_module_module_dependency
-        WHERE
-            module_id = ir_module_module.id
-            AND ir_module_module.name in %s
-        """, (tuple(module_list),))
-
-    return list(set(module_list + [x[0] for x in cr.fetchall()]))
-
+        SELECT name from ir_module_module WHERE state IN %s
+        """, (('installed', 'to install', 'to upgrade'),))
+    modules = list(set(module_list + [row[0] for row in cr.fetchall()]))
+    cr.execute("""
+        SELECT name from ir_module_module m
+        WHERE auto_install IS TRUE
+            AND state = 'uninstalled'
+            AND NOT EXISTS(
+                SELECT id FROM ir_module_module_dependency d
+                WHERE d.module_id = m.id
+                AND name NOT IN %s)
+         """, (tuple(modules),))
+    auto_modules = [row[0] for row in cr.fetchall()]
+    if auto_modules:
+        logger.info(
+            "Selecting autoinstallable modules %s", ','.join(auto_modules))
+        module_list += auto_modules
+    print module_list
+    return module_list
 
 def log_model(model, local_registry):
     """

--- a/openerp/openupgrade/openupgrade_loading.py
+++ b/openerp/openupgrade/openupgrade_loading.py
@@ -101,7 +101,7 @@ def add_module_dependencies(cr, module_list):
         logger.info(
             "Selecting autoinstallable modules %s", ','.join(auto_modules))
         module_list += auto_modules
-    print module_list
+
     return module_list
 
 def log_model(model, local_registry):


### PR DESCRIPTION
Forward port of commits 4647 and 4651 (in launchpad https://code.launchpad.net/~openupgrade-committers/openupgrade-server/7.0), in order to install correctly the dependencies (new modules and auto installable modules) of modules.
