### PR TITLE
Update travis pep8 checking to cover migration files starting in pre- and pro-

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
     - flake8 openerp/openupgrade --max-line-length=120
     - flake8 openerp/addons/openupgrade* --max-line-length=120 --filename=__init__.py --ignore=F401
     - flake8 openerp/addons/openupgrade* --max-line-length=120 --exclude=__init__.py
-    - flake8 . --max-line-length=120 --filename=pre-migration.py,post-migration.py,pre_migration.py,post_migration.py
+    - flake8 . --max-line-length=120 --filename=pre-*.py,post-*.py


### PR DESCRIPTION
Migration scripts can have any name of the form pre-\* and post-\* as seen in #37
