### PR TITLE
[IMP] base: remove sql view that prevents column changings

### DIFF
--- a/openerp/addons/base/migrations/8.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/8.0.1.3/pre-migration.py
@@ -26,6 +26,9 @@ from openerp.addons.openupgrade_records.lib import apriori
 
 @openupgrade.migrate()
 def migrate(cr, version):
+    # Drop view that inhibits changing field types. It will be recreated BTW
+    cr.execute('drop view if exists report_document_user cascade')
+
     openupgrade.update_module_names(
         cr, apriori.renamed_modules.iteritems()
     )


### PR DESCRIPTION
Small fix for error (similar to #159):

```
2014-12-12 09:22:42,129 23335 ERROR testdb openerp.sql_db: bad query: ALTER TABLE "ir_attachment" ALTER COLUMN "datas_fname" TYPE VARCHAR
Traceback (most recent call last):
  File "/var/tmp/openupgrade/8.0/server/openerp/sql_db.py", line 234, in execute
    res = self._obj.execute(query, params)
NotSupportedError: cannot alter type of a column used by a view or rule
DETAIL:  rule _RETURN on view report_document_user depends on column "datas_fname"
```
