### PR TITLE
[FIX] mrp - Update the 'produce_delay' column on the 'product_template' table

### DIFF
--- a/addons/mrp/migrations/8.0.1.1/post-migrate.py
+++ b/addons/mrp/migrations/8.0.1.1/post-migrate.py
@@ -6,7 +6,7 @@ def move_fields(cr, pool):
     execute = openupgrade.logged_query
     queries = [
         """
-        UPDATE product_product
+        UPDATE product_template
         SET produce_delay = (
             SELECT pt.%s
             FROM product_template pt


### PR DESCRIPTION
The `post-migrate.py` script try to update the `produce_delay` column on `product_product`, but this last one is defined on the `product_template` table (see https://github.com/OCA/OpenUpgrade/blob/8.0/addons/mrp/product.py#L25).
The traceback:

``` python
2015-09-24 20:15:14,332 7351 INFO 70to80 openerp.modules.migration: module mrp: Running migration [8.0.1.1>] post-migrate
2015-09-24 20:15:14,332 7351 INFO 70to80 openerp.modules.migration: module mrp: Running migration [8.0.1.1>] post-migrate
2015-09-24 20:15:14,333 7351 INFO 70to80 OpenUpgrade: mrp: post-migration script called with version 7.0.1.1
2015-09-24 20:15:14,333 7351 WARNING 70to80 openerp.pooler: openerp.pooler.get_db_and_pool() is deprecated.
2015-09-24 20:15:14,342 7351 ERROR 70to80 openerp.sql_db: Programming error: column "produce_delay" of relation "product_product" does not exist
LINE 3:         SET produce_delay = (
                    ^
, in query 
        UPDATE product_product
        SET produce_delay = (
            SELECT pt.openupgrade_legacy_8_0_produce_delay
            FROM product_template pt
            WHERE pt.id = product_product.product_tmpl_id)

2015-09-24 20:15:14,342 7351 ERROR 70to80 OpenUpgrade: mrp: error in migration script /home/openerp/oerp/server/addons/mrp/migrations/8.0.1.1/post-migrate.py: column "produce_delay" of relation "product_product" does not exist
LINE 3:         SET produce_delay = (
```
