### PR TITLE
[ADD] crm_todo: Nothing to do

### DIFF
--- a/addons/crm_todo/migrations/7.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/crm_todo/migrations/7.0.1.0/openupgrade_analysis_work.txt
@@ -1,0 +1,6 @@
+---Fields in module 'crm_todo'---
+crm_todo / project.task / lead_id (many2one) : DEL relation: crm.lead
+# False positive - Nothing to do
+
+---XML records in module 'crm_todo'---
+


### PR DESCRIPTION
It's curious that the analysis file mentions the field lead_id as removed, where the field remains unaltered. I have removed this line.
