### PR TITLE
[FIX] Cannot reinstall sale_timesheet and project modules

### DIFF
--- a/addons/project/project_data.xml
+++ b/addons/project/project_data.xml
@@ -23,14 +23,18 @@
 
 
         <!-- sale_timesheet and project define the same field without depending on each, which causes the field to be deleted when the module that created it
-        is deleted. To avoid this, we create xmlids manually for this field in both modules to prevent accidental deletion. To fix in saas-7 by moving the field definition-->
-        <record id="duplicate_field_xmlid" model="ir.model.data">
+        is deleted. To avoid this, we create xmlids manually for this field in both modules to prevent accidental deletion. To fix in saas-7 by moving the field definition
+
+        OpenUpgrade: this breaks reinstallation of the module at analysis time, so it is disabled.
+        Maybe inject this XML ID from the migration scripts.
+        -->
+        <!-- record id="duplicate_field_xmlid" model="ir.model.data">
             <field name="res_id" search="[('model','=','res.company'),('name','=','project_time_mode_id')]" model="ir.model.fields"/>
             <field name="model">ir.model.fields</field>
             <field name="module">project</field>
             <field name="name">project_time_mode_id_duplicate_xmlid</field>
             <field name="noupdate">True</field>
-        </record>
+        </record -->
 
     </data>
     <data>

--- a/addons/purchase/migrations/9.0.1.2/pre-create-properties.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-create-properties.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+# This migration script is part of the Odoo distribution, and is not Flake8
+# compliant.
+# flake8: noqa
 
 def convert_field(cr, model, field, target_model):
     table = model.replace('.', '_')

--- a/addons/sale_timesheet/data/sale_timesheet_data.xml
+++ b/addons/sale_timesheet/data/sale_timesheet_data.xml
@@ -3,14 +3,18 @@
     <data noupdate="1">
 
         <!-- sale_timesheet and project define the same field without depending on each, which causes the field to be deleted when the module that created it
-        is deleted. To avoid this, we create xmlids manually for this field in both modules to prevent accidental deletion. To fix in saas-7 by moving the field definition-->
-        <record id="duplicate_field_xmlid" model="ir.model.data">
+        is deleted. To avoid this, we create xmlids manually for this field in both modules to prevent accidental deletion. To fix in saas-7 by moving the field definition
+
+        OpenUpgrade: this breaks reinstallation of the module at analysis time, so it is disabled.
+        Maybe inject this XML ID from the migration scripts.
+        -->
+        <!-- record id="duplicate_field_xmlid" model="ir.model.data">
             <field name="res_id" search="[('model','=','res.company'),('name','=','project_time_mode_id')]" model="ir.model.fields"/>
             <field name="model">ir.model.fields</field>
             <field name="module">sale_timesheet</field>
             <field name="name">project_time_mode_id_duplicate_xmlid</field>
             <field name="noupdate">True</field>
-        </record>
+        </record -->
     </data>
 
 </odoo>


### PR DESCRIPTION
After a merge of upstream Odoo into OpenUpgrade 9.0, two modules could not be reinstalled anyore (reinstallation essential for the analysis process). It concerns a hack that creates XML ids for the same field that is present in two independent modules. This shared ownership of the data prevents the dropping of the column after deinstallation of the module that was installed first.

The hack consist of an XML record that forces the creation of the XML id in each module. As it is executed at installation time, and each XML id (module + name) is supposed to be unique, upon reinstallation the server crashes on uniqueness constraints in the ir_model_data table. This change disables the forced creation of the XML ids upon installation.

To prevent the original problem, the dropping of the column, the XML ids need to be added in the migration scripts of each module. That is something that this change does not yet implement though.
