### PR TITLE
Remove hr_holidays_meeting_id_fkey constrain to avoid migration issues.

### DIFF
--- a/addons/hr_holidays/migrations/8.0.1.5/pre-migration.py
+++ b/addons/hr_holidays/migrations/8.0.1.5/pre-migration.py
@@ -24,6 +24,9 @@ from openerp.openupgrade import openupgrade
 @openupgrade.migrate()
 def migrate(cr, version):
     cr.execute(
+        "ALTER TABLE hr_holidays DROP CONSTRAINT hr_holidays_meeting_id_fkey"
+    )
+    cr.execute(
         '''update hr_holidays
         set meeting_id=calendar_event.id
         from calendar_event where meeting_id=%s''' % (


### PR DESCRIPTION
- The constraint will be reset by the ORM later.
- Not doing it may abort it altogether.

This replaces PR #185.  See my next-to-last comment in that for rationale.
