### PR TITLE
[FIX] actually get the state from matching analytic account

### DIFF
--- a/addons/project/migrations/7.0.1.1/post-migration.py
+++ b/addons/project/migrations/7.0.1.1/post-migration.py
@@ -26,11 +26,11 @@ from openerp import pooler, SUPERUSER_ID
 def copy_state_from_analytic_account(cr):
     openupgrade.logged_query(cr, """
         UPDATE project_project pp
-        SET state = account_analytic_account.state
-        FROM project_project
-        INNER JOIN account_analytic_account
-        ON account_analytic_account.id = project_project.analytic_account_id
-        WHERE pp.analytic_account_id is not NULL
+        SET state = a.state
+        FROM project_project p
+        INNER JOIN account_analytic_account a
+        ON a.id = p.analytic_account_id
+        WHERE pp.analytic_account_id=a.id
         """)
 
 


### PR DESCRIPTION
the statement before didn't hook the join to the updated table, resulting in all states being copied from one account
