### PR TITLE
fix: [openupgrade] exception in ``log_model()`` upon module loading.

### DIFF
--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -173,6 +173,7 @@ def load_module_graph(cr, graph, status=None, perform_checks=True, skip_modules=
 
         loaded_modules.append(package.name)
         if hasattr(package, 'init') or hasattr(package, 'update') or package.state in ('to install', 'to upgrade'):
+            registry.setup_models(cr, partial=True)
             # OpenUpgrade: add this module's models to the registry
             local_registry = {}
             for model in models:
@@ -181,8 +182,6 @@ def load_module_graph(cr, graph, status=None, perform_checks=True, skip_modules=
                 openupgrade_loading.log_model(model, local_registry)
             openupgrade_loading.compare_registries(
                 cr, package.name, upg_registry, local_registry)
-
-            registry.setup_models(cr, partial=True)
             init_module_models(cr, package.name, models)
 
         # Can't put this line out of the loop: ir.module.module will be


### PR DESCRIPTION
Since commit 2f06adde9c46be73d2fbf13a9cfd6b333117e395 in odoo,
the `_columns` gets lazy valued and recomputed only by
`registry.setup_fields()` call.

As openupgrade depends on `._columns` to be set up, this seems
to be the fix: it successfully goes through the loading process on my side.

I'm currently on a rebased version of openupgrade on last `odoo/8.0` ... In the current `openupgrade/8.0`, you don't have the culprit commit I'm mentionning.

This fix makes it go through the module loading process on my rebased version.

May I ask you if you see any side effects on launching `.setup_models()` before `.log_model` and `compare_registries()` ?

If this seems okay, feel free to cherry pick this whenever you'll update to the latest version 8.0 of odoo, or include it right now to protect yourself in advance.
