### PR TITLE
[IMP] resource: remove sql view created by hr_holidays that prevents column changings

### DIFF
--- a/addons/resource/migrations/8.0.1.1/pre-migration.py
+++ b/addons/resource/migrations/8.0.1.1/pre-migration.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from openerp.openupgrade import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(cr, version):
+    # Drop view that inhibits changing field types. It will be recreated BTW
+    cr.execute('drop view if exists hr_holidays_remaining_leaves_user cascade')


### PR DESCRIPTION
I had the error:

```
2014-12-12 09:23:35,921 23335 ERROR testdb openerp.sql_db: bad query: ALTER TABLE "resource_resource" ALTER COLUMN "name" TYPE VARCHAR
Traceback (most recent call last):
  File "/var/tmp/openupgrade/8.0/server/openerp/sql_db.py", line 234, in execute
    res = self._obj.execute(query, params)
NotSupportedError: cannot alter type of a column used by a view or rule
DETAIL:  rule _RETURN on view hr_holidays_remaining_leaves_user depends on column "name"
```

This change drops the view to be able alter the column (copied and adapted from #154).
