### PR TITLE
Fixed rename_xmlids to log error message instead of crashing (7.0)

### DIFF
--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -175,7 +175,7 @@ def rename_xmlids(cr, xmlids_spec):
     although they were still being defined in their respective module).
     """
     for (old, new) in xmlids_spec:
-        if not old.split('.') or not new.split('.'):
+        if '.' not in old or '.' not in new:
             logger.error(
                 'Cannot rename XMLID %s to %s: need the module '
                 'reference to be specified in the IDs' % (old, new))


### PR DESCRIPTION
Correct error message is now shown when rename_xmlids parameter is missing dots. Fixes #192 for branch 7.0
