### PR TITLE
[FIX] Set l10n_be_intrastat to uninstallable, as it depends on l10n_be

### DIFF
--- a/addons/l10n_be/__openerp__.py
+++ b/addons/l10n_be/__openerp__.py
@@ -81,7 +81,7 @@ Wizards provided by this module:
         'views/report_vatpartnerlisting.xml',
     ],
     'demo': [],
-    'installable': False,
+    'installable': True,
     'website': 'https://www.odoo.com/page/accounting',
 }
 

--- a/addons/l10n_be_hr_payroll_account/__openerp__.py
+++ b/addons/l10n_be_hr_payroll_account/__openerp__.py
@@ -37,7 +37,7 @@ Accounting Data for Belgian Payroll Rules.
         'l10n_be_hr_payroll_account_data.xml',
         'data/hr.salary.rule.csv',
     ],
-    'installable': False
+    'installable': True,
 }
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/addons/l10n_be_intrastat/__openerp__.py
+++ b/addons/l10n_be_intrastat/__openerp__.py
@@ -39,5 +39,5 @@ Based on invoices.
         'l10n_be_intrastat.xml',
         'wizard/l10n_be_intrastat_xml_view.xml',
     ],
-    'installable': True,
+    'installable': False,
 }

--- a/addons/l10n_be_intrastat/__openerp__.py
+++ b/addons/l10n_be_intrastat/__openerp__.py
@@ -39,5 +39,5 @@ Based on invoices.
         'l10n_be_intrastat.xml',
         'wizard/l10n_be_intrastat_xml_view.xml',
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/openerp/addons/openupgrade_records/__init__.py
+++ b/openerp/addons/openupgrade_records/__init__.py
@@ -1,1 +1,2 @@
-import model
+from . import model
+from . import blacklist

--- a/openerp/addons/openupgrade_records/blacklist.py
+++ b/openerp/addons/openupgrade_records/blacklist.py
@@ -1,0 +1,15 @@
+BLACKLIST_MODULES = [
+    # l10n_be cannot be reinstalled as the module's yaml data installs
+    # the chart of accounts at installation time, and the other modules
+    # depend on this module and the chart installation itself.
+    'l10n_be',
+    'l10n_be_intrastat',
+    'l10n_be_hr_payroll_account',
+    # the hw_* modules are not affected by a migration as they don't
+    # contain any ORM functionality, but they do start up threads that
+    # delay the process and spit out annoying log messages continously.
+    'hw_escpos',
+    'hw_proxy',
+    'hw_scale',
+    'hw_scanner',
+]

--- a/openerp/addons/openupgrade_records/model/install_all_wizard.py
+++ b/openerp/addons/openupgrade_records/model/install_all_wizard.py
@@ -28,10 +28,12 @@ try:
     from openerp.osv.orm import TransientModel
     from openerp.osv import fields
     from openerp import pooler
+    from openerp.addons.openupgrade_records.blacklist import BLACKLIST_MODULES
 except ImportError:
     from osv.osv import osv_memory as TransientModel
     from osv import fields
     import pooler
+    from openupgrade_records.blacklist import BLACKLIST_MODULES
 
 
 class install_all_wizard(TransientModel):
@@ -66,22 +68,6 @@ class install_all_wizard(TransientModel):
             {'to_install': module_ids and len(module_ids) or False}
             )
         return res
-
-    BLACKLIST_MODULES = [
-        # l10n_be cannot be reinstalled as the module's yaml data installs
-        # the chart of accounts at installation time, and the other modules
-        # depend on this module and the chart installation itself.
-        'l10n_be',
-        'l10n_be_intrastat',
-        'l10n_be_hr_payroll_account',
-        # the hw_* modules are not affected by a migration as they don't
-        # contain any ORM functionality, but they do start up threads that
-        # delay the process and spit out annoying log messages continously.
-        'hw_escpos',
-        'hw_proxy',
-        'hw_scale',
-        'hw_scanner',
-    ]
 
     def quirk_fiscalyear(self, cr, uid, ids, context=None):
         """
@@ -130,7 +116,7 @@ class install_all_wizard(TransientModel):
                 ('state', 'not in',
                  ['installed', 'uninstallable', 'unknown']),
                 ('category_id.name', '!=', 'Tests'),
-                ('name', 'not in', self.BLACKLIST_MODULES),
+                ('name', 'not in', BLACKLIST_MODULES),
                 ], context=context)
         if module_ids:
             module_obj.write(


### PR DESCRIPTION
which itself is set to uninstallable in OpenUpgrade because it messes
up the analysis.
This module was added after the last 8.0 analysis and it now makes the
analysis fail when comparing with 9.0
