### PR TITLE
[FIX] Recursive import between openupgrade and osv

### DIFF
--- a/openerp/openupgrade/openupgrade_loading.py
+++ b/openerp/openupgrade/openupgrade_loading.py
@@ -24,7 +24,7 @@ import logging
 from openerp import release
 from openerp.osv.orm import TransientModel
 from openerp.osv import fields
-from openerp.openupgrade.openupgrade import table_exists
+from openupgradelib.openupgrade_tools import table_exists
 from openerp.tools import config, safe_eval
 
 # A collection of functions used in


### PR DESCRIPTION
Trying to fix the documentation I encountered this recursive import again, which is exactly the reason that the table_exists function was isolated in its own module.
