### PR TITLE
[FIX] Correct renamed module names for bank-statement-import repository.

### DIFF
--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -13,9 +13,13 @@ renamed_modules = {
     'audittrail': 'auditlog',
     # OCA/bank-statement-import
     'account_banking': 'account_bank_statement_import',
-    'account_banking_camt': 'bank_statement_parse_camt',
-    'account_banking_nl_ing_mt940': 'bank_statement_parse_nl_ing_mt940',
-    'account_banking_nl_rabo_mt940': 'bank_statement_parse_nl_rabo_mt940',
+    'account_banking_camt': 'account_bank_statement_import_camt',
+    'account_banking_mt940':
+        'account_bank_statement_import_mt940_base',
+    'account_banking_nl_ing_mt940':
+        'account_bank_statement_import_mt940_nl_ing',
+    'account_banking_nl_rabo_mt940':
+        'account_bank_statement_import_mt940_nl_rabo',
 }
 
 renamed_models = {


### PR DESCRIPTION
Module names in bank-statement-import repository were changed some month's ago to be more consistent. This PR changes the module names to correctly rename the 7.0 versions to the 8.0 ones.
