### PR TITLE
[FIX] fix wrong filter in search view (account/sale)

### DIFF
--- a/addons/account/report/account_invoice_report_view.xml
+++ b/addons/account/report/account_invoice_report_view.xml
@@ -73,7 +73,6 @@
                 <group expand="1" string="Group By">
                     <filter string="Partner" name="partner_id" context="{'group_by':'partner_id','residual_visible':True}"/>
                     <filter string="Salesperson" name='user' context="{'group_by':'user_id'}"/>
-                    <filter string="Sales Team" domain="[]" context="{'group_by':'section_id'}" groups="base.group_multi_salesteams"/>
                     <filter string="Category of Product" name="category_product" context="{'group_by':'categ_id','residual_invisible':True}"/>
                     <filter string="Status" context="{'group_by':'state'}"/>
                     <filter string="Company" context="{'group_by':'company_id'}" groups="base.group_multi_company"/>

--- a/addons/sale/__openerp__.py
+++ b/addons/sale/__openerp__.py
@@ -74,6 +74,7 @@ The Dashboard for the Sales Manager will include
         'sales_team_view.xml',
         'res_partner_view.xml',
         'report/sale_report_view.xml',
+        'report/invoice_report_view.xml',
         'edi/sale_order_action_data.xml',
         'res_config_view.xml',
         'views/report_saleorder.xml',

--- a/addons/sale/report/invoice_report_view.xml
+++ b/addons/sale/report/invoice_report_view.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+	<data>
+		<record model="ir.ui.view" id="view_account_invoice_report_search_inherit">
+			<field name="name">account.invoice.report.search</field>
+			<field name="model">account.invoice.report</field>
+			<field name="inherit_id" ref="account.view_account_invoice_report_search" />
+			<field name="arch" type="xml">
+				<filter name="user" position="after">
+					<filter string="Sales Team" domain="[]"
+						context="{'group_by':'section_id'}" groups="base.group_multi_salesteams" />
+				</filter>
+			</field>
+		</record>
+
+	</data>
+</openerp>


### PR DESCRIPTION
the field section_id is created in addon sale, but used in the account
reporting views.  This commit moves the search view definition
in the correct file.

This fixes a TypeError when clicking on a + sign in the account.invoice.report.graph view, similar to what is reported at: https://www.odoo.com/nl_NL/forum/help-1/question/error-with-customer-invoice-graph-view-70665

Note that this is a bugfix from Odoo 8.0. I am not entirely clear on what the strategy is to keep up with Odoo 8.0 changes, but from https://github.com/OpenUpgrade/OpenUpgrade/pull/103#issuecomment-56507805 it appears that we're applying fixes from Odoo 8.0 like this instead of making big merges?
