### PR TITLE
[FIX] base: Propagate also customer and supplier flags from partner to address

### DIFF
--- a/openerp/addons/base/migrations/7.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/post-migration.py
@@ -147,8 +147,8 @@ def migrate_partner_address(cr, pool):
         'partner_id', 'name', 'company_id'
         ]
     propagate_fields = [
-        'lang', 'tz',
-        ]
+        'lang', 'tz', 'customer', 'supplier',
+    ]
     partner_found = []
     processed_ids = []
 


### PR DESCRIPTION
Propagate also these fields, because although at the beginning it feels that don't have addresses in the list with the default filter, this becomes quickly inconsistently when you create new partners + contacts. Also, you are not able to select these addresses on sales/purchase orders due to not having the corresponding field marked.
