### PR TITLE
[FIX] Module 'base' - pre-migration.py - create_users_partner()

### DIFF
--- a/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
@@ -128,6 +128,13 @@ CREATE TABLE ir_model_relation (
             "ALTER TABLE ir_act_client INHERIT ir_actions")
 
 
+def is_module_installed(cr, module):
+    cr.execute(
+        "SELECT id FROM ir_module_module "
+        "WHERE name=%s and state='installed'", (module,))
+    return bool(cr.fetchone())
+
+
 def create_users_partner(cr):
     """
     Users now have an inherits on res.partner.
@@ -173,14 +180,24 @@ def create_users_partner(cr):
         "WHERE module='base' and name='user_root'")
     user_root = cr.fetchone()
     user_root_id = user_root and user_root[0] or 0
+    warning_installed = is_module_installed(cr, 'warning')
     cr.execute(
         "SELECT id, name, active FROM res_users "
         "WHERE partner_id IS NULL")
-    for row in cr.fetchall():
-        cr.execute(
+    sql_insert_partner = (
+        "INSERT INTO res_partner "
+        "(name, active) "
+        "VALUES(%s,%s) RETURNING id")
+    if warning_installed:
+        sql_insert_partner = (
             "INSERT INTO res_partner "
-            "(name, active) "
-            "VALUES(%s,%s) RETURNING id", row[1:])
+            "(name, active,picking_warn,sale_warn,"
+            "invoice_warn,purchase_warn) "
+            "VALUES("
+            "%s,%s,'no-message','no-message','no-message','no-message') "
+            "RETURNING id")
+    for row in cr.fetchall():
+        cr.execute(sql_insert_partner, row[1:])
         partner_id = cr.fetchone()[0]
         cr.execute(
             "UPDATE res_users "

--- a/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
@@ -131,7 +131,7 @@ CREATE TABLE ir_model_relation (
 def is_module_installed(cr, module):
     cr.execute(
         "SELECT id FROM ir_module_module "
-        "WHERE name=%s and state='installed'", (module,))
+        "WHERE name=%s and state IN ('installed', 'to upgrade')", (module,))
     return bool(cr.fetchone())
 
 

--- a/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/pre-migration.py
@@ -128,13 +128,6 @@ CREATE TABLE ir_model_relation (
             "ALTER TABLE ir_act_client INHERIT ir_actions")
 
 
-def is_module_installed(cr, module):
-    cr.execute(
-        "SELECT id FROM ir_module_module "
-        "WHERE name=%s and state IN ('installed', 'to upgrade')", (module,))
-    return bool(cr.fetchone())
-
-
 def create_users_partner(cr):
     """
     Users now have an inherits on res.partner.
@@ -180,7 +173,7 @@ def create_users_partner(cr):
         "WHERE module='base' and name='user_root'")
     user_root = cr.fetchone()
     user_root_id = user_root and user_root[0] or 0
-    warning_installed = is_module_installed(cr, 'warning')
+    warning_installed = openupgrade.is_module_installed(cr, 'warning')
     cr.execute(
         "SELECT id, name, active FROM res_users "
         "WHERE partner_id IS NULL")


### PR DESCRIPTION
Change the INSERT INTO SQL query if the `warning` module is installed to satisfy required fields, fixing #369.

This is not the more robust way to do it for sure (don't know if there are other modules which add required fields on the `res_partner` table?), but as the `warning` module is a standard one, I think it's worth it.
