### PR TITLE
Fix move field m2o binary

### DIFF
--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -865,12 +865,7 @@ def move_field_m2o(
                 field_old_model, table_old_model, m2o_field_old_model, ko_id))
         cr.execute(query)
         if binary_field:
-            vals = []
-            for x in cr.fetchall():
-                if x[0]:
-                    vals.append(x[0][:])
-                else:
-                    vals.append(False)
+            vals = [str(x[0][:]) if x[0] else False for x in cr.fetchall()]
         else:
             vals = [x[0] for x in cr.fetchall()]
         value = func(cr, pool, ko_id, vals)

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -802,7 +802,7 @@ def move_field_m2o(
                 res = val
         return res
 
-    logger.info("Moving data from '%s'.'%s' to '%s'.%s" % (
+    logger.info("Moving data from '%s'.'%s' to '%s'.'%s'" % (
         registry_old_model, field_old_model,
         registry_new_model, field_new_model))
 

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -861,7 +861,12 @@ def move_field_m2o(
                 field_old_model, table_old_model, m2o_field_old_model, ko_id))
         cr.execute(query)
         if binary_field:
-            vals = [str(x[0][:]) for x in cr.fetchall()]
+            vals = []
+            for x in cr.fetchall():
+                if x[0]:
+                    vals.append(x[0][:])
+                else:
+                    vals.append(False)
         else:
             vals = [x[0] for x in cr.fetchall()]
         value = func(cr, pool, ko_id, vals)

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -802,6 +802,10 @@ def move_field_m2o(
                 res = val
         return res
 
+    logger.info("Moving data from '%s'.'%s' to '%s'.%s" % (
+        registry_old_model, field_old_model,
+        registry_new_model, field_new_model))
+
     table_old_model = pool[registry_old_model]._table
     table_new_model = pool[registry_new_model]._table
     # Manage regular case (all the value are identical)


### PR DESCRIPTION
Hi, 
I try to fix a minor bug in move_field_m2o function of openupgrade framework that occures if we try to migrate binary_field with undefined data. (In my case, move of image field from product.product to product.template).

Kind regards.
