### PR TITLE
8.0 ignore implicit columns

### DIFF
--- a/addons/calendar/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/calendar/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -33,7 +33,6 @@ base_calendar / calendar.event           / alarm_id (many2one)           : DEL r
 base_calendar / calendar.event           / attendee_ids (many2many)      : type is now 'one2many' ('many2many')
 base_calendar / calendar.event           / base_calendar_alarm_id (many2one): DEL relation: calendar.alarm
 base_calendar / calendar.event           / base_calendar_url (char)      : DEL 
-base_calendar / calendar.event           / create_date (datetime)        : DEL 
 base_calendar / calendar.event           / date (datetime)               : DEL required: required
 base_calendar / calendar.event           / date_deadline (datetime)      : DEL required: required
 base_calendar / calendar.event           / end_date (date)               : DEL 

--- a/addons/crm/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/crm/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -28,8 +28,6 @@ crm          / crm.lead                 / priority (selection)          : select
 crm          / crm.phonecall            / message_last_post (datetime)  : NEW 
 crm          / crm.phonecall            / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['1', '2', '3', '4', '5']')
 crm          / crm.phonecall            / state (selection)             : selection_keys is now '['cancel', 'done', 'open', 'pending']' ('['cancel', 'done', 'draft', 'open', 'pending']')
-crm          / res.partner              / create_date (datetime)        : NEW 
-crm          / res.partner              / id (integer)                  : NEW 
 crm          / res.partner              / meeting_ids (many2many)       : relation is now 'calendar.event' ('crm.meeting')
 crm          / res.partner              / section_id (many2one)         : module is now 'sales_team' ('crm')
 ---XML records in module 'crm'---

--- a/addons/gamification/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/gamification/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -16,8 +16,6 @@ gamification / gamification.badge       / rule_max_number (integer)     : NEW
 gamification / gamification.badge.user  / badge_id (many2one)           : NEW relation: gamification.badge, required: required
 gamification / gamification.badge.user  / challenge_id (many2one)       : NEW relation: gamification.challenge
 gamification / gamification.badge.user  / comment (text)                : NEW 
-gamification / gamification.badge.user  / create_date (datetime)        : NEW 
-gamification / gamification.badge.user  / create_uid (many2one)         : NEW relation: res.users
 gamification / gamification.badge.user  / sender_id (many2one)          : NEW relation: res.users
 gamification / gamification.badge.user  / user_id (many2one)            : NEW relation: res.users, required: required
 gamification / gamification.challenge   / category (selection)          : NEW required: required, selection_keys: function, req_default: hr

--- a/addons/hr/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/hr/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -7,7 +7,6 @@ hr           / hr.job                   / message_last_post (datetime)  : NEW
 hr           / hr.job                   / no_of_employee (float)        : type is now 'integer' ('float')
 hr           / hr.job                   / no_of_hired_employee (integer): NEW 
 hr           / hr.job                   / no_of_recruitment (float)     : type is now 'integer' ('float')
-hr           / hr.job                   / write_date (datetime)         : NEW 
 hr           / res.users                / display_employees_suggestions (boolean): NEW 
 ---XML records in module 'hr'---
 DEL ir.actions.act_window: hr.open_board_hr

--- a/addons/mass_mailing/migrations/8.0.2.0/openupgrade_analysis.txt
+++ b/addons/mass_mailing/migrations/8.0.2.0/openupgrade_analysis.txt
@@ -16,7 +16,6 @@ mass_mailing / mail.mass_mailing        / attachment_ids (many2many)    : NEW re
 mass_mailing / mail.mass_mailing        / body_html (html)              : NEW 
 mass_mailing / mail.mass_mailing        / contact_ab_pc (integer)       : NEW 
 mass_mailing / mail.mass_mailing        / contact_list_ids (many2many)  : NEW relation: mail.mass_mailing.list
-mass_mailing / mail.mass_mailing        / create_date (datetime)        : NEW 
 mass_mailing / mail.mass_mailing        / email_from (char)             : NEW required: required, req_default: function
 mass_mailing / mail.mass_mailing        / mailing_domain (char)         : NEW 
 mass_mailing / mail.mass_mailing        / mailing_model (selection)     : NEW required: required, selection_keys: function, req_default: mail.mass_mailing.contact
@@ -35,7 +34,6 @@ mass_mailing / mail.mass_mailing.campaign / stage_id (many2one)           : NEW 
 mass_mailing / mail.mass_mailing.campaign / unique_ab_testing (boolean)   : NEW 
 mass_mailing / mail.mass_mailing.campaign / user_id (many2one)            : NEW relation: res.users, required: required, req_default: function
 mass_mailing / mail.mass_mailing.category / name (char)                   : NEW required: required
-mass_mailing / mail.mass_mailing.contact / create_date (datetime)        : NEW 
 mass_mailing / mail.mass_mailing.contact / email (char)                  : NEW required: required
 mass_mailing / mail.mass_mailing.contact / list_id (many2one)            : NEW relation: mail.mass_mailing.list, required: required, req_default: function
 mass_mailing / mail.mass_mailing.contact / name (char)                   : NEW 

--- a/addons/project/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/project/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -5,7 +5,6 @@ project      / project.project          / task_ids (one2many)           : NEW re
 project      / project.task             / date_last_stage_update (datetime): NEW 
 project      / project.task             / message_last_post (datetime)  : NEW 
 project      / project.task             / priority (selection)          : selection_keys is now '['0', '1', '2']' ('['0', '1', '2', '3', '4']')
-project      / project.task             / write_date (datetime)         : NEW 
 project      / project.task.history     / state (selection)             : DEL selection_keys: ['cancelled', 'done', 'draft', 'open', 'pending']
 project      / project.task.type        / state (selection)             : DEL required: required, selection_keys: ['cancelled', 'done', 'draft', 'open', 'pending'], req_default: open
 ---XML records in module 'project'---

--- a/addons/stock/migrations/8.0.1.1/openupgrade_analysis.txt
+++ b/addons/stock/migrations/8.0.1.1/openupgrade_analysis.txt
@@ -165,7 +165,6 @@ stock        / stock.picking.type       / sequence (integer)            : NEW
 stock        / stock.picking.type       / sequence_id (many2one)        : NEW relation: ir.sequence, required: required
 stock        / stock.picking.type       / warehouse_id (many2one)       : NEW relation: stock.warehouse
 stock        / stock.production.lot     / company_id (many2one)         : DEL relation: res.company
-stock        / stock.production.lot     / create_date (datetime)        : NEW 
 stock        / stock.production.lot     / date (datetime)               : DEL required: required, req_default: function
 stock        / stock.production.lot     / message_ids (one2many)        : NEW relation: mail.message
 stock        / stock.production.lot     / message_last_post (datetime)  : NEW 
@@ -175,7 +174,6 @@ stock        / stock.production.lot     / quant_ids (one2many)          : NEW re
 stock        / stock.production.lot     / revisions (one2many)          : DEL relation: stock.production.lot.revision
 stock        / stock.quant              / company_id (many2one)         : NEW relation: res.company, required: required, req_default: function
 stock        / stock.quant              / cost (float)                  : NEW 
-stock        / stock.quant              / create_date (datetime)        : NEW 
 stock        / stock.quant              / history_ids (many2many)       : NEW relation: stock.move
 stock        / stock.quant              / in_date (datetime)            : NEW 
 stock        / stock.quant              / location_id (many2one)        : NEW relation: stock.location, required: required

--- a/addons/website_blog/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_blog/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -12,8 +12,6 @@ website_blog / blog.post                / author_id (many2one)          : NEW re
 website_blog / blog.post                / background_image (binary)     : NEW 
 website_blog / blog.post                / blog_id (many2one)            : NEW relation: blog.blog, required: required
 website_blog / blog.post                / content (html)                : NEW 
-website_blog / blog.post                / create_date (datetime)        : NEW 
-website_blog / blog.post                / create_uid (many2one)         : NEW relation: res.users
 website_blog / blog.post                / history_ids (one2many)        : NEW relation: blog.post.history
 website_blog / blog.post                / message_ids (one2many)        : NEW relation: mail.message
 website_blog / blog.post                / message_last_post (datetime)  : NEW 
@@ -26,11 +24,7 @@ website_blog / blog.post                / website_meta_description (text): NEW
 website_blog / blog.post                / website_meta_keywords (char)  : NEW 
 website_blog / blog.post                / website_meta_title (char)     : NEW 
 website_blog / blog.post                / website_published (boolean)   : NEW 
-website_blog / blog.post                / write_date (datetime)         : NEW 
-website_blog / blog.post                / write_uid (many2one)          : NEW relation: res.users
 website_blog / blog.post.history        / content (text)                : NEW 
-website_blog / blog.post.history        / create_date (datetime)        : NEW 
-website_blog / blog.post.history        / create_uid (many2one)         : NEW relation: res.users
 website_blog / blog.post.history        / post_id (many2one)            : NEW relation: blog.post
 website_blog / blog.post.history        / summary (char)                : NEW 
 website_blog / blog.tag                 / name (char)                   : NEW required: required

--- a/addons/website_forum/migrations/8.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_forum/migrations/8.0.1.0/openupgrade_analysis.txt
@@ -14,8 +14,6 @@ website_forum / forum.post               / closed_date (datetime)        : NEW
 website_forum / forum.post               / closed_reason_id (many2one)   : NEW relation: forum.post.reason
 website_forum / forum.post               / closed_uid (many2one)         : NEW relation: res.users
 website_forum / forum.post               / content (html)                : NEW 
-website_forum / forum.post               / create_date (datetime)        : NEW 
-website_forum / forum.post               / create_uid (many2one)         : NEW relation: res.users
 website_forum / forum.post               / favourite_ids (many2many)     : NEW relation: res.users
 website_forum / forum.post               / forum_id (many2one)           : NEW relation: forum.forum, required: required
 website_forum / forum.post               / is_correct (boolean)          : NEW 
@@ -31,14 +29,10 @@ website_forum / forum.post               / website_message_ids (one2many): NEW r
 website_forum / forum.post               / website_meta_description (text): NEW 
 website_forum / forum.post               / website_meta_keywords (char)  : NEW 
 website_forum / forum.post               / website_meta_title (char)     : NEW 
-website_forum / forum.post               / write_date (datetime)         : NEW 
-website_forum / forum.post               / write_uid (many2one)          : NEW relation: res.users
 website_forum / forum.post.reason        / name (char)                   : NEW required: required
-website_forum / forum.post.vote          / create_date (datetime)        : NEW 
 website_forum / forum.post.vote          / post_id (many2one)            : NEW relation: forum.post, required: required
 website_forum / forum.post.vote          / user_id (many2one)            : NEW relation: res.users, required: required, req_default: function
 website_forum / forum.post.vote          / vote (selection)              : NEW required: required, selection_keys: ['-1', '0', '1'], req_default: function
-website_forum / forum.tag                / create_uid (many2one)         : NEW relation: res.users
 website_forum / forum.tag                / forum_id (many2one)           : NEW relation: forum.forum, required: required
 website_forum / forum.tag                / name (char)                   : NEW required: required
 website_forum / forum.tag                / post_ids (many2many)          : NEW relation: forum.post
@@ -47,7 +41,6 @@ website_forum / forum.tag                / website_meta_keywords (char)  : NEW
 website_forum / forum.tag                / website_meta_title (char)     : NEW 
 website_forum / gamification.badge       / level (selection)             : NEW selection_keys: ['bronze', 'gold', 'silver']
 website_forum / res.users                / badge_ids (one2many)          : NEW relation: gamification.badge.user
-website_forum / res.users                / create_date (datetime)        : NEW 
 website_forum / res.users                / karma (integer)               : NEW 
 ---XML records in module 'website_forum'---
 NEW forum.forum: website_forum.forum_help

--- a/openerp/addons/base/migrations/8.0.1.3/openupgrade_analysis.txt
+++ b/openerp/addons/base/migrations/8.0.1.3/openupgrade_analysis.txt
@@ -29,8 +29,6 @@ base         / ir.actions.server        / use_relational_model (selection): NEW 
 base         / ir.actions.server        / use_write (selection)         : NEW required: required, selection_keys: ['current', 'expression', 'other'], req_default: current
 base         / ir.actions.server        / wkf_transition_id (many2one)  : NEW relation: workflow.transition
 base         / ir.actions.server        / write_id (char)               : was renamed to write_expression [nothing to to]
-base         / ir.logging               / create_date (datetime)        : NEW 
-base         / ir.logging               / create_uid (integer)          : NEW 
 base         / ir.logging               / dbname (char)                 : NEW 
 base         / ir.logging               / func (char)                   : NEW required: required
 base         / ir.logging               / level (char)                  : NEW 
@@ -44,13 +42,11 @@ base         / ir.property              / res_id (reference)            : type i
 base         / ir.property              / type (selection)              : selection_keys is now '['binary', 'boolean', 'char', 'date', 'datetime', 'float', 'integer', 'many2one', 'selection', 'text']' ('['binary', 'boolean', 'char', 'date', 'datetime', 'float', 'integer', 'many2one', 'text']')
 base         / ir.property              / value_reference (reference)   : type is now 'char' ('reference')
 base         / ir.ui.view               / application (selection)       : NEW required: required, selection_keys: ['always', 'disabled', 'enabled'], req_default: always
-base         / ir.ui.view               / create_date (datetime)        : NEW 
 base         / ir.ui.view               / inherit_children_ids (one2many): NEW relation: ir.ui.view
 base         / ir.ui.view               / mode (selection)              : NEW required: required, selection_keys: ['extension', 'primary'], req_default: primary
 base         / ir.ui.view               / model_ids (one2many)          : NEW relation: ir.model.data
 base         / ir.ui.view               / type (selection)              : not a function anymore
 base         / ir.ui.view               / type (selection)              : selection_keys is now '['calendar', 'diagram', 'form', 'gantt', 'graph', 'kanban', 'qweb', 'search', 'tree']' ('['calendar', 'diagram', 'form', 'gantt', 'graph', 'kanban', 'mdx', 'search', 'tree']')
-base         / ir.ui.view               / write_date (datetime)         : NEW 
 base         / res.company              / font (many2one)               : NEW relation: res.font
 base         / res.company              / paper_format (selection)      : was renamed to rml_paper_format [nothing to to]
 base         / res.country              / image (binary)                : NEW 

--- a/openerp/addons/openupgrade_records/lib/compare.py
+++ b/openerp/addons/openupgrade_records/lib/compare.py
@@ -41,6 +41,15 @@ def model_map(model):
     return apriori.renamed_models.get(model, model)
 
 
+IGNORE_FIELDS = [
+    'create_date',
+    'create_uid',
+    'id',
+    'write_date',
+    'write_uid',
+    ]
+
+
 def compare_records(dict_old, dict_new, fields):
     """
     Check equivalence of two OpenUpgrade field representations
@@ -83,7 +92,8 @@ def search(item, item_list, fields):
 
 def fieldprint(old, new, field, text, reprs):
     fieldrepr = "%s (%s)" % (old['field'], old['type'])
-    fullrepr = '%-12s / %-24s / %-30s' % (old['module'], old['model'], fieldrepr)
+    fullrepr = '%-12s / %-24s / %-30s' % (
+        old['module'], old['model'], fieldrepr)
     if not text:
         text = "%s is now '%s' ('%s')" % (field, new[field], old[field])
     reprs[module_map(old['module'])].append("%s: %s" % (fullrepr, text))
@@ -192,23 +202,25 @@ def compare_sets(old_records, new_records):
         ]
     for column in old_records:
         # we do not care about removed function fields
-        if not column['isfunction']:
-            if column['mode'] == 'create':
-                column['mode'] = ''
-            fieldprint(
-                column, None, None, "DEL " + ", ".join(
-                    [k + ': ' + str(column[k]) for k in printkeys if column[k]]
-                    ), reprs)
+        if column['isfunction'] or column['field'] in IGNORE_FIELDS:
+            continue
+        if column['mode'] == 'create':
+            column['mode'] = ''
+        fieldprint(
+            column, None, None, "DEL " + ", ".join(
+                [k + ': ' + str(column[k]) for k in printkeys if column[k]]
+                ), reprs)
 
     for column in new_records:
         # we do not care about newly added function fields
-        if not column['isfunction']:
-            if column['mode'] == 'create':
-                column['mode'] = ''
-            fieldprint(
-                column, None, None, "NEW " + ", ".join(
-                    [k + ': ' + str(column[k]) for k in printkeys if column[k]]
-                    ), reprs)
+        if column['isfunction'] or column['field'] in IGNORE_FIELDS:
+            continue
+        if column['mode'] == 'create':
+            column['mode'] = ''
+        fieldprint(
+            column, None, None, "NEW " + ", ".join(
+                [k + ': ' + str(column[k]) for k in printkeys if column[k]]
+                ), reprs)
 
     for line in [
             "# %d fields matched," % (origlen - len(old_records)),

--- a/openerp/addons/openupgrade_records/model/install_all_wizard.py
+++ b/openerp/addons/openupgrade_records/model/install_all_wizard.py
@@ -106,13 +106,15 @@ class install_all_wizard(TransientModel):
     def install_all(self, cr, uid, ids, context=None):
         """
         Main wizard step. Set all installable modules to install
-        and actually install them.
+        and actually install them. Exclude testing modules.
         """
         module_obj = self.pool.get('ir.module.module')
         module_ids = module_obj.search(
             cr, uid, [
                 ('state', 'not in',
-                 ['installed', 'uninstallable', 'unknown'])])
+                 ['installed', 'uninstallable', 'unknown']),
+                ('category_id.name', '!=', 'Tests'),
+                ])
         if module_ids:
             module_obj.write(
                 cr, uid, module_ids, {'state': 'to install'})


### PR DESCRIPTION
- Ignore dedicated test addons, as they can rely on demo data
- Ignore implicit columns (create_uid etc.) which are now added automatically as fields
- Manually remove references to implicit columns from analysis files
