### PR TITLE
[IMP] don't error out when trying to drop nonexisting constraints

### DIFF
--- a/addons/crm/migrations/8.0.1.0/pre-migration.py
+++ b/addons/crm/migrations/8.0.1.0/pre-migration.py
@@ -58,5 +58,6 @@ def migrate(cr, version):
             'crm_lead_channel_id_fkey',
             'crm_lead_type_id_fkey']:
         cr.execute(
-            "ALTER TABLE crm_lead DROP CONSTRAINT {}".format(constraint))
+            "ALTER TABLE crm_lead DROP CONSTRAINT IF EXISTS {}".format(
+                constraint))
     openupgrade.rename_xmlids(cr, xmlids)

--- a/addons/hr_holidays/migrations/8.0.1.5/pre-migration.py
+++ b/addons/hr_holidays/migrations/8.0.1.5/pre-migration.py
@@ -24,7 +24,8 @@ from openerp.openupgrade import openupgrade
 @openupgrade.migrate()
 def migrate(cr, version):
     cr.execute(
-        "ALTER TABLE hr_holidays DROP CONSTRAINT hr_holidays_meeting_id_fkey"
+        "ALTER TABLE hr_holidays DROP CONSTRAINT IF EXISTS "
+        "hr_holidays_meeting_id_fkey"
     )
     cr.execute(
         '''update hr_holidays


### PR DESCRIPTION
which for example happens often for migrated databases...
