### PR TITLE
[ADD] Migration of the procurement references on the sale order line

### DIFF
--- a/addons/sale_stock/migrations/8.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/sale_stock/migrations/8.0.1.0/openupgrade_analysis_work.txt
@@ -1,4 +1,12 @@
 ---Fields in module 'sale_stock'---
+# This module has not yet been migrated, except the one change below,
+# in preparation of the migration of the sale module
+
+# Now a one2many in sale. Migrated in this module.
+sale_stock   / sale.order.line          / procurement_id (many2one)     : DEL relation: procurement.order
+
+# TODO: process all other changes below
+
 sale_stock   / sale.order               / invoice_quantity (False)      : DEL selection_keys: ['order', 'procurement'], mode: modify
 sale_stock   / sale.order               / picking_ids (one2many)        : now a function
 sale_stock   / sale.order               / picking_ids (one2many)        : relation is now 'stock.picking' ('stock.picking.out')
@@ -8,8 +16,6 @@ sale_stock   / sale.order               / warehouse_id (many2one)       : NEW re
 sale_stock   / sale.order.line          / delay (float)                 : module is now 'sale' ('sale_stock')
 sale_stock   / sale.order.line          / move_ids (one2many)           : DEL relation: stock.move
 
-# Now a one2many in sale. Migrated in this module.
-sale_stock   / sale.order.line          / procurement_id (many2one)     : DEL relation: procurement.order
 
 sale_stock   / sale.order.line          / property_ids (many2many)      : module is now 'sale_mrp' ('sale_stock')
 sale_stock   / sale.order.line          / route_id (many2one)           : NEW relation: stock.location.route

--- a/addons/sale_stock/migrations/8.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/sale_stock/migrations/8.0.1.0/openupgrade_analysis_work.txt
@@ -1,0 +1,69 @@
+---Fields in module 'sale_stock'---
+sale_stock   / sale.order               / invoice_quantity (False)      : DEL selection_keys: ['order', 'procurement'], mode: modify
+sale_stock   / sale.order               / picking_ids (one2many)        : now a function
+sale_stock   / sale.order               / picking_ids (one2many)        : relation is now 'stock.picking' ('stock.picking.out')
+sale_stock   / sale.order               / shipped (boolean)             : now a function
+sale_stock   / sale.order               / state (False)                 : DEL selection_keys: ['cancel', 'done', 'draft', 'invoice_except', 'manual', 'progress', 'sent', 'shipping_except', 'waiting_date'], mode: modify
+sale_stock   / sale.order               / warehouse_id (many2one)       : NEW relation: stock.warehouse, required: required, req_default: function
+sale_stock   / sale.order.line          / delay (float)                 : module is now 'sale' ('sale_stock')
+sale_stock   / sale.order.line          / move_ids (one2many)           : DEL relation: stock.move
+
+# Now a one2many in sale. Migrated in this module.
+sale_stock   / sale.order.line          / procurement_id (many2one)     : DEL relation: procurement.order
+
+sale_stock   / sale.order.line          / property_ids (many2many)      : module is now 'sale_mrp' ('sale_stock')
+sale_stock   / sale.order.line          / route_id (many2one)           : NEW relation: stock.location.route
+sale_stock   / sale.report              / warehouse_id (many2one)       : NEW relation: stock.warehouse
+sale_stock   / stock.location.route     / sale_selectable (boolean)     : NEW 
+sale_stock   / stock.move               / sale_line_id (many2one)       : DEL relation: sale.order.line
+sale_stock   / stock.picking            / sale_id (many2one)            : now a function
+---XML records in module 'sale_stock'---
+DEL ir.model.access: sale_stock.access_report_stock_move_sales
+NEW ir.ui.menu: base.menu_invoiced
+DEL ir.ui.menu: sale_stock.menu_action_shop_form
+NEW ir.ui.view: sale_stock.stock_location_route_form_view_inherit
+NEW ir.ui.view: sale_stock.view_order_form_inherit2
+NEW ir.ui.view: sale_stock.view_order_line_tree_inherit
+NEW ir.ui.view: sale_stock.view_order_product_search_sale_stock_inherit
+NEW ir.ui.view: sale_stock.view_picking_internal_search_inherit
+DEL ir.ui.view: sale_stock.stock_move_sale
+DEL ir.ui.view: sale_stock.stock_picking_inherit_sale
+DEL ir.ui.view: sale_stock.stock_picking_out_inherit_sale
+DEL ir.ui.view: sale_stock.view_order_product_tree_inherit
+DEL ir.ui.view: sale_stock.view_sale_shop_form_inherit
+DEL ir.ui.view: sale_stock.view_shop_tree_inherit
+DEL process.node: sale_stock.process_node_deliveryorder0
+DEL process.node: sale_stock.process_node_invoiceafterdelivery0
+DEL process.node: sale_stock.process_node_packinglist0
+DEL process.node: sale_stock.process_node_saleorderprocurement0
+DEL process.node: sale_stock.process_node_saleprocurement0
+DEL process.transition: sale_stock.process_transition_deliver0
+DEL process.transition: sale_stock.process_transition_invoiceafterdelivery0
+DEL process.transition: sale_stock.process_transition_packing0
+DEL process.transition: sale_stock.process_transition_saleorderprocurement0
+DEL process.transition: sale_stock.process_transition_saleprocurement0
+DEL process.transition.action: sale_stock.process_transition_action_assign0
+DEL process.transition.action: sale_stock.process_transition_action_cancel1
+DEL process.transition.action: sale_stock.process_transition_action_cancel2
+DEL process.transition.action: sale_stock.process_transition_action_cancelassignation0
+DEL process.transition.action: sale_stock.process_transition_action_forceassignation0
+DEL process.transition.action: sale_stock.process_transition_action_validate0
+NEW res.groups: sale_stock.group_route_so_lines
+DEL sale.shop: sale.sale_shop_1
+DEL workflow.activity: sale_stock.act_cancel3
+DEL workflow.activity: sale_stock.act_ship
+DEL workflow.activity: sale_stock.act_ship_cancel
+DEL workflow.activity: sale_stock.act_ship_end
+DEL workflow.activity: sale_stock.act_ship_except
+DEL workflow.activity: sale_stock.act_wait_ship
+DEL workflow.transition: sale_stock.trans_router_wait_invoice_shipping
+DEL workflow.transition: sale_stock.trans_router_wait_ship
+DEL workflow.transition: sale_stock.trans_ship_end_done
+DEL workflow.transition: sale_stock.trans_ship_except_ship
+DEL workflow.transition: sale_stock.trans_ship_except_ship_cancel
+DEL workflow.transition: sale_stock.trans_ship_except_ship_end
+DEL workflow.transition: sale_stock.trans_ship_ship_end
+DEL workflow.transition: sale_stock.trans_ship_ship_except
+DEL workflow.transition: sale_stock.trans_wait_invoice_invoice
+DEL workflow.transition: sale_stock.trans_wait_ship_cancel3
+DEL workflow.transition: sale_stock.trans_wait_ship_ship

--- a/addons/sale_stock/migrations/8.0.1.0/post-migration.py
+++ b/addons/sale_stock/migrations/8.0.1.0/post-migration.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, a suite of business apps
+#    This module Copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.modules.registry import RegistryManager
+from openerp.openupgrade import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(cr, version):
+    registry = RegistryManager.get(cr.dbname)
+    openupgrade.m2o_to_x2m(
+        cr, registry['sale.order.line'],
+        'sale_order_line', 'procurement_ids',
+        openupgrade.get_legacy_name('procurement_id'))

--- a/addons/sale_stock/migrations/8.0.1.0/pre-migration.py
+++ b/addons/sale_stock/migrations/8.0.1.0/pre-migration.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Odoo, a suite of business apps
+#    This module Copyright (C) 2014 Therp BV (<http://therp.nl>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+from openerp.openupgrade import openupgrade
+
+column_renames = {
+    'sale.order.line': [('procurement_id', None)]}
+
+
+@openupgrade.migrate()
+def migrate(cr, version):
+    openupgrade.rename_columns(cr, column_renames)

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -51,7 +51,7 @@ __all__ = [
     'update_module_names',
     'add_ir_model_fields',
     'get_legacy_name',
-    'm2o_to_m2m',
+    'm2o_to_x2m',
     'float_to_integer',
     'message',
     'check_values_selection_field',
@@ -470,15 +470,15 @@ def get_legacy_name(original_name):
 
 def m2o_to_x2m(cr, model, table, field, source_field):
     """
-    Recreate relations in many2many fields that were formerly
-    many2one fields. Use rename_columns in your pre-migrate
-    script to retain the column's old value, then call m2o_to_m2m
+    Transform many2one relations into one2many or many2many.
+    Use rename_columns in your pre-migrate
+    script to retain the column's old value, then call m2o_to_x2m
     in your post-migrate script.
 
-    :param model: The target model pool object
+    :param model: The target model registry object
     :param table: The source table
-    :param field: The field name of the target model
-    :param source_field: the many2one column on the source table.
+    :param field: The new field name on the target model
+    :param source_field: the (renamed) many2one column on the source table.
 
     .. versionadded:: 7.0
     """
@@ -493,6 +493,7 @@ def m2o_to_x2m(cr, model, table, field, source_field):
 
 # Backwards compatibility
 m2o_to_m2m = m2o_to_x2m
+
 
 def float_to_integer(cr, table, field):
     """

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -468,7 +468,7 @@ def get_legacy_name(original_name):
         map(str, release.version_info[0:2]))+'_'+original_name
 
 
-def m2o_to_m2m(cr, model, table, field, source_field):
+def m2o_to_x2m(cr, model, table, field, source_field):
     """
     Recreate relations in many2many fields that were formerly
     many2one fields. Use rename_columns in your pre-migrate
@@ -491,6 +491,8 @@ def m2o_to_m2m(cr, model, table, field, source_field):
     for row in cr.fetchall():
         model.write(cr, SUPERUSER_ID, row[0], {field: [(4, row[1])]})
 
+# Backwards compatibility
+m2o_to_m2m = m2o_to_x2m
 
 def float_to_integer(cr, table, field):
     """


### PR DESCRIPTION
I'm taking on sale, but it contains a change that needs migration in sale_stock. Requesting a pull of this atomic change to prevent conflicts when someone wants to work on sale_stock.
