### PR TITLE
[REF] openupgrade_records: sorting key can be a tuple

### DIFF
--- a/openerp/addons/openupgrade_records/lib/compare.py
+++ b/openerp/addons/openupgrade_records/lib/compare.py
@@ -240,7 +240,7 @@ def compare_xml_sets(old_records, new_records):
 
     sorted_records = sorted(
         old_records + new_records,
-        key=lambda k: '%-128s%s%s' % (k['model'], 'old' in k, k['name'])
+        key=lambda k: (k['model'], 'old' in k, k['name'])
     )
     for entry in sorted_records:
         if 'old' in entry:


### PR DESCRIPTION
remove useless string formatting.

No change for the boolean field because: "False" < "True" and False < True
