### PR TITLE
[FIX] base: Handle correctly migration of base_contact

### DIFF
--- a/openerp/addons/base/migrations/7.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/post-migration.py
@@ -61,71 +61,61 @@ def migrate_company(cr):
 
 def migrate_base_contact(cr):
     """
-    Move entries of res_partner_contact into res_partner
+    In v6.1, base_contact module has this structure:
+
+    res.partner
+    |
+    |-> res.partner.address -|
+    |-> res.partner.address -|
+                             |-> res.partner.contact
+    res.partner              |
+    |                        |
+    |-> res.partner.address -|
+
+    And res.partner.contact contains information that is shared to linked
+    res.partner.address via related fields.
+
+    In v7, now that we remove res.partner.contact, we should copy
+    res.partner.contact information on each linked address (that has been
+    converted also to a res.partner record), but not create a new res.partner
+    for each res.partner.contact.
     """
     cr.execute(
         "SELECT * FROM ir_module_module "
         "WHERE name = 'base_contact' and state = 'to remove';")
     if not cr.fetchall():
         return
-    fields = [
-        'create_date',
-        'name',
-        'website',
-        'image',
-        'active',
-        'comment',
-        'title',
-        'phone',
-        'country_id',
-        'email',
-        'birthdate',
-        'lang',
-        'parent_id',
-    ]
-    # Add lang from lang_id
+    # Add non-existing columns that can be used with partner_lastname module
+    cr.execute("ALTER TABLE res_partner "
+               "ADD COLUMN firstname character varying;")
+    cr.execute("ALTER TABLE res_partner "
+               "ADD COLUMN lastname character varying;")
+    # Update addresses with contact information
     openupgrade.logged_query(
         cr,
-        "ALTER TABLE res_partner_contact "
-        "ADD COLUMN lang character varying(5);")
-    openupgrade.logged_query(cr, """
-        UPDATE res_partner_contact
-        SET lang = (SELECT code
-                    FROM res_lang l
-                    WHERE lang_id = l.id
-                    LIMIT 1);""")
-    # Add parent_id
-    openupgrade.logged_query(
-        cr, "ALTER TABLE res_partner_contact ADD COLUMN parent_id integer;")
-    openupgrade.logged_query(cr, """
-        UPDATE res_partner_contact
-        SET parent_id = (SELECT openupgrade_7_migrated_to_partner_id
-                         FROM res_partner_address a
-                         WHERE id = a.contact_id
-                         LIMIT 1);""")
-    # Make sure fields exist
-    cr.execute(
-        "SELECT column_name "
-        "FROM information_schema.columns "
-        "WHERE table_name = 'res_partner_contact';")
-    available_fields = set(i[0] for i in cr.fetchall())
-    lost_fields = set(fields) - available_fields
-    if lost_fields:
-        openupgrade.logger.warning("""\
-The following columns are not present in the table of %s: %s.
-
-This can be the case if an additional module installed on your database changes
-the type of a regular column to a non-stored function or related field.
-""", 'res_partner_contact', ", ".join(lost_fields))
-    fields = list(available_fields.intersection(fields))
-    # Move data
-    openupgrade.logged_query(
-        cr, """
-        INSERT INTO res_partner (%s)
-        SELECT %s
-        FROM res_partner_contact;""" % (
-            ", ".join(fields + ['customer', 'is_company']),
-            ", ".join(fields + ['TRUE', 'FALSE'])))
+        """
+        UPDATE res_partner
+        SET lastname=contact.last_name,
+            firstname=contact.first_name,
+            mobile=contact.mobile,
+            image=contact.photo,
+            website=contact.website,
+            lang=res_lang.code,
+            active=contact.active,
+            comment=contact.comment,
+            country_id=contact.country_id,
+            email=contact.email,
+            birthdate=contact.birthdate
+        FROM
+            res_lang,
+            res_partner_contact contact,
+            res_partner_address
+        WHERE
+            res_lang.id = contact.lang_id AND
+            res_partner.id =
+            res_partner_address.openupgrade_7_migrated_to_partner_id AND
+            contact.id = res_partner_address.contact_id
+        """)
 
 
 def migrate_partner_address(cr, pool):

--- a/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
@@ -67,22 +67,6 @@ def disable_demo_data(cr):
         "UPDATE ir_module_module SET demo = false")
 
 
-def rename_base_contact_columns(cr):
-    """
-    Rename columns only if res_partner_contact is installed
-    """
-    cr.execute(
-        "SELECT * FROM information_schema.tables "
-        "WHERE table_name = 'res_partner_contact';")
-    if cr.fetchall():
-        openupgrade.rename_columns(cr, {
-            'res_partner_contact': [
-                ('photo', 'image'),
-                ('mobile', 'phone'),
-            ]
-        })
-
-
 def migrate_ir_attachment(cr):
     # Data is now stored in db_datas column and datas is a function field
     # like in the document module in 6.1. If the db_datas column already
@@ -232,7 +216,6 @@ def migrate(cr, version):
     openupgrade.drop_columns(cr, [('ir_actions_todo', 'action_id')])
     openupgrade.rename_columns(cr, column_renames)
     openupgrade.rename_tables(cr, table_renames)
-    rename_base_contact_columns(cr)
     openupgrade.rename_xmlids(cr, xmlid_renames)
     openupgrade.rename_models(cr, model_renames)
     migrate_ir_attachment(cr)


### PR DESCRIPTION
This modification handles correctly the migration of _base_contact_ module, making an update instead of inserting new records.

In v6.1, base_contact module has this structure:

```
res.partner
|
|-> res.partner.address -|
|-> res.partner.address -|
                         |-> res.partner.contact
res.partner              |
|                        |
|-> res.partner.address -|
```

And res.partner.contact contains information that is shared to linked res.partner.address via related fields.

In v7, now that we remove res.partner.contact, we should copy res.partner.contact information on each linked address, but not creating a new res.partner for each res.partner.contact.
