### PR TITLE
[ADD] have migrate.py download its own copy of openupgradelib

### DIFF
--- a/openerp/openupgrade/doc/source/migrate.py.rst
+++ b/openerp/openupgrade/doc/source/migrate.py.rst
@@ -12,9 +12,7 @@ OpenUpgrade server.
 Download it from github_.
 
 The script assumes that all python libraries that are required by Odoo are
-installed in the current environment. Note that you need OpenUpgrade's
-additional dependency `openupgradelib
-<https://pypi.python.org/pypi/openupgradelib>`_.
+installed in the current environment.
 
 The script accepts a couple of parameters, the mandatory ones are
 

--- a/scripts/migrate.py
+++ b/scripts/migrate.py
@@ -322,6 +322,20 @@ for version in options.migrations.split(','):
             else:
                 raise Exception('Unknown type %s' % addon_config_type)
 
+openupgradelib = os.path.join(options.branch_dir, 'openupgradelib')
+if os.path.exists(openupgradelib):
+    os.system('cd %(location)s; git pull origin master' % {
+        'location': openupgradelib,
+        })
+else:
+    os.system(
+        'git clone --single-branch --depth=1 %(url)s %(target)s' % {
+            'url': 'https://github.com/OCA/openupgradelib',
+            'target': openupgradelib,
+            })
+os.environ['PYTHONPATH'] = ':'.join([
+    openupgradelib, os.environ.get('PYTHONPATH')])
+
 db_name = conn_parms['database']
 if not options.inplace:
     db_name = copy_database(conn_parms)


### PR DESCRIPTION
This is more in line with the script fetching everything specific to openupgrade
