### PR TITLE
[IMP] get user's partner_id from employee record if available

### DIFF
--- a/addons/hr/migrations/7.0.1.1/post-migration.py
+++ b/addons/hr/migrations/7.0.1.1/post-migration.py
@@ -67,9 +67,49 @@ def migrate_hr_job(cr):
         cr, "UPDATE hr_job SET state = 'open' WHERE state = 'old' ")
 
 
+def replace_user_partner(cr, pool):
+    """
+    If there's a sensible partner to use for the user record, do that instead
+    of using the newly created one.
+    address_id wins against address_home_id, and none of both is used if it
+    points to a company's partner.
+    """
+    cr.execute(
+        '''UPDATE res_users SET partner_id=u.partner_id
+        FROM (
+            SELECT r.user_id, COALESCE(e.address_id, e.address_home_id)
+            FROM hr_employee e
+            JOIN resource_resource r ON e.resource_id=r.id
+            WHERE r.user_id IS NOT NULL
+            AND COALESCE(e.address_id, e.address_home_id) IS NOT NULL
+            AND COALESCE(e.address_id, e.address_home_id) NOT IN
+                (SELECT partner_id FROM res_company)) u
+        WHERE
+        (
+            res_users.partner_id IS NULL or
+            res_users.partner_id=openupgrade_7_created_partner_id
+        )
+        AND u.user_id=res_users.id
+        RETURNING id''')
+    root_partner_id = pool['ir.model.data'].get_object_reference(
+        cr, SUPERUSER_ID, 'base', 'partner_root')[1]
+    updated_user_ids = [i for i, in cr.fetchall()]
+    cr.execute(
+        '''UPDATE res_users
+        SET openupgrade_7_created_partner_id=NULL
+        WHERE id in %s AND partner_id <> %s''',
+        (updated_user_ids, root_partner_id))
+    cr.execute(
+        '''DELETE FROM res_partner p
+        USING res_users u
+        WHERE u.partner_id=p.id AND u.id in %s AND p.id <> %s''',
+        (updated_user_ids, root_partner_id))
+
+
 @openupgrade.migrate()
 def migrate(cr, version):
     pool = pooler.get_pool(cr.dbname)
     migrate_hr_employee_addresses(cr, pool)
     migrate_hr_employee_department(cr, pool)
     migrate_hr_job(cr)
+    replace_user_partner(cr, pool)

--- a/addons/hr/migrations/7.0.1.1/post-migration.py
+++ b/addons/hr/migrations/7.0.1.1/post-migration.py
@@ -77,7 +77,8 @@ def replace_user_partner(cr, pool):
     cr.execute(
         '''UPDATE res_users SET partner_id=u.partner_id
         FROM (
-            SELECT r.user_id, COALESCE(e.address_id, e.address_home_id)
+            SELECT
+            r.user_id, COALESCE(e.address_id, e.address_home_id) partner_id
             FROM hr_employee e
             JOIN resource_resource r ON e.resource_id=r.id
             WHERE r.user_id IS NOT NULL

--- a/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
@@ -178,11 +178,6 @@ def create_users_partner(cr):
     to track the partners we create here. These are not necessarily
     the same, especially if you have a custom module implementing
     similar behaviour for 6.1.
-
-    For installations with hr installed, we need a different strategy
-    as the employee's data probably already lives in one of the addresses
-    linked with address_home_id and address_id. In this case, we simply
-    link the address' partner if it exists.
     """
     if not openupgrade.column_exists(
             cr, 'res_users', 'partner_id'):

--- a/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
@@ -207,31 +207,6 @@ def create_users_partner(cr):
         "WHERE module='base' and name='user_root'")
     user_root = cr.fetchone()
     user_root_id = user_root and user_root[0] or 0
-
-    if openupgrade.column_exists(
-            cr, 'hr_employee', 'address_id') and\
-            openupgrade.column_exists(
-                cr, 'resource_resource', 'user_id'):
-        # if hr is installed, get partners from there if possible
-        cr.execute(
-            '''UPDATE res_users SET partner_id=u.partner_id
-            FROM (
-                SELECT r.user_id, a.partner_id
-                FROM hr_employee e
-                JOIN resource_resource r ON e.resource_id=r.id
-                JOIN res_partner_address a ON COALESCE(
-                    e.address_id, e.address_home_id)=a.id
-                WHERE r.user_id IS NOT NULL AND a.partner_id IS NOT NULL) u
-            WHERE res_users.partner_id IS NULL and u.user_id=res_users.id''')
-        # inject xmlid for root partner if we set it above
-        cr.execute(
-            '''INSERT INTO ir_model_data
-            (res_id, model, module, name, noupdate)
-            SELECT
-            partner_id, 'res.partner', 'base', 'partner_root', TRUE
-            FROM res_users where id=%s AND partner_id IS NOT NULL''',
-            (user_root_id,))
-
     cr.execute(
         "SELECT id, name, active FROM res_users "
         "WHERE partner_id IS NULL")

--- a/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
@@ -230,7 +230,7 @@ def create_users_partner(cr):
             SELECT
             partner_id, 'res.partner', 'base', 'partner_root', TRUE
             FROM res_users where id=%s AND partner_id IS NOT NULL''',
-            user_root_id)
+            (user_root_id,))
 
     cr.execute(
         "SELECT id, name, active FROM res_users "

--- a/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
@@ -178,6 +178,11 @@ def create_users_partner(cr):
     to track the partners we create here. These are not necessarily
     the same, especially if you have a custom module implementing
     similar behaviour for 6.1.
+
+    For installations with hr installed, we need a different strategy
+    as the employee's data probably already lives in one of the addresses
+    linked with address_home_id and address_id. In this case, we simply
+    link the address' partner if it exists.
     """
     if not openupgrade.column_exists(
             cr, 'res_users', 'partner_id'):
@@ -202,6 +207,31 @@ def create_users_partner(cr):
         "WHERE module='base' and name='user_root'")
     user_root = cr.fetchone()
     user_root_id = user_root and user_root[0] or 0
+
+    if openupgrade.column_exists(
+            cr, 'hr_employee', 'address_id') and\
+            openupgrade.column_exists(
+                cr, 'resource_resource', 'user_id'):
+        # if hr is installed, get partners from there if possible
+        cr.execute(
+            '''UPDATE res_users SET partner_id=u.partner_id
+            FROM (
+                SELECT r.user_id, a.partner_id
+                FROM hr_employee e
+                JOIN resource_resource r ON e.resource_id=r.id
+                JOIN res_partner_address a ON COALESCE(
+                    e.address_id, e.address_home_id)=a.id
+                WHERE r.user_id IS NOT NULL AND a.partner_id IS NOT NULL) u
+            WHERE res_users.partner_id IS NULL and u.user_id=res_users.id''')
+        # inject xmlid for root partner if we set it above
+        cr.execute(
+            '''INSERT INTO ir_model_data
+            (res_id, model, module, name, noupdate)
+            SELECT
+            partner_id, 'res.partner', 'base', 'partner_root', TRUE
+            FROM res_users where id=%s AND partner_id IS NOT NULL''',
+            user_root_id)
+
     cr.execute(
         "SELECT id, name, active FROM res_users "
         "WHERE partner_id IS NULL")


### PR DESCRIPTION
For installations with hr installed, we need a different strategy
as the employee's data probably already lives in one of the addresses
linked with address_home_id and address_id. In this case, we simply
link the address' partner if it exists.
