### PR TITLE
[FIX] don't try to fix nonexisting partner_id

### DIFF
--- a/addons/crm/migrations/7.0.1.0/post-migration.py
+++ b/addons/crm/migrations/7.0.1.0/post-migration.py
@@ -27,8 +27,6 @@ from openupgrade.openupgrade_70 import (
 
 
 def migrate_partners(cr, pool):
-    fix_partner(cr, pool, 'crm.meeting', 'partner_id',
-                openupgrade.get_legacy_name('partner_address_id'))
     fix_partner(cr, pool, 'crm.lead', 'partner_id',
                 openupgrade.get_legacy_name('partner_address_id'))
     fix_partner(cr, pool, 'crm.phonecall', 'partner_id',


### PR DESCRIPTION
We move crm_meeting.partner_id out of the way in https://github.com/OpenUpgrade/OpenUpgrade/blob/7.0/addons/crm/migrations/7.0.1.0/pre-migration.py#L44. This problem was revealed by #236, before the ORM happily ignored the nonexisting field.
