### PR TITLE
[Framework] Function to move field (product.product -> product.template)

### DIFF
--- a/addons/hr_expense/migrations/8.0.1.0/post_migration.py
+++ b/addons/hr_expense/migrations/8.0.1.0/post_migration.py
@@ -41,7 +41,7 @@ def migrate(cr, version):
     openupgrade_80.set_message_last_post(
         cr, uid, pool, ['hr.expense.expense']
     )
-    openupgrade.move_field_many_values_to_one(
+    openupgrade.move_field_m2o(
         cr, pool,
         'product.product', openupgrade.get_legacy_name('hr_expense_ok'),
         'product_tmpl_id',

--- a/addons/hr_expense/migrations/8.0.1.0/post_migration.py
+++ b/addons/hr_expense/migrations/8.0.1.0/post_migration.py
@@ -30,8 +30,7 @@ logger = logging.getLogger('OpenUpgrade')
 def hr_expense_ok_field_func(cr, pool, id, vals):
     logger.warning(
         'hr_expense_ok of product.template %d has been set to True '
-        'whereas at least one of its product_product was False',
-        id)
+        'whereas at least one of its product_product was False', id)
     return any(vals)
 
 
@@ -44,7 +43,7 @@ def migrate(cr, version):
     )
     openupgrade.move_field_many_values_to_one(
         cr, pool,
-        'product_product', 'product_tmpl_id',
-        openupgrade.get_legacy_name('hr_expense_ok'),
-        'product_template', 'hr_expense_ok',
+        'product.product', openupgrade.get_legacy_name('hr_expense_ok'),
+        'product_tmpl_id',
+        'product.template', 'hr_expense_ok',
         compute_func=hr_expense_ok_field_func)

--- a/addons/product/migrations/8.0.1.1/post-migration.py
+++ b/addons/product/migrations/8.0.1.1/post-migration.py
@@ -136,16 +136,21 @@ def active_field_template_func(cr, pool, id, vals):
 @openupgrade.migrate()
 def migrate(cr, version):
     pool = pooler.get_pool(cr.dbname)
+    get_legacy_name = openupgrade.get_legacy_name
     openupgrade.move_field_many_values_to_one(
-        cr, pool, 'product_product', 'product_tmpl_id',
-        openupgrade.get_legacy_name('color'),
-        'product_template', 'color')
+        cr, pool,
+        'product.product', get_legacy_name('color'), 'product_tmpl_id',
+        'product.template', 'color')
     openupgrade.move_field_many_values_to_one(
-        cr, pool, 'product_product', 'product_tmpl_id', 'image_variant',
-        'product_template', 'image', binary_field=True)
+        cr, pool,
+        'product.product', 'image_variant', 'product_tmpl_id',
+        'product.template', 'image',
+        quick_request=False, binary_field=True)
     openupgrade.move_field_many_values_to_one(
-        cr, pool, 'product_product', 'product_tmpl_id', 'active',
-        'product_template', 'active', compute_func=active_field_template_func)
+        cr, pool,
+        'product.product', 'active', 'product_tmpl_id',
+        'product.template', 'active',
+        compute_func=active_field_template_func)
     move_fields(cr, pool)
     migrate_packaging(cr, pool)
     create_properties(cr, pool)

--- a/addons/product/migrations/8.0.1.1/post-migration.py
+++ b/addons/product/migrations/8.0.1.1/post-migration.py
@@ -37,31 +37,9 @@ def move_fields(cr, pool):
                "          FROM product_product "
                "          WHERE product_product.id=product_supplierinfo.%s) " %
                openupgrade.get_legacy_name('product_id'),
-               #
-               "UPDATE product_template as pt "
-               "SET color=(SELECT pp1.%s "
-               "      FROM product_product as pp1 "
-               "      WHERE pp1.product_tmpl_id=pt.id ORDER BY pp1.id LIMIT 1), "
-               "    image=(SELECT pp2.image_variant "
-               "      FROM product_product as pp2 "
-               "      WHERE pp2.product_tmpl_id=pt.id ORDER BY pp2.id LIMIT 1)" %
-               openupgrade.get_legacy_name('color')
-               #
-
                ]
     for sql in queries:
         execute(cr, sql)
-
-
-def copy_fields(cr, pool):
-    product_tmpl = pool['product.template']
-    # copy the active field from product to template
-    ctx = {'active_test': False}
-    tmpl_ids = product_tmpl.search(cr, SUPERUSER_ID, [], context=ctx)
-    for template in product_tmpl.browse(cr, SUPERUSER_ID, tmpl_ids, context=ctx):
-        template.write({'active': any(variant.active
-                                      for variant in template.product_variant_ids)
-                        })
 
 
 def migrate_packaging(cr, pool):
@@ -151,11 +129,24 @@ def migrate_variants(cr, pool):
             attribute_line_obj.create(cr, SUPERUSER_ID, values)
 
 
+def active_field_template_func(cr, pool, id, vals):
+    return any(vals)
+
+
 @openupgrade.migrate()
 def migrate(cr, version):
     pool = pooler.get_pool(cr.dbname)
+    openupgrade.move_field_many_values_to_one(
+        cr, pool, 'product_product', 'product_tmpl_id',
+        openupgrade.get_legacy_name('color'),
+        'product_template', 'color')
+    openupgrade.move_field_many_values_to_one(
+        cr, pool, 'product_product', 'product_tmpl_id', 'image_variant',
+        'product_template', 'image', binary_field=True)
+    openupgrade.move_field_many_values_to_one(
+        cr, pool, 'product_product', 'product_tmpl_id', 'active',
+        'product_template', 'active', compute_func=active_field_template_func)
     move_fields(cr, pool)
-    copy_fields(cr, pool)
     migrate_packaging(cr, pool)
     create_properties(cr, pool)
     migrate_variants(cr, pool)

--- a/addons/product/migrations/8.0.1.1/post-migration.py
+++ b/addons/product/migrations/8.0.1.1/post-migration.py
@@ -137,16 +137,16 @@ def active_field_template_func(cr, pool, id, vals):
 def migrate(cr, version):
     pool = pooler.get_pool(cr.dbname)
     get_legacy_name = openupgrade.get_legacy_name
-    openupgrade.move_field_many_values_to_one(
+    openupgrade.move_field_m2o(
         cr, pool,
         'product.product', get_legacy_name('color'), 'product_tmpl_id',
         'product.template', 'color')
-    openupgrade.move_field_many_values_to_one(
+    openupgrade.move_field_m2o(
         cr, pool,
         'product.product', 'image_variant', 'product_tmpl_id',
         'product.template', 'image',
         quick_request=False, binary_field=True)
-    openupgrade.move_field_many_values_to_one(
+    openupgrade.move_field_m2o(
         cr, pool,
         'product.product', 'active', 'product_tmpl_id',
         'product.template', 'active',

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -55,7 +55,7 @@ __all__ = [
     'float_to_integer',
     'message',
     'check_values_selection_field',
-    'move_field_many_values_to_one',
+    'move_field_m2o',
 ]
 
 
@@ -584,7 +584,7 @@ def migrate(no_version=False):
     return wrap
 
 
-def move_field_many_values_to_one(
+def move_field_m2o(
         cr, pool,
         registry_old_model, field_old_model, m2o_field_old_model,
         registry_new_model, field_new_model,

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -55,6 +55,7 @@ __all__ = [
     'float_to_integer',
     'message',
     'check_values_selection_field',
+    'move_field_many_values_to_one',
 ]
 
 
@@ -581,3 +582,94 @@ def migrate(no_version=False):
                 raise
         return wrapped_function
     return wrap
+
+
+def move_field_many_values_to_one(
+        cr, pool,
+        table_old_model, m2o_field_old_model, field_old_model,
+        table_new_model, field_new_model, compute_func=None,
+        binary_field=False):
+    """
+    Use that function in the following case:
+    A field moves from a model A to the model B with : A -> m2o -> B.
+    (For exemple product_product -> product_template)
+    This function manage the migration of this field.
+    available on post script migration.
+    :param table_old_model: name of the table of the model A;
+    :param m2o_field_old_model: name of the field of the table of the model A;
+        that link model A to model B;
+    :param field_old_model: name of the field to move in the table of the
+        model A;
+    :param table_new_model: name of the table of the model B;
+    :param field_new_model: name of the field moved in the table of the
+        model B;
+    :param compute_func: This a function that receives 4 parameters:
+        cr, pool: common args;
+        id: id of the instance of Model B
+        vals:  list of different values.
+        This function must return a unique value that will be set to the
+        instance of Model B which id is 'id' param;
+        If compute_func is not set, the algorithm will take the value that
+        is the most present in vals.
+    :binary_field: Set to True if the migrated field is a binary field
+    .. versionadded:: 8.0
+    """
+    def default_func(cr, pool, id, vals):
+        """This function return the value the most present in vals."""
+        quantity = {}.fromkeys(set(vals), 0)
+        for val in vals:
+            quantity[val] += 1
+        res = vals[0]
+        for val in vals:
+            if quantity[res] < quantity[val]:
+                res = val
+        return res
+
+    # Manage regular case (all the value are identical)
+    cr.execute(
+        " SELECT %s"
+        " FROM %s"
+        " GROUP BY %s"
+        " HAVING count(*) = 1;" % (
+            m2o_field_old_model, table_old_model, m2o_field_old_model
+        ))
+    ok_ids = [x[0] for x in cr.fetchall()]
+    query = (
+        " UPDATE %s as new_table"
+        " SET %s=("
+        "    SELECT old_table.%s"
+        "    FROM %s as old_table"
+        "    WHERE old_table.%s=new_table.id"
+        "    LIMIT 1) "
+        " WHERE id in %%s" % (
+            table_new_model, field_new_model, field_old_model,
+            table_old_model, m2o_field_old_model))
+    logged_query(cr, query, [tuple(ok_ids)])
+
+    # Manage non-determinist case (some values are different)
+    func = compute_func if compute_func else default_func
+    cr.execute(
+        " SELECT %s "
+        " FROM %s "
+        " GROUP BY %s having count(*) != 1;" % (
+            m2o_field_old_model, table_old_model, m2o_field_old_model
+        ))
+    ko_ids = [x[0] for x in cr.fetchall()]
+    for ko_id in ko_ids:
+        query = (
+            " SELECT %s"
+            " FROM %s"
+            " WHERE %s = %s;" % (
+                field_old_model, table_old_model, m2o_field_old_model, ko_id))
+        cr.execute(query)
+        if binary_field:
+            vals = [x[0][0][:] for x in cr.fetchall()]
+        else:
+            vals = [x[0] for x in cr.fetchall()]
+        value = func(cr, pool, vals)
+        query = (
+            " UPDATE %s"
+            " SET %s=%%s"
+            " WHERE id = %%s" % (table_new_model, field_new_model))
+        logged_query(
+            cr, query, (value, ko_id))

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -586,23 +586,23 @@ def migrate(no_version=False):
 
 def move_field_many_values_to_one(
         cr, pool,
-        table_old_model, m2o_field_old_model, field_old_model,
-        table_new_model, field_new_model, compute_func=None,
-        binary_field=False):
+        registry_old_model, field_old_model, m2o_field_old_model,
+        registry_new_model, field_new_model,
+        quick_request=True, compute_func=None, binary_field=False):
     """
     Use that function in the following case:
     A field moves from a model A to the model B with : A -> m2o -> B.
     (For exemple product_product -> product_template)
     This function manage the migration of this field.
     available on post script migration.
-    :param table_old_model: name of the table of the model A;
+    :param registry_old_model: registry of the model A;
+    :param field_old_model: name of the field to move in model A;
     :param m2o_field_old_model: name of the field of the table of the model A;
         that link model A to model B;
-    :param field_old_model: name of the field to move in the table of the
-        model A;
-    :param table_new_model: name of the table of the model B;
-    :param field_new_model: name of the field moved in the table of the
-        model B;
+    :param registry_new_model: registry of the model B;
+    :param field_new_model: name of the field to move in model B;
+    :param quick_request: Set to False, if you want to use write function to
+        update value; Otherwise, the function will use UPDATE SQL request;
     :param compute_func: This a function that receives 4 parameters:
         cr, pool: common args;
         id: id of the instance of Model B
@@ -625,6 +625,8 @@ def move_field_many_values_to_one(
                 res = val
         return res
 
+    table_old_model = pool[registry_old_model]._table
+    table_new_model = pool[registry_new_model]._table
     # Manage regular case (all the value are identical)
     cr.execute(
         " SELECT %s"
@@ -634,17 +636,36 @@ def move_field_many_values_to_one(
             m2o_field_old_model, table_old_model, m2o_field_old_model
         ))
     ok_ids = [x[0] for x in cr.fetchall()]
-    query = (
-        " UPDATE %s as new_table"
-        " SET %s=("
-        "    SELECT old_table.%s"
-        "    FROM %s as old_table"
-        "    WHERE old_table.%s=new_table.id"
-        "    LIMIT 1) "
-        " WHERE id in %%s" % (
-            table_new_model, field_new_model, field_old_model,
-            table_old_model, m2o_field_old_model))
-    logged_query(cr, query, [tuple(ok_ids)])
+    if quick_request:
+        query = (
+            " UPDATE %s as new_table"
+            " SET %s=("
+            "    SELECT old_table.%s"
+            "    FROM %s as old_table"
+            "    WHERE old_table.%s=new_table.id"
+            "    LIMIT 1) "
+            " WHERE id in %%s" % (
+                table_new_model, field_new_model, field_old_model,
+                table_old_model, m2o_field_old_model))
+        logged_query(cr, query, [tuple(ok_ids)])
+    else:
+        query = (
+            " SELECT %s, %s"
+            " FROM %s "
+            " WHERE %s in %%s"
+            " GROUP BY %s, %s" % (
+                m2o_field_old_model, field_old_model, table_old_model,
+                m2o_field_old_model, m2o_field_old_model, field_old_model))
+        cr.execute(query, [tuple(ok_ids)])
+        for res in cr.fetchall():
+            if res[1] and binary_field:
+                pool[registry_new_model].write(
+                    cr, SUPERUSER_ID, res[0],
+                    {field_new_model: res[1][:]})
+            else:
+                pool[registry_new_model].write(
+                    cr, SUPERUSER_ID, res[0],
+                    {field_new_model: res[1]})
 
     # Manage non-determinist case (some values are different)
     func = compute_func if compute_func else default_func
@@ -663,13 +684,18 @@ def move_field_many_values_to_one(
                 field_old_model, table_old_model, m2o_field_old_model, ko_id))
         cr.execute(query)
         if binary_field:
-            vals = [x[0][0][:] for x in cr.fetchall()]
+            vals = [str(x[0][:]) for x in cr.fetchall()]
         else:
             vals = [x[0] for x in cr.fetchall()]
-        value = func(cr, pool, vals)
-        query = (
-            " UPDATE %s"
-            " SET %s=%%s"
-            " WHERE id = %%s" % (table_new_model, field_new_model))
-        logged_query(
-            cr, query, (value, ko_id))
+        value = func(cr, pool, ko_id, vals)
+        if quick_request:
+            query = (
+                " UPDATE %s"
+                " SET %s=%%s"
+                " WHERE id = %%s" % (table_new_model, field_new_model))
+            logged_query(
+                cr, query, (value, ko_id))
+        else:
+            pool[registry_new_model].write(
+                cr, SUPERUSER_ID, [ko_id],
+                {field_new_model: value})

--- a/openerp/openupgrade/openupgrade_80.py
+++ b/openerp/openupgrade/openupgrade_80.py
@@ -59,15 +59,16 @@ def set_message_last_post(cr, uid, pool, models):
     :param cr: database cursor
     :param uid: user id, assumed to be openerp.SUPERUSER_ID
     :param pool: orm pool, assumed to be openerp.pooler.get_pool(cr.dbname)
-    :param models: a list of model names for which 'message_last_post' needs to \
-    be filled
+    :param models: a list of model names for which 'message_last_post' needs \
+    to be filled
     :return:
     """
     if type(models) is not list:
         models = [models]
     for model in models:
         model_pool = pool[model]
-        obj_ids = model_pool.search(cr, uid, [], context={'active_test': False})
+        obj_ids = model_pool.search(
+            cr, uid, [], context={'active_test': False})
         last_posts = get_last_post_for_model(cr, uid, obj_ids, model_pool)
         for i in obj_ids:
             model_pool.write(cr, uid, i, {'message_last_post': last_posts[i]})


### PR DESCRIPTION
Hi, 

I propose a function 'move_field_many_values_to_one' in the openupgrade framework that manage the move of a field from a table to an other when the old table is linked by a many2one link to the new.
Exemple for 7.0 to 8.0: A lot of fields have moved from product.product to product.template Model.
I changed the code to use this function in the two migrated modules 'product' and 'hr_expense'.
The function will be usefull for a lot of change in 'point_of_sale' too.

The function can be called with different optional parameters: 
- 'quick_request': to do a sql request, otherwise a write() call will be done; (see 'product' migration for implementation);
- 'binary_field': to handle a special case if the field is a fields.binary(); (see 'product' migration for implementation);
- 'compute_func': is a function that can be defined to indicate which value will be selected; (see hr_expense migration for implementation);

Thanks for your review.
