### PR TITLE
[FIX] Match purchase lines and procurements by move_dest_id first (and faster)

### DIFF
--- a/addons/purchase/migrations/8.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/purchase/migrations/8.0.1.1/openupgrade_analysis_work.txt
@@ -1,9 +1,11 @@
 ---Fields in module 'purchase'---
 purchase     / account.invoice.line     / purchase_line_id (many2one)   : NEW relation: purchase.order.line
 # NOTHING TO DO
+
 purchase     / procurement.order        / purchase_id (many2one)        : now a function
 purchase     / procurement.order        / purchase_line_id (many2one)   : NEW relation: purchase.order.line
-# DONE
+purchase     / purchase.order.line      / procurement_ids (one2many)    : NEW relation: procurement.order
+# DONE: match procurements with purchase order lines based on stock move connection or product_id
 
 purchase     / purchase.order           / bid_date (date)               : NEW
 purchase     / purchase.order           / bid_validity (date)           : NEW
@@ -16,7 +18,7 @@ purchase     / purchase.order           / currency_id (many2one)        : not a 
 # NOTHING TO DO from related to many2one
 
 purchase     / purchase.order           / message_last_post (datetime)  : NEW
-# DONE
+# DONE: populate using 8.0 api
 
 purchase     / purchase.order           / picking_ids (one2many)        : now a function
 purchase     / purchase.order           / picking_ids (one2many)        : relation is now 'stock.picking' ('stock.picking.in')
@@ -29,10 +31,11 @@ purchase     / purchase.order           / state (selection)             : select
 purchase     / purchase.order           / warehouse_id (many2one)       : DEL relation: stock.warehouse
 purchase     / purchase.order           / website_message_ids (one2many): NEW relation: mail.message
 purchase     / purchase.order.line      / date_order (date)             : type is now 'datetime' ('date')
-purchase     / purchase.order.line      / move_dest_id (many2one)       : DEL relation: stock.move
 # NOTHING TO DO
-purchase     / purchase.order.line      / procurement_ids (one2many)    : NEW relation: procurement.order
-# DONE
+
+purchase     / purchase.order.line      / move_dest_id (many2one)       : DEL relation: stock.move
+# NOTHING TO DO: after migration of the purchase order line on the procurement,
+# the originating move can be retrieved from the procurement itself
 
 purchase     / res.partner              / purchase_order_ids (one2many) : DEL relation: purchase.order
 purchase     / stock.picking            / purchase_id (many2one)        : DEL relation: purchase.order

--- a/addons/purchase/migrations/8.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/purchase/migrations/8.0.1.1/openupgrade_analysis_work.txt
@@ -35,7 +35,7 @@ purchase     / purchase.order.line      / date_order (date)             : type i
 
 purchase     / purchase.order.line      / move_dest_id (many2one)       : DEL relation: stock.move
 # NOTHING TO DO: after migration of the purchase order line on the procurement,
-# the originating move can be retrieved from the procurement itself
+# this field is redundant because the originating move is accessible through there.
 
 purchase     / res.partner              / purchase_order_ids (one2many) : DEL relation: purchase.order
 purchase     / stock.picking            / purchase_id (many2one)        : DEL relation: purchase.order

--- a/addons/purchase/migrations/8.0.1.1/post-migration.py
+++ b/addons/purchase/migrations/8.0.1.1/post-migration.py
@@ -103,8 +103,15 @@ def migrate_product_supply_method(cr):
 
 def migrate_procurement_order(cr):
     """
-    Switch the old purchase_id in Procurement Order for the new field
-    Purchase Order Line. Search by move_dest_id first, then by product_id.
+    On procurements, purchase_id is replaced by purchase_line_id. We should be
+    able to match most purchase lines because they got the procurement's
+    move_id as their move_dest_id. Fallback on product_id, for presumably the
+    manually created procurements without a related move from a sale or
+    production order.
+
+    In Odoo 8.0, stock moves generated for the procurement (moves from the
+    supplier or production location to stock) are also recorded on the
+    procurement. For purchase procurements, gather them here.
     """
     openupgrade.logged_query(
         cr,

--- a/addons/purchase/migrations/8.0.1.1/post-migration.py
+++ b/addons/purchase/migrations/8.0.1.1/post-migration.py
@@ -112,6 +112,10 @@ def migrate_procurement_order(cr):
     In Odoo 8.0, stock moves generated for the procurement (moves from the
     supplier or production location to stock) are also recorded on the
     procurement. For purchase procurements, gather them here.
+
+    Note that procurement_order.move_dest_id was proc.move_id in 7.0, renamed
+    to legacy in the 8.0 procurement migration script and then renamed again
+    to move_dest_id in the stock migration script.
     """
     openupgrade.logged_query(
         cr,
@@ -121,11 +125,10 @@ def migrate_procurement_order(cr):
         FROM purchase_order_line pol
         WHERE proc.{purchase_id} = pol.order_id
              AND pol.{move_dest_id} IS NOT NULL
-             AND pol.{move_dest_id} = proc.{move_id}
+             AND pol.{move_dest_id} = proc.move_dest_id
         """.format(
             purchase_id=openupgrade.get_legacy_name('purchase_id'),
-            move_dest_id=openupgrade.get_legacy_name('move_dest_id'),
-            move_id=openupgrade.get_legacy_name('move_id')))
+            move_dest_id=openupgrade.get_legacy_name('move_dest_id')))
 
     openupgrade.logged_query(
         cr,

--- a/addons/purchase/migrations/8.0.1.1/post-migration.py
+++ b/addons/purchase/migrations/8.0.1.1/post-migration.py
@@ -127,6 +127,7 @@ def migrate_procurement_order(cr):
         SET purchase_line_id = pol.id
         FROM purchase_order_line pol
         WHERE proc.{purchase_id} = pol.order_id
+             AND proc.purchase_line_id IS NULL
              AND pol.product_id = proc.product_id
              AND pol.id NOT IN (
                  SELECT purchase_line_id

--- a/addons/purchase/migrations/8.0.1.1/pre-migration.py
+++ b/addons/purchase/migrations/8.0.1.1/pre-migration.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
 #
-#    Copyright 2014 ONESTEiN B.V.
+#    Copyright (C) 2014 Therp BV
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -17,37 +17,14 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
-
 from openerp.openupgrade import openupgrade
 
 column_renames = {
-    'procurement_order': [
-        ('message', None),
-        ('note', None),
-        ('move_id', None),
-        ('procure_method', None),
-    ],
-    'product_template': [
-        ('supply_method', None),
-        ('procure_method', None),
-    ],
-    'stock_warehouse_orderpoint': [
-        ('procurement_id', None),
-    ],
-}
-
-xmlid_renames = [
-    ('procurement.access_stock_warehouse_orderpoint',
-     'stock.access_stock_warehouse_orderpoint'),
-    ('procurement.access_stock_warehouse_orderpoint_system',
-     'stock.access_stock_warehouse_orderpoint_system'),
-    ('procurement.stock_warehouse_orderpoint_rule',
-     'stock.stock_warehouse_orderpoint_rule'),
-]
+    'procurement_order': [('purchase_id', None)],
+    'purchase_order_line': [('move_dest_id', None)],
+    }
 
 
 @openupgrade.migrate()
 def migrate(cr, version):
     openupgrade.rename_columns(cr, column_renames)
-    openupgrade.rename_xmlids(cr, xmlid_renames)
-    openupgrade.delete_model_workflow(cr, 'procurement.order')


### PR DESCRIPTION
[IMP] Warn about unmatched files
[ADD] Populate purchase procurement's move_ids
[RFR] Rename procurement purchase_id field in the right module
