### PR TITLE
[FIX] move xmlids of moved fields

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -406,12 +406,18 @@ class BaseModel(object):
         cols = {}
         for rec in cr.dictfetchall():
             # OpenUpgrade start:
-            if rec['name'] in self._columns.keys() and\
+            if 'module' in context and\
+                    rec['name'] in self._columns.keys() and\
                     rec['module'] != context.get('module') and\
                     rec['module'] not in self.pool._init_modules:
-                cr.execute("DELETE FROM ir_model_fields WHERE id=%(id)s", rec)
-                cr.execute("DELETE FROM ir_model_data WHERE id=%(xmlid_id)s", rec)
-                continue
+                _logger.info(
+                    'Moving XMLID for ir.model.fields record of %s#%s '
+                    'from %s to %s',
+                    self._name, rec['name'], rec['module'], context['module'])
+                cr.execute(
+                    "UPDATE ir_model_data SET module=%(module)s "
+                    "WHERE id=%(xmlid_id)s",
+                    dict(rec, module=context['module']))
             # OpenUpgrade end
             cols[rec['name']] = rec
 

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -395,8 +395,7 @@ class BaseModel(object):
         # module
         # Given that we arrive here in order of inheritance, we simply check
         # if the field's xmlid belongs to a module already loaded, and if not,
-        # drop the record to let the following standard code create it for the
-        # correct module.
+        # update the record with the correct module name.
         cr.execute(
             "SELECT f.*, d.module, d.id as xmlid_id "
             "FROM ir_model_fields f LEFT JOIN ir_model_data d "


### PR DESCRIPTION
```
        # OpenUpgrade edit start: In rare cases, an old module defined a field
        # on a model that is not defined in another module earlier in the
        # chain of inheritance. Then we need to assign the ir.model.fields'
        # xmlid to this other module, otherwise the column would be dropped
        # when uninstalling the first module.
        # An example is res.partner#display_name defined in 7.0 by
        # account_report_company, but now the field belongs to the base
        # module
        # Given that we arrive here in order of inheritance, we simply check
        # if the field's xmlid belongs to a module already loaded, and if not,
        # drop the record to let the following standard code create it for the
        # correct module.
```
