### PR TITLE
[UPD] 8.0 analysis without _auto=False

### DIFF
--- a/addons/account/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/account/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -10,10 +10,6 @@ account      / account.bank.statement.line / move_ids (many2many)          : DEL
 account      / account.bank.statement.line / type (selection)              : DEL required: required, selection_keys: ['customer', 'general', 'supplier'], req_default: general
 account      / account.chart.template   / currency_id (many2one)        : NEW relation: res.currency
 account      / account.invoice          / message_last_post (datetime)  : NEW 
-account      / account.invoice.report   / country_id (many2one)         : NEW relation: res.country
-account      / account.invoice.report   / day (char)                    : DEL 
-account      / account.invoice.report   / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-account      / account.invoice.report   / year (char)                   : DEL 
 account      / account.statement.operation.template / account_id (many2one)         : NEW relation: account.account
 account      / account.statement.operation.template / amount (float)                : NEW 
 account      / account.statement.operation.template / amount_type (selection)       : NEW required: required, selection_keys: ['fixed', 'percentage_of_balance', 'percentage_of_total'], req_default: fixed
@@ -21,9 +17,6 @@ account      / account.statement.operation.template / analytic_account_id (many2
 account      / account.statement.operation.template / label (char)                  : NEW 
 account      / account.statement.operation.template / name (char)                   : NEW required: required
 account      / account.statement.operation.template / tax_id (many2one)             : NEW relation: account.tax
-account      / analytic.entries.report  / day (char)                    : DEL 
-account      / analytic.entries.report  / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-account      / analytic.entries.report  / year (char)                   : DEL 
 account      / res.partner              / invoice_ids (one2many)        : relation is now 'account.invoice' ('account.invoice.line')
 ---XML records in module 'account'---
 NEW account.analytic.journal: account.exp

--- a/addons/crm/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/crm/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -25,24 +25,9 @@ crm          / crm.lead                 / date_last_stage_update (datetime): NEW
 crm          / crm.lead                 / message_bounce (integer)      : NEW 
 crm          / crm.lead                 / message_last_post (datetime)  : NEW 
 crm          / crm.lead                 / priority (selection)          : selection_keys is now '['0', '1', '2', '3', '4']' ('['1', '2', '3', '4', '5']')
-crm          / crm.lead.report          / creation_day (char)           : DEL 
-crm          / crm.lead.report          / creation_month (selection)    : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-crm          / crm.lead.report          / creation_year (char)          : DEL 
-crm          / crm.lead.report          / date_deadline (date)          : NEW 
-crm          / crm.lead.report          / date_last_stage_update (datetime): NEW 
-crm          / crm.lead.report          / deadline_day (char)           : DEL 
-crm          / crm.lead.report          / deadline_month (selection)    : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-crm          / crm.lead.report          / deadline_year (char)          : DEL 
-crm          / crm.lead.report          / nbr (integer)                 : DEL 
-crm          / crm.lead.report          / priority (selection)          : selection_keys is now '['0', '1', '2', '3', '4']' ('['1', '2', '3', '4', '5']')
-crm          / crm.lead.report          / state (selection)             : DEL selection_keys: ['cancel', 'done', 'draft', 'open', 'pending']
 crm          / crm.phonecall            / message_last_post (datetime)  : NEW 
 crm          / crm.phonecall            / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['1', '2', '3', '4', '5']')
 crm          / crm.phonecall            / state (selection)             : selection_keys is now '['cancel', 'done', 'open', 'pending']' ('['cancel', 'done', 'draft', 'open', 'pending']')
-crm          / crm.phonecall.report     / day (char)                    : DEL 
-crm          / crm.phonecall.report     / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-crm          / crm.phonecall.report     / name (char)                   : DEL 
-crm          / crm.phonecall.report     / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['1', '2', '3', '4', '5']')
 crm          / res.partner              / create_date (datetime)        : NEW 
 crm          / res.partner              / id (integer)                  : NEW 
 crm          / res.partner              / meeting_ids (many2many)       : relation is now 'calendar.event' ('crm.meeting')

--- a/addons/crm_claim/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/crm_claim/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -2,8 +2,6 @@
 crm_claim    / crm.claim                / message_last_post (datetime)  : NEW 
 crm_claim    / crm.claim                / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['1', '2', '3', '4', '5']')
 crm_claim    / crm.claim                / website_message_ids (one2many): NEW relation: mail.message
-crm_claim    / crm.claim.report         / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['1', '2', '3', '4', '5']')
-crm_claim    / crm.claim.report         / state (selection)             : DEL selection_keys: ['cancel', 'done', 'draft', 'open', 'pending']
 crm_claim    / crm.claim.stage          / case_refused (boolean)        : DEL 
 crm_claim    / crm.claim.stage          / state (selection)             : DEL required: required, selection_keys: ['cancel', 'done', 'draft', 'open', 'pending'], req_default: draft
 crm_claim    / res.partner              / claims_ids (one2many)         : DEL relation: crm.claim

--- a/addons/crm_partner_assign/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/crm_partner_assign/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -1,9 +1,4 @@
 ---Fields in module 'crm_partner_assign'---
-crm_partner_assign / crm.lead.report.assign   / day (char)                    : DEL 
-crm_partner_assign / crm.lead.report.assign   / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-crm_partner_assign / crm.lead.report.assign   / priority (selection)          : selection_keys is now '['0', '1', '2', '3', '4']' ('['1', '2', '3', '4', '5']')
-crm_partner_assign / crm.lead.report.assign   / state (selection)             : DEL selection_keys: ['cancel', 'done', 'draft', 'open', 'pending']
-crm_partner_assign / crm.lead.report.assign   / year (char)                   : DEL 
 crm_partner_assign / res.partner              / assigned_partner_id (many2one): NEW relation: res.partner
 crm_partner_assign / res.partner              / date_localization (date)      : module is now 'base_geolocalize' ('crm_partner_assign')
 crm_partner_assign / res.partner              / implemented_partner_ids (one2many): NEW relation: res.partner

--- a/addons/document/migrations/8.0.2.1/openupgrade_analysis.txt
+++ b/addons/document/migrations/8.0.2.1/openupgrade_analysis.txt
@@ -1,8 +1,6 @@
 ---Fields in module 'document'---
 document     / ir.attachment            / file_type (char)              : module is now 'mail' ('document')
 document     / ir.attachment            / file_type (char)              : now a function
-document     / report.document.user     / user_id (integer)             : relation is now 'res.users' ('False')
-document     / report.document.user     / user_id (integer)             : type is now 'many2one' ('integer')
 ---XML records in module 'document'---
 NEW ir.model.access: document.access_document_storage
 NEW ir.ui.view: document.assets_backend

--- a/addons/event/migrations/8.0.0.1/openupgrade_analysis.txt
+++ b/addons/event/migrations/8.0.0.1/openupgrade_analysis.txt
@@ -16,12 +16,6 @@ event        / event.event              / register_prospect (float)     : type i
 event        / event.event              / register_prospect (float)     : was renamed to seats_unconfirmed [nothing to to]
 event        / event.event              / speaker_confirmed (boolean)   : DEL 
 event        / event.registration       / message_last_post (datetime)  : NEW 
-event        / report.event.registration / event_date (char)             : type is now 'datetime' ('char')
-event        / report.event.registration / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-event        / report.event.registration / register_max (integer)        : DEL 
-event        / report.event.registration / seats_max (integer)           : NEW 
-event        / report.event.registration / speaker_id (many2one)         : DEL relation: res.partner
-event        / report.event.registration / year (char)                   : DEL 
 event        / res.partner              / event_ids (one2many)          : DEL relation: event.event
 event        / res.partner              / event_registration_ids (one2many): DEL relation: event.registration
 ---XML records in module 'event'---

--- a/addons/hr_evaluation/migrations/8.0.0.1/openupgrade_analysis.txt
+++ b/addons/hr_evaluation/migrations/8.0.0.1/openupgrade_analysis.txt
@@ -8,7 +8,6 @@ hr_evaluation / hr.evaluation.interview  / state (selection)             : NEW r
 hr_evaluation / hr.evaluation.interview  / user_id (many2one)            : NEW relation: res.users
 hr_evaluation / hr.evaluation.interview  / user_to_review_id (many2one)  : now a function
 hr_evaluation / hr.evaluation.interview  / website_message_ids (one2many): NEW relation: mail.message
-hr_evaluation / hr.evaluation.report     / request_id (many2one)         : relation is now 'survey.user_input' ('survey.request')
 hr_evaluation / hr_evaluation.evaluation / message_last_post (datetime)  : NEW 
 hr_evaluation / hr_evaluation.evaluation / website_message_ids (one2many): NEW relation: mail.message
 hr_evaluation / hr_evaluation.plan.phase / survey_id (many2one)          : relation is now 'survey.survey' ('survey')

--- a/addons/hr_expense/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/hr_expense/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -3,7 +3,6 @@ hr_expense   / hr.expense.expense       / message_last_post (datetime)  : NEW
 hr_expense   / hr.expense.expense       / state (selection)             : selection_keys is now '['accepted', 'cancelled', 'confirm', 'done', 'draft', 'paid']' ('['accepted', 'cancelled', 'confirm', 'done', 'draft']')
 hr_expense   / hr.expense.expense       / voucher_id (many2one)         : DEL relation: account.voucher
 hr_expense   / hr.expense.expense       / website_message_ids (one2many): NEW relation: mail.message
-hr_expense   / hr.expense.report        / voucher_id (many2one)         : DEL relation: account.voucher
 hr_expense   / product.product          / hr_expense_ok (boolean)       : DEL 
 hr_expense   / product.template         / hr_expense_ok (boolean)       : NEW 
 ---XML records in module 'hr_expense'---

--- a/addons/hr_recruitment/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/hr_recruitment/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -14,16 +14,6 @@ hr_recruitment / hr.job                   / application_ids (one2many)    : NEW 
 hr_recruitment / hr.job                   / color (integer)               : NEW 
 hr_recruitment / hr.job                   / survey_id (many2one)          : relation is now 'survey.survey' ('survey')
 hr_recruitment / hr.job                   / user_id (many2one)            : NEW relation: res.users
-hr_recruitment / hr.recruitment.report    / date (date)                   : DEL 
-hr_recruitment / hr.recruitment.report    / date_create (datetime)        : NEW 
-hr_recruitment / hr.recruitment.report    / date_last_stage_update (datetime): NEW 
-hr_recruitment / hr.recruitment.report    / day (char)                    : DEL 
-hr_recruitment / hr.recruitment.report    / last_stage_id (many2one)      : NEW relation: hr.recruitment.stage
-hr_recruitment / hr.recruitment.report    / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-hr_recruitment / hr.recruitment.report    / nbr (integer)                 : DEL 
-hr_recruitment / hr.recruitment.report    / priority (selection)          : selection_keys is now '['0', '1', '2', '3', '4']' ('['', '1', '2', '3', '4', '5']')
-hr_recruitment / hr.recruitment.report    / state (selection)             : DEL selection_keys: ['cancel', 'done', 'draft', 'open', 'pending']
-hr_recruitment / hr.recruitment.report    / year (char)                   : DEL 
 hr_recruitment / hr.recruitment.stage     / state (selection)             : DEL required: required, selection_keys: ['cancel', 'done', 'draft', 'open', 'pending'], req_default: draft
 hr_recruitment / hr.recruitment.stage     / template_id (many2one)        : NEW relation: email.template
 ---XML records in module 'hr_recruitment'---

--- a/addons/hr_timesheet_sheet/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/hr_timesheet_sheet/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -1,7 +1,4 @@
 ---Fields in module 'hr_timesheet_sheet'---
-hr_timesheet_sheet / hr.timesheet.report      / day (char)                    : DEL 
-hr_timesheet_sheet / hr.timesheet.report      / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-hr_timesheet_sheet / hr.timesheet.report      / year (char)                   : DEL 
 hr_timesheet_sheet / hr_timesheet_sheet.sheet / message_last_post (datetime)  : NEW 
 hr_timesheet_sheet / hr_timesheet_sheet.sheet / website_message_ids (one2many): NEW relation: mail.message
 ---XML records in module 'hr_timesheet_sheet'---

--- a/addons/mail/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/mail/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -12,7 +12,11 @@ mail         / mail.message             / record_name (char)            : not a 
 mail         / mail.message             / reply_to (char)               : NEW 
 mail         / mail.message.subtype     / hidden (boolean)              : NEW 
 mail         / mail.message.subtype     / sequence (integer)            : NEW 
-mail         / mail.thread              / message_last_post (datetime)  : NEW 
+mail         / mail.thread              / message_follower_ids (many2many): module is now 'website_mail' ('mail')
+mail         / mail.thread              / message_ids (one2many)        : module is now 'website_mail' ('mail')
+mail         / mail.thread              / message_is_follower (boolean) : module is now 'website_mail' ('mail')
+mail         / mail.thread              / message_summary (text)        : module is now 'website_mail' ('mail')
+mail         / mail.thread              / message_unread (boolean)      : module is now 'website_mail' ('mail')
 mail         / res.partner              / message_last_post (datetime)  : NEW 
 mail         / res.partner              / notification_email_send (selection): selection_keys is now '['always', 'none']' ('['all', 'comment', 'email', 'none']')
 mail         / res.partner              / notification_email_send (selection): was renamed to notify_email [nothing to to]

--- a/addons/mrp/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/mrp/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -33,7 +33,6 @@ mrp          / mrp.production.workcenter.line / website_message_ids (one2many): 
 mrp          / product.product          / bom_ids (one2many)            : DEL relation: mrp.bom
 mrp          / product.product          / produce_delay (float)         : NEW 
 mrp          / product.template         / bom_ids (one2many)            : NEW relation: mrp.bom
-mrp          / report.mrp.inout         / company_id (many2one)         : NEW relation: res.company, required: required
 mrp          / stock.move               / consumed_for (many2one)       : NEW relation: stock.move
 mrp          / stock.move               / raw_material_production_id (many2one): NEW relation: mrp.production
 mrp          / stock.warehouse          / manufacture_pull_id (many2one): NEW relation: procurement.rule

--- a/addons/mrp_operations/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/mrp_operations/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -1,8 +1,5 @@
 ---Fields in module 'mrp_operations'---
 mrp_operations / mrp.production.workcenter.line / production_state (selection)  : selection_keys is now '['cancel', 'confirmed', 'done', 'draft', 'in_production', 'ready']' ('['cancel', 'confirmed', 'done', 'draft', 'in_production', 'picking_except', 'ready']')
-mrp_operations / mrp.workorder            / day (char)                    : DEL 
-mrp_operations / mrp.workorder            / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-mrp_operations / mrp.workorder            / year (char)                   : DEL 
 ---XML records in module 'mrp_operations'---
 DEL ir.actions.act_window.view: mrp_operations.action_report_mrp_workorder_tree
 DEL ir.ui.view: mrp_operations.view_report_mrp_workorder_tree

--- a/addons/point_of_sale/migrations/8.0.1.0.1/openupgrade_analysis.txt
+++ b/addons/point_of_sale/migrations/8.0.1.0.1/openupgrade_analysis.txt
@@ -20,11 +20,6 @@ point_of_sale / product.template         / expense_pdt (boolean)         : NEW
 point_of_sale / product.template         / income_pdt (boolean)          : NEW 
 point_of_sale / product.template         / pos_categ_id (many2one)       : NEW relation: pos.category
 point_of_sale / product.template         / to_weight (boolean)           : NEW 
-point_of_sale / report.pos.order         / day (char)                    : DEL 
-point_of_sale / report.pos.order         / location_id (many2one)        : NEW relation: stock.location
-point_of_sale / report.pos.order         / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-point_of_sale / report.pos.order         / shop_id (many2one)            : DEL relation: sale.shop
-point_of_sale / report.pos.order         / year (char)                   : DEL 
 ---XML records in module 'point_of_sale'---
 NEW ir.actions.act_url: point_of_sale.action_pos_pos
 NEW ir.actions.act_window: point_of_sale.product_pos_category_action

--- a/addons/project/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/project/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -7,14 +7,7 @@ project      / project.task             / message_last_post (datetime)  : NEW
 project      / project.task             / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['0', '1', '2', '3', '4']')
 project      / project.task             / write_date (datetime)         : NEW 
 project      / project.task.history     / state (selection)             : DEL selection_keys: ['cancelled', 'done', 'draft', 'open', 'pending']
-project      / project.task.history.cumulative / state (selection)             : DEL selection_keys: ['cancelled', 'done', 'draft', 'open', 'pending']
 project      / project.task.type        / state (selection)             : DEL required: required, selection_keys: ['cancelled', 'done', 'draft', 'open', 'pending'], req_default: open
-project      / report.project.task.user / date_last_stage_update (date) : NEW 
-project      / report.project.task.user / day (char)                    : DEL 
-project      / report.project.task.user / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-project      / report.project.task.user / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['0', '1', '2', '3', '4']')
-project      / report.project.task.user / stage_id (many2one)           : NEW relation: project.task.type
-project      / report.project.task.user / year (char)                   : DEL 
 ---XML records in module 'project'---
 DEL ir.actions.act_window: project.action_project_task_reevaluate
 DEL ir.actions.act_window: project.my_open_tasks_action

--- a/addons/project_issue/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/project_issue/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -3,9 +3,6 @@ project_issue / project.issue            / date_last_stage_update (datetime): NE
 project_issue / project.issue            / message_last_post (datetime)  : NEW 
 project_issue / project.issue            / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['1', '2', '3', '4', '5']')
 project_issue / project.issue            / website_message_ids (one2many): NEW relation: mail.message
-project_issue / project.issue.report     / date_last_stage_update (date) : NEW 
-project_issue / project.issue.report     / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['1', '2', '3', '4', '5']')
-project_issue / project.issue.report     / state (selection)             : DEL selection_keys: ['cancel', 'done', 'draft', 'open', 'pending']
 project_issue / project.project          / issue_ids (one2many)          : NEW relation: project.issue
 ---XML records in module 'project_issue'---
 NEW ir.actions.act_window: project_issue.action_view_issues

--- a/addons/purchase/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/purchase/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -15,11 +15,6 @@ purchase     / purchase.order           / warehouse_id (many2one)       : DEL re
 purchase     / purchase.order           / website_message_ids (one2many): NEW relation: mail.message
 purchase     / purchase.order.line      / move_dest_id (many2one)       : DEL relation: stock.move
 purchase     / purchase.order.line      / procurement_ids (one2many)    : NEW relation: procurement.order
-purchase     / purchase.report          / day (char)                    : DEL 
-purchase     / purchase.report          / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-purchase     / purchase.report          / name (char)                   : DEL 
-purchase     / purchase.report          / picking_type_id (many2one)    : NEW relation: stock.warehouse
-purchase     / purchase.report          / warehouse_id (many2one)       : DEL relation: stock.warehouse
 purchase     / res.partner              / purchase_order_ids (one2many) : DEL relation: purchase.order
 purchase     / stock.picking            / purchase_id (many2one)        : DEL relation: purchase.order
 purchase     / stock.warehouse          / buy_pull_id (many2one)        : NEW relation: procurement.rule

--- a/addons/sale/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/sale/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -13,12 +13,6 @@ sale         / sale.order               / state (selection)             : select
 sale         / sale.order               / website_message_ids (one2many): NEW relation: mail.message
 sale         / sale.order.line          / procurement_ids (one2many)    : NEW relation: procurement.order
 sale         / sale.order.line          / type (selection)              : DEL required: required, selection_keys: ['make_to_order', 'make_to_stock'], req_default: make_to_stock
-sale         / sale.report              / date (date)                   : type is now 'datetime' ('date')
-sale         / sale.report              / day (char)                    : DEL 
-sale         / sale.report              / month (selection)             : DEL selection_keys: ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
-sale         / sale.report              / section_id (many2one)         : NEW relation: crm.case.section
-sale         / sale.report              / shop_id (many2one)            : DEL relation: sale.shop
-sale         / sale.report              / year (char)                   : DEL 
 ---XML records in module 'sale'---
 NEW ir.actions.act_window: sale.action_account_invoice_report_salesteam
 NEW ir.actions.act_window: sale.action_invoice_salesteams

--- a/addons/sale_crm/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/sale_crm/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -1,6 +1,5 @@
 ---Fields in module 'sale_crm'---
 sale_crm     / account.invoice          / section_id (many2one)         : module is now 'sale' ('sale_crm')
-sale_crm     / account.invoice.report   / section_id (many2one)         : module is now 'sale' ('sale_crm')
 sale_crm     / res.users                / default_section_id (many2one) : module is now 'sales_team' ('sale_crm')
 sale_crm     / sale.order               / section_id (many2one)         : module is now 'sale' ('sale_crm')
 ---XML records in module 'sale_crm'---

--- a/addons/sale_stock/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/sale_stock/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -10,7 +10,6 @@ sale_stock   / sale.order.line          / move_ids (one2many)           : DEL re
 sale_stock   / sale.order.line          / procurement_id (many2one)     : DEL relation: procurement.order
 sale_stock   / sale.order.line          / property_ids (many2many)      : module is now 'sale_mrp' ('sale_stock')
 sale_stock   / sale.order.line          / route_id (many2one)           : NEW relation: stock.location.route
-sale_stock   / sale.report              / warehouse_id (many2one)       : NEW relation: stock.warehouse
 sale_stock   / stock.location.route     / sale_selectable (boolean)     : NEW 
 sale_stock   / stock.move               / sale_line_id (many2one)       : DEL relation: sale.order.line
 sale_stock   / stock.picking            / sale_id (many2one)            : now a function

--- a/addons/stock/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/stock/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -39,8 +39,6 @@ stock        / product.template         / track_all (boolean)           : NEW
 stock        / product.template         / track_incoming (boolean)      : NEW 
 stock        / product.template         / track_outgoing (boolean)      : NEW 
 stock        / product.template         / valuation (selection)         : NEW required: required, selection_keys: ['manual_periodic', 'real_time'], req_default: manual_periodic
-stock        / report.stock.lines.date  / active (boolean)              : NEW 
-stock        / report.stock.lines.date  / move_date (datetime)          : NEW 
 stock        / res.company              / internal_transit_location_id (many2one): NEW relation: stock.location
 stock        / res.company              / propagation_minimum_delta (integer): NEW 
 stock        / stock.fixed.putaway.strat / category_id (many2one)        : NEW relation: product.category, required: required

--- a/addons/stock_account/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/stock_account/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -1,15 +1,6 @@
 ---Fields in module 'stock_account'---
 stock_account / procurement.order        / invoice_state (selection)     : NEW required: required, selection_keys: ['2binvoiced', 'invoiced', 'none'], req_default: none
 stock_account / procurement.rule         / invoice_state (selection)     : NEW required: required, selection_keys: ['2binvoiced', 'invoiced', 'none'], req_default: none
-stock_account / stock.history            / company_id (many2one)         : NEW relation: res.company
-stock_account / stock.history            / date (datetime)               : NEW 
-stock_account / stock.history            / location_id (many2one)        : NEW relation: stock.location, required: required
-stock_account / stock.history            / move_id (many2one)            : NEW relation: stock.move, required: required
-stock_account / stock.history            / price_unit_on_quant (float)   : NEW 
-stock_account / stock.history            / product_categ_id (many2one)   : NEW relation: product.category, required: required
-stock_account / stock.history            / product_id (many2one)         : NEW relation: product.product, required: required
-stock_account / stock.history            / quantity (integer)            : NEW 
-stock_account / stock.history            / source (char)                 : NEW 
 stock_account / stock.inventory          / period_id (many2one)          : NEW relation: account.period
 stock_account / stock.move               / invoice_state (selection)     : NEW required: required, selection_keys: ['2binvoiced', 'invoiced', 'none'], req_default: function
 ---XML records in module 'stock_account'---

--- a/addons/survey/migrations/8.0.2.0/openupgrade_analysis.txt
+++ b/addons/survey/migrations/8.0.2.0/openupgrade_analysis.txt
@@ -98,7 +98,7 @@ survey       / survey.user_input        / token (char)                  : NEW re
 survey       / survey.user_input        / type (selection)              : NEW required: required, selection_keys: ['link', 'manually'], req_default: manually
 survey       / survey.user_input        / user_input_line_ids (one2many): NEW relation: survey.user_input_line
 survey       / survey.user_input_line   / answer_type (selection)       : NEW selection_keys: ['date', 'free_text', 'number', 'suggestion', 'text']
-survey       / survey.user_input_line   / date_create (datetime)        : NEW required: required, req_default: 2014-06-02 21:55:01
+survey       / survey.user_input_line   / date_create (datetime)        : NEW required: required, req_default: 2014-06-04 21:52:32
 survey       / survey.user_input_line   / question_id (many2one)        : NEW relation: survey.question, required: required
 survey       / survey.user_input_line   / quizz_mark (float)            : NEW 
 survey       / survey.user_input_line   / skipped (boolean)             : NEW 

--- a/addons/website_mail/migrations/8.0.0.1/openupgrade_analysis.txt
+++ b/addons/website_mail/migrations/8.0.0.1/openupgrade_analysis.txt
@@ -1,5 +1,6 @@
 ---Fields in module 'website_mail'---
 website_mail / mail.message             / website_published (boolean)   : NEW 
+website_mail / mail.thread              / message_last_post (datetime)  : NEW 
 website_mail / mail.thread              / website_message_ids (one2many): NEW relation: mail.message
 ---XML records in module 'website_mail'---
 NEW ir.ui.view: website_mail.email_designer

--- a/openerp/addons/base/migrations/8.0.1.3/openupgrade_general_log.txt
+++ b/openerp/addons/base/migrations/8.0.1.3/openupgrade_general_log.txt
@@ -1,12 +1,12 @@
 ---Fields in module 'general'---
-# 4995 fields matched,
-# Direct match: 4405
-# Found in other module: 77
+# 5051 fields matched,
+# Direct match: 3730
+# Found in other module: 80
 # Found with different name: 0
 # Found with different type: 0
-# In obsolete models: 513
-# New columns: 1595
-# Not matched: 322
+# In obsolete models: 1241
+# New columns: 1568
+# Not matched: 266
 new model account.analytic.invoice.line
 new model account.statement.operation.template
 new model blog.blog
@@ -99,7 +99,6 @@ new model sale.quote.option
 new model sale.quote.template
 new model sale_layout.category
 new model stock.fixed.putaway.strat
-new model stock.history
 new model stock.landed.cost
 new model stock.landed.cost.lines
 new model stock.location.route
@@ -139,22 +138,48 @@ new model website.menu
 new model website.seo.metadata
 new model website.twitter.tweet
 new model wizard.price
+obsolete model account.entries.report
+obsolete model account.invoice.report
+obsolete model account.treasury.report
+obsolete model account_analytic_analysis.summary.month
+obsolete model account_analytic_analysis.summary.user
+obsolete model account_followup.stat
+obsolete model account_followup.stat.by.partner
+obsolete model analytic.entries.report
+obsolete model asset.asset.report
 obsolete model audittrail.log
 obsolete model audittrail.log.line
 obsolete model audittrail.rule
 obsolete model calendar.todo
+obsolete model campaign.analysis
+obsolete model crm.claim.report
+obsolete model crm.helpdesk.report
+obsolete model crm.lead.report
+obsolete model crm.lead.report.assign
 obsolete model crm.meeting
 obsolete model crm.meeting.type
+obsolete model crm.partner.report.assign
+obsolete model crm.phonecall.report
 obsolete model document.page
 obsolete model document.page.history
 obsolete model document.webdav.dir.property
 obsolete model document.webdav.file.property
 obsolete model event.moodle.config.wiz
 obsolete model google.docs.config
+obsolete model hr.evaluation.report
+obsolete model hr.expense.report
+obsolete model hr.holidays.remaining.leaves.user
+obsolete model hr.recruitment.report
+obsolete model hr.timesheet.report
+obsolete model hr_timesheet_sheet.sheet.account
+obsolete model hr_timesheet_sheet.sheet.day
 obsolete model idea.category
 obsolete model idea.idea
 obsolete model ir.actions.wizard
 obsolete model ir.ui.view_sc
+obsolete model mrp.workorder
+obsolete model payment.advice.report
+obsolete model payslip.report
 obsolete model portal.payment.acquirer
 obsolete model process.condition
 obsolete model process.node
@@ -165,15 +190,47 @@ obsolete model product.manufacturer.attribute
 obsolete model product.pulled.flow
 obsolete model project.gtd.context
 obsolete model project.gtd.timebox
+obsolete model project.issue.report
 obsolete model project.phase
+obsolete model project.task.history.cumulative
 obsolete model project.user.allocation
+obsolete model purchase.report
+obsolete model report.account.analytic.line.to.invoice
+obsolete model report.account.receivable
+obsolete model report.account.sales
+obsolete model report.account_type.sales
+obsolete model report.aged.receivable
+obsolete model report.analytic.account.close
+obsolete model report.document.file
+obsolete model report.document.user
+obsolete model report.event.registration
+obsolete model report.intrastat
+obsolete model report.invoice.created
+obsolete model report.lunch.order.line
+obsolete model report.membership
+obsolete model report.mrp.inout
+obsolete model report.pos.order
+obsolete model report.project.task.user
 obsolete model report.sales.by.margin.pos
 obsolete model report.sales.by.margin.pos.month
+obsolete model report.sales.by.user.pos
+obsolete model report.sales.by.user.pos.month
 obsolete model report.stock.inventory
+obsolete model report.stock.lines.date
 obsolete model report.stock.move
+obsolete model report.timesheet.line
+obsolete model report.timesheet.task.user
+obsolete model report.transaction.pos
+obsolete model report.workcenter.load
+obsolete model report_timesheet.account
+obsolete model report_timesheet.account.date
+obsolete model report_timesheet.invoice
+obsolete model report_timesheet.user
 obsolete model res.alarm
 obsolete model res.request
 obsolete model res.request.history
+obsolete model sale.receipt.report
+obsolete model sale.report
 obsolete model sale.shop
 obsolete model stock.journal
 obsolete model stock.picking.in
@@ -192,6 +249,7 @@ obsolete model survey.response.answer
 obsolete model survey.response.line
 obsolete model survey.tbl.column.heading
 obsolete model survey.type
+obsolete model timesheet.report
 obsolete model web_tests_demo.model
 ---XML records in module 'general'---
 ERROR: module not in list of installed modules:
@@ -435,7 +493,6 @@ DEL ir.ui.view: stock_no_autopicking.view_product_form_auto_pick
 ERROR: module not in list of installed modules:
 ---Fields in module 'account_report_company'---
 account_report_company / account.invoice          / commercial_partner_id (many2one): module is now 'account' ('account_report_company')
-account_report_company / account.invoice.report   / commercial_partner_id (many2one): module is now 'account' ('account_report_company')
 account_report_company / res.partner              / display_name (char)           : module is now 'base' ('account_report_company')
 ---XML records in module 'account_report_company'---
 DEL ir.ui.view: account_report_company.account_report_company_invoice_report_search_view

--- a/openerp/addons/openupgrade_records/lib/compare.py
+++ b/openerp/addons/openupgrade_records/lib/compare.py
@@ -85,7 +85,7 @@ def fieldprint(old, new, field, text, reprs):
     fieldrepr = "%s (%s)" % (old['field'], old['type'])
     fullrepr = '%-12s / %-24s / %-30s' % (old['module'], old['model'], fieldrepr)
     if not text:
-        text = "%s is now '%s' ('%s')" % (new[field], old[field])
+        text = "%s is now '%s' ('%s')" % (field, new[field], old[field])
     reprs[module_map(old['module'])].append("%s: %s" % (fullrepr, text))
 
 


### PR DESCRIPTION
This analysis ignores models with  _auto=False. There is a puzzling false positive stating that fields from mail.thread moved to website_mail, but that is because mail.thread (an AbstractModel from the mail module) is accidentally overriden in website_mail as a regular Model). I dislike the fact that there is now no clear overview of the changes in abstract models such as mail.thread, but the changes are in every model that inherits from it so I guess that will have to do.
