### PR TITLE
[FIX] stock: Recreate correctly data of transferred moves

### DIFF
--- a/addons/stock/migrations/8.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/stock/migrations/8.0.1.1/openupgrade_analysis_work.txt
@@ -202,7 +202,7 @@ stock        / stock.move               / product_uom_qty (float)       : NEW re
 stock        / stock.move               / propagate (boolean)           : NEW 
 stock        / stock.move               / push_rule_id (many2one)       : NEW relation: stock.location.path
 stock        / stock.move               / quant_ids (many2many)         : NEW relation: stock.quant
-# DONE: let Odoo do this by reconfirming done moves
+# DONE: let Odoo do this by creating stock.pack.operation records and doing picking transfer
 
 stock        / stock.move               / reserved_quant_ids (one2many) : NEW relation: stock.quant
 stock        / stock.move               / restrict_lot_id (many2one)    : NEW relation: stock.production.lot


### PR DESCRIPTION
With current script approach, no stock.pack.operation is recreated, losing information at stock.picking level (you can't print picking report with serial number), and with no link with moves for reversing operations.

This PR amends this, creating the equivalent stock.pack.operation, and calling after picking do_transfer method that creates the quant and makes the links.
