### PR TITLE
[FIX] drop old foreign key contraint

### DIFF
--- a/addons/hr_holidays/migrations/7.0.1.5/pre-migration.py
+++ b/addons/hr_holidays/migrations/7.0.1.5/pre-migration.py
@@ -31,3 +31,7 @@ column_renames = {
 @openupgrade.migrate()
 def migrate(cr, version):
     openupgrade.rename_columns(cr, column_renames)
+    # drop constraint with wrong name, will be recreated if applicable
+    cr.execute(
+        "ALTER TABLE hr_holidays DROP CONSTRAINT IF EXISTS "
+        "hr_holidays_case_id_fkey")


### PR DESCRIPTION
Leaving it will cause trouble in the 8.0 migration of `hr_holidays`
