### PR TITLE
[FIX #288] migrate.py assign all external repositories as a module and not all of them are right written modules.

### DIFF
--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -340,8 +340,8 @@ for version in options.migrations.split(','):
         'addons_path',
         ','.join(
             [os.path.realpath(os.path.join(options.branch_dir,
-                          version,
-                          'addons'))] +
+                                           version,
+                                           'addons'))] +
             []))
     config.set(
         'options',

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -315,13 +315,12 @@ for version in options.migrations.split(','):
 
         realtarget = os.path.realpath(target)
         for root, dirs, files in os.walk(realtarget):
-            for file in files:
-                if file == "__openerp__.py":
-                    linkpath = os.path.join(options.branch_dir,
-                                            version, 'addons', name)
-                    if os.path.exists(linkpath):
-                        os.remove(linkpath)
-                    os.symlink(root, linkpath)
+            if "__openerp__.py" in files:
+                linkpath = os.path.join(options.branch_dir,
+                                        version, 'addons', name)
+                if os.path.exists(linkpath):
+                    os.remove(linkpath)
+                os.symlink(root, linkpath)
 
 db_name = conn_parms['database']
 if not options.inplace:


### PR DESCRIPTION
[FIX #288] migrate.py assign all external repositories as directories of modules, but some modules are in the root of the repository. Then odoo ignore the real module, and all subdirectories are assigned as new modules or shadowing the real ones. This fix use a common directory where all repositories are stored and find in them all **openerp**.py script to detect real modules. Detected modules will link it to the main addon directory.
