### PR TITLE
[ADD] Function to fallback on workflow state

### DIFF
--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -312,12 +312,17 @@ def update_workflow_workitems(cr, pool, ref_spec_actions):
     """Find all the workflow items from the target state to set them to
     the wanted state.
 
-    Remove a workflow action and move those to fallback state
-    (use in pre-migration)
+    When a workflow action is removed, from model, the objects whose states
+    are in these actions need to be set to another to be able to continue the
+    workflow properly.
+
+    Run in pre-migration
 
     :param ref_spec_actions: list of tuples with couple of workflow.action's
-        external ids. The first id is replaced to the second.
+        external ids. The first id is replaced with the second.
     :return: None
+
+    .. versionadded:: 7.0
     """
     workflow_workitems = pool['workflow.workitem']
     ir_model_data_model = pool['ir.model.data']

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -324,10 +324,14 @@ def update_workflow_workitems(cr, pool, ref_spec_actions):
 
     for (target_external_id, wanted_external_id) in ref_spec_actions:
         target_activity_id = ir_model_data_model.get_object(
-            cr, SUPERUSER_ID, target_external_id
+            cr, SUPERUSER_ID,
+            target_external_id.split(".")[0],
+            target_external_id.split(".")[1],
         ).id
         wanted_activity_id = ir_model_data_model.get_object(
-            cr, SUPERUSER_ID, wanted_external_id
+            cr, SUPERUSER_ID,
+            wanted_external_id.split(".")[0],
+            wanted_external_id.split(".")[1],
         ).id
 
         ids = workflow_workitems.search(

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -46,6 +46,7 @@ __all__ = [
     'add_xmlid',
     'drop_columns',
     'delete_model_workflow',
+    'update_workflow_workitems',
     'warn_possible_dataloss',
     'set_defaults',
     'logged_query',
@@ -305,6 +306,36 @@ def drop_columns(cr, column_spec):
         else:
             logger.warn("table %s: column %s did not exist",
                         table, column)
+
+
+def update_workflow_workitems(cr, pool, ref_spec_actions):
+    """Find all the workflow items from the target state to set them to
+    the wanted state.
+
+    Remove a workflow action and move those to fallback state
+    (use in pre-migration)
+
+    :param ref_spec_actions: list of tuples with couple of workflow.action's
+        external ids. The first id is replaced to the second.
+    :return: None
+    """
+    workflow_workitems = pool['workflow.workitem']
+    ir_model_data_model = pool['ir.model.data']
+
+    for (target_external_id, wanted_external_id) in ref_spec_actions:
+        target_activity_id = ir_model_data_model.get_object(
+            cr, SUPERUSER_ID, target_external_id
+        ).id
+        wanted_activity_id = ir_model_data_model.get_object(
+            cr, SUPERUSER_ID, wanted_external_id
+        ).id
+
+        ids = workflow_workitems.search(
+            cr, SUPERUSER_ID, [('act_id', '=', target_activity_id)]
+        )
+        workflow_workitems.write(
+            cr, SUPERUSER_ID, ids, {'act_id': wanted_activity_id}
+        )
 
 
 def delete_model_workflow(cr, model):

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -327,24 +327,29 @@ def update_workflow_workitems(cr, pool, ref_spec_actions):
     workflow_workitems = pool['workflow.workitem']
     ir_model_data_model = pool['ir.model.data']
 
-    for (target_external_id, wanted_external_id) in ref_spec_actions:
-        target_activity_id = ir_model_data_model.get_object(
+    for (target_external_id, fallback_external_id) in ref_spec_actions:
+        target_activity = ir_model_data_model.get_object(
             cr, SUPERUSER_ID,
             target_external_id.split(".")[0],
             target_external_id.split(".")[1],
-        ).id
-        wanted_activity_id = ir_model_data_model.get_object(
+        )
+        fallback_activity = ir_model_data_model.get_object(
             cr, SUPERUSER_ID,
-            wanted_external_id.split(".")[0],
-            wanted_external_id.split(".")[1],
-        ).id
-
+            fallback_external_id.split(".")[0],
+            fallback_external_id.split(".")[1],
+        )
         ids = workflow_workitems.search(
-            cr, SUPERUSER_ID, [('act_id', '=', target_activity_id)]
+            cr, SUPERUSER_ID, [('act_id', '=', target_activity.id)]
         )
-        workflow_workitems.write(
-            cr, SUPERUSER_ID, ids, {'act_id': wanted_activity_id}
-        )
+        if ids:
+            logger.info(
+                "Moving %d items in the removed workflow action (%s) to a "
+                "fallback action (%s): %s",
+                len(ids), target_activity.name, fallback_activity.name, ids
+            )
+            workflow_workitems.write(
+                cr, SUPERUSER_ID, ids, {'act_id': fallback_activity.id}
+            )
 
 
 def delete_model_workflow(cr, model):


### PR DESCRIPTION
Replace state which could have been remove from all instances with a fallback state

This could happen in the case where a workflow is simplified and one state is removed.

This will get these items out of that removed state in the pre-upgrade and put them in a defined fallback.
