### PR TITLE
Update the module's own external id after renaming it

### DIFF
--- a/openerp/openupgrade/openupgrade.py
+++ b/openerp/openupgrade/openupgrade.py
@@ -543,6 +543,11 @@ def update_module_names(cr, namespec):
         query = ("UPDATE ir_model_data SET module = %s "
                  "WHERE module = %s ")
         logged_query(cr, query, (new_name, old_name))
+        query = ("UPDATE ir_model_data SET name = %s "
+                 "WHERE name = %s AND module = 'base' AND "
+                 "model='ir.module.module' ")
+        logged_query(cr, query,
+                     ("module_%s" % new_name, "module_%s" % old_name))
         query = ("UPDATE ir_module_module_dependency SET name = %s "
                  "WHERE name = %s")
         logged_query(cr, query, (new_name, old_name))


### PR DESCRIPTION
Modules have an external id of the form `base.module_*`
This makes sure they are also renamed when the module name changes
