### PR TITLE
[FIX] Analysis wizard: Rename field "write" to "write_files"

### DIFF
--- a/openerp/addons/openupgrade_records/model/analysis_wizard.py
+++ b/openerp/addons/openupgrade_records/model/analysis_wizard.py
@@ -55,14 +55,14 @@ class openupgrade_analysis_wizard(TransientModel):
             [('init', 'Init'), ('ready', 'Ready')], 'State',
             readonly=True),
         'log': fields.text('Log'),
-        'write': fields.boolean(
+        'write_files': fields.boolean(
             'Write files',
             help='Write analysis files to the module directories'
             ),
         }
     _defaults = {
-        'state': lambda *a: 'init',
-        'write': lambda *a: True,
+        'state': 'init',
+        'write_files': True,
         }
 
     def get_communication(self, cr, uid, ids, context=None):
@@ -163,7 +163,7 @@ class openupgrade_analysis_wizard(TransientModel):
                     "ERROR: module not in list of installed modules:\n" +
                     contents)
                 continue
-            if wizard.write:
+            if wizard.write_files:
                 error = write_file(
                     key, modules[key]['installed_version'], contents)
                 if error:
@@ -173,7 +173,7 @@ class openupgrade_analysis_wizard(TransientModel):
                 general += contents
 
         # Store the general log in as many places as possible ;-)
-        if wizard.write and 'base' in modules:
+        if wizard.write_files and 'base' in modules:
             write_file(
                 'base', modules['base']['installed_version'], general,
                 'openupgrade_general_log.txt')

--- a/openerp/addons/openupgrade_records/view/analysis_wizard.xml
+++ b/openerp/addons/openupgrade_records/view/analysis_wizard.xml
@@ -11,7 +11,7 @@
                     <field name="state"/>
                     <field name="log" colspan="4"
                            attrs="{'invisible': [('state', '!=', 'ready')]}"/>
-                    <field name="write"                           
+                    <field name="write_files"                           
                            attrs="{'readonly': [('state', '!=', 'init')]}"/>
                     <button icon="gtk-close"
                             special="cancel"


### PR DESCRIPTION
To prevent error when calling the orm "write()" method on the wizard model as it calls the "write" field descriptor instead which raises `AttributeError: 'openupgrade.analysis.wizard' object has no attribute '_ids'`
