### PR TITLE
Fix import SUPERUSER_ID in project_issue migration scripts

### DIFF
--- a/addons/project_issue/migrations/8.0.1.0/post-migration.py
+++ b/addons/project_issue/migrations/8.0.1.0/post-migration.py
@@ -19,7 +19,7 @@
 #
 ##############################################################################
 
-from openerp import SUPERUSER_UID as uid
+from openerp import SUPERUSER_ID as uid
 from openerp.openupgrade import openupgrade, openupgrade_80
 
 


### PR DESCRIPTION
Found error:

```
2014-07-18 17:04:11,710 8772 ERROR v8mig openerp.modules.migration: module project_issue: Unable to load post-migration file project_issue/migrations/8.0.1.0/post-migration.py
Traceback (most recent call last):
  File "/home/dr/work/openupg/OpenUpgrade/openerp/modules/migration.py", line 167, in migrate_module
    mod = imp.load_module(name, fp, pathname, ('.py', 'r', imp.PY_SOURCE))
  File "/home/dr/work/openupg/OpenUpgrade/addons/project_issue/migrations/8.0.1.0/post-migration.py", line 22, in <module>
    from openerp import SUPERUSER_UID as uid
ImportError: cannot import name SUPERUSER_UID
```
