### PR TITLE
[7.0] Update workflow workitems

### DIFF
--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -210,12 +210,17 @@ def update_workflow_workitems(cr, pool, ref_spec_actions):
     """Find all the workflow items from the target state to set them to
     the wanted state.
 
-    Remove a workflow action and move those to fallback state
-    (use in pre-migration)
+    When a workflow action is removed, from model, the objects whose states
+    are in these actions need to be set to another to be able to continue the
+    workflow properly.
+
+    Run in pre-migration
 
     :param ref_spec_actions: list of tuples with couple of workflow.action's
-        external ids. The first id is replaced to the second.
+        external ids. The first id is replaced with the second.
     :return: None
+
+    .. versionadded:: 7.0
     """
     workflow_workitems = pool['workflow.workitem']
     ir_model_data_model = pool['ir.model.data']

--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -222,10 +222,14 @@ def update_workflow_workitems(cr, pool, ref_spec_actions):
 
     for (target_external_id, wanted_external_id) in ref_spec_actions:
         target_activity_id = ir_model_data_model.get_object(
-            cr, SUPERUSER_ID, target_external_id
+            cr, SUPERUSER_ID,
+            target_external_id.split(".")[0],
+            target_external_id.split(".")[1],
         ).id
         wanted_activity_id = ir_model_data_model.get_object(
-            cr, SUPERUSER_ID, wanted_external_id
+            cr, SUPERUSER_ID,
+            wanted_external_id.split(".")[0],
+            wanted_external_id.split(".")[1],
         ).id
 
         ids = workflow_workitems.search(


### PR DESCRIPTION
Same as #250

Replace state which could have been remove from all instances with a fallback state

This could happen in the case where a workflow is simplified and one state is removed.

This will get these items out of that removed state in the pre-upgrade and put them in a defined fallback.
