### PR TITLE
Revert "[IMP/FIX] m2o_to_m2m: Use SQL for performance and for avoiding s...

### DIFF
--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -582,27 +582,14 @@ def m2o_to_x2m(cr, model, table, field, source_field):
 
     .. versionadded:: 7.0
     """
-    if not model._columns.get(field):
-        raise orm.except_orm(
-            "Error", "m2o_to_m2m: field %s doesn't exist in model %s" % (
-                field, model._name))
-    if not isinstance(model._columns[field], orm.fields.many2many):
-        raise orm.except_orm(
-            "Error", "m2o_to_m2m: field %s of model %s is not a many2many "
-                     "one" % (field, model._name))
     cr.execute('SELECT id, %(field)s '
                'FROM %(table)s '
                'WHERE %(field)s is not null' % {
                    'table': table,
                    'field': source_field,
                    })
-    rel, id1, id2 = orm.fields.many2many._sql_names(model._columns[field],
-                                                    model)
     for row in cr.fetchall():
-        cr.execute(
-            "INSERT INTO %s (%s, %s) "
-            "VALUES (%%s, %%s)" %
-            (rel, id1, id2), (row[0], row[1]))
+        model.write(cr, SUPERUSER_ID, row[0], {field: [(4, row[1])]})
 
 # Backwards compatibility
 m2o_to_m2m = m2o_to_x2m


### PR DESCRIPTION
I have to revert this one because it doesn't take into account one2many fields (due to this has been introduced on 8.0). I'll make a new PR joining the query and taking this into account.
