### PR TITLE
[FIX/IMP] API method set_partner_id_from_partner_address_id switched to SQL

### DIFF
--- a/openerp/openupgrade/openupgrade_70.py
+++ b/openerp/openupgrade/openupgrade_70.py
@@ -23,8 +23,6 @@
 # This module provides simple tools for openupgrade migration, specific for the
 # 6.1 -> 7.0.
 
-from openerp import SUPERUSER_ID
-
 
 def set_partner_id_from_partner_address_id(
         cr, pool, model_name, partner_field, address_field, table=None):
@@ -48,7 +46,9 @@ def set_partner_id_from_partner_address_id(
              res_partner_address as address
         WHERE address.id = target.%s""" % (table, address_field))
     for row in cr.fetchall():
-        model.write(cr, SUPERUSER_ID, row[0], {partner_field: row[1]})
+        cr.execute("UPDATE %s "
+                   "SET %s=%%s "
+                   "WHERE id=%%s" % (table, partner_field), (row[1], row[0]))
 
 
 def get_partner_id_from_user_id(cr, user_id):


### PR DESCRIPTION
As in #234, using ORM write makes this call very slow and also error prone due to the checks that are performed on the write.

This switches the write to SQL to avoid this.
