### PR TITLE
[FIX]Do not migrate account_id to allow reconciliation of existing bank ...

### DIFF
--- a/addons/account/migrations/8.0.1.1/pre-migration.py
+++ b/addons/account/migrations/8.0.1.1/pre-migration.py
@@ -25,6 +25,7 @@ column_renames = {
     'account_bank_statement_line': [
         ('analytic_account_id', None),
         ('type', None),
+        ('account_id', None),
     ]
 }
 


### PR DESCRIPTION
...statements.

This resolves issue #151. When account_id from account.bank.statement.line is migrated from 7 to 8, the reconciliation workflow in 8 uses the account_id to reconcile automatically, skipping the step where it is possible to make reconciliation adjustments. This also prevented closed bank statements from being adjusted.
Renaming the account_id field allows us to use the new reconciliation process for existing bank statements.

The help argument of account_bank_statement_line.account_id further clarifies this: "This technical field can be used at the statement line creation/import time in order to avoid the reconciliation process on it later on. The statement line will simply create a counterpart on this account".
