### PR TITLE
[FIX] prefer the product's code to variant price

### DIFF
--- a/addons/product/migrations/8.0.1.1/post-migration.py
+++ b/addons/product/migrations/8.0.1.1/post-migration.py
@@ -93,7 +93,7 @@ def migrate_variants(cr, pool):
     attribute_line_obj = pool['product.attribute.line']
     fields = {'variant': openupgrade.get_legacy_name('variants'),
               'price': openupgrade.get_legacy_name('price_extra')}
-    sql = ("SELECT id, %(variant)s, %(price)s, product_tmpl_id "
+    sql = ("SELECT id, %(variant)s, %(price)s, default_code, product_tmpl_id "
            "FROM product_product "
            "WHERE %(variant)s IS NOT NULL "
            "OR %(price)s IS NOT NULL AND %(price)s <> 0"
@@ -112,7 +112,8 @@ def migrate_variants(cr, pool):
             # active_id needed to create the 'product.attribute.price'
             ctx = {'active_id': tmpl_id}
             values = {
-                'name': name or '%.2f' % price_extra,
+                'name': name or variant['default_code'] or
+                    '%.2f' % price_extra,
                 'attribute_id': attr_id,
                 'product_ids': [(6, 0, [variant['id']])],
                 # a 'product.attribute.price' is created when we write

--- a/addons/product/migrations/8.0.1.1/post-migration.py
+++ b/addons/product/migrations/8.0.1.1/post-migration.py
@@ -113,7 +113,7 @@ def migrate_variants(cr, pool):
             ctx = {'active_id': tmpl_id}
             values = {
                 'name': name or variant['default_code'] or
-                    '%.2f' % price_extra,
+                '%.2f' % price_extra,
                 'attribute_id': attr_id,
                 'product_ids': [(6, 0, [variant['id']])],
                 # a 'product.attribute.price' is created when we write


### PR DESCRIPTION
Current code breaks if two variants have the same price, now we've got a chance if the variants have different codes
