### PR TITLE
[FIX] mail: Incorrect mail_message post migration UPDATE statement

### DIFF
--- a/addons/mail/migrations/8.0.1.0/post-migration.py
+++ b/addons/mail/migrations/8.0.1.0/post-migration.py
@@ -38,9 +38,9 @@ def mail_mail_to_mail_message_migration(cr, uid, pool):
     legacy_server_id = openupgrade.get_legacy_name('mail_server_id')
     legacy_reply_to = openupgrade.get_legacy_name('reply_to')
     openupgrade.logged_query(cr, """
-UPDATE mail_message
+UPDATE mail_message AS a
 SET %s = %s, %s = %s
-FROM mail_message AS a JOIN mail_mail AS b ON a.id = b.mail_message_id
+FROM mail_mail AS b WHERE a.id = b.mail_message_id
 """ % ('mail_server_id', legacy_server_id, 'reply_to', legacy_reply_to, ))
 
 


### PR DESCRIPTION
The mail_message table is wrongly included in the FROM clause. This led to a huge cross join and even if it is successfully completed, the data would not be correct.

In a database with about 280k mail_message rows and 970 mail_mail rows, the query always consumes all the memory (6GB) until the OOM killer takes down the PG backend. I'm wondering how this error was never caught before?!!
