### PR TITLE
Rename models in ir_model_data

### DIFF
--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -184,6 +184,8 @@ def rename_models(cr, model_spec):
                    'WHERE model = %s', (new, old,))
         cr.execute('UPDATE ir_model_fields SET relation = %s '
                    'WHERE relation = %s', (new, old,))
+        cr.execute('UPDATE ir_model_data SET model = %s '
+                   'WHERE model = %s', (new, old,))
     # TODO: signal where the model occurs in references to ir_model
 
 


### PR DESCRIPTION
When renaming models, we also want to rename them in ir_model_data.

This prevents errors in rename_xmlids such as:

> External ID conflict, document_page_procedure already refers to a `wiki.wiki` record, you can't define a `document.page` record with this ID.

Please also see 7.0 patch here: https://code.launchpad.net/~savoirfairelinux/openupgrade-server/rename_ir_model_data/+merge/231599
