### PR TITLE
product: Fix invalid migration for product_supplierinfo

### DIFF
--- a/addons/product/migrations/8.0.1.1/openupgrade_analysis_WORK.txt
+++ b/addons/product/migrations/8.0.1.1/openupgrade_analysis_WORK.txt
@@ -42,7 +42,7 @@ product      / product.product          / attribute_value_ids (many2many): NEW r
 
 product      / product.supplierinfo     / product_id (many2one)         : DEL relation: product.template, required: required
 product      / product.supplierinfo     / product_tmpl_id (many2one)    : NEW relation: product.template, required: required
-# OK seller_ids moved from product.product to product.template
+# OK renamed
 
 product      / product.template         / active (boolean)              : NEW 
 # OK: set to True if at least one variant is active

--- a/addons/product/migrations/8.0.1.1/post-migration.py
+++ b/addons/product/migrations/8.0.1.1/post-migration.py
@@ -30,18 +30,6 @@ def load_data(cr):
                           mode='init')
 
 
-def move_fields(cr, pool):
-    execute = openupgrade.logged_query
-    queries = ["UPDATE product_supplierinfo "
-               "SET product_tmpl_id=(SELECT product_tmpl_id "
-               "          FROM product_product "
-               "          WHERE product_product.id=product_supplierinfo.%s) " %
-               openupgrade.get_legacy_name('product_id'),
-               ]
-    for sql in queries:
-        execute(cr, sql)
-
-
 def migrate_packaging(cr, pool):
     """create 1 product UL for each different product packaging dimension
     and link it to the packagings
@@ -151,7 +139,6 @@ def migrate(cr, version):
         'product.product', 'active', 'product_tmpl_id',
         'product.template', 'active',
         compute_func=active_field_template_func)
-    move_fields(cr, pool)
     migrate_packaging(cr, pool)
     create_properties(cr, pool)
     migrate_variants(cr, pool)

--- a/addons/product/migrations/8.0.1.1/pre-migration.py
+++ b/addons/product/migrations/8.0.1.1/pre-migration.py
@@ -22,9 +22,8 @@
 from openerp.openupgrade import openupgrade
 
 column_renames = {
-    # Using magic None value to trigger call to get_legacy_name()
     'product_supplierinfo': [
-        ('product_id', None),
+        ('product_id', 'product_tmpl_id'),
     ],
     'product_product': [
         ('color', None),
@@ -33,8 +32,8 @@ column_renames = {
         ('price_extra', None),
     ],
     'product_template': [
-        ('produce_delay', None),  # need to handle in mrp migration
-        ('cost_method', None),  # need to handle in stock_account migration
+        ('produce_delay', None),    # data handled in mrp migration
+        ('cost_method', None),      # data handled in stock_account migration
         ('standard_price', None),
     ],
     'product_packaging': [


### PR DESCRIPTION
This one was annoying. The column was simply renamed. 
