### PR TITLE
[FIX] - setup_models missing commit()

### DIFF
--- a/openerp/openupgrade/openupgrade_loading_90.py
+++ b/openerp/openupgrade/openupgrade_loading_90.py
@@ -52,3 +52,5 @@ def migrate_model_tables(cr):
         cr.execute("""ALTER TABLE ir_model_constraint
                       ADD COLUMN definition varchar
                       """)
+
+        cr.commit()


### PR DESCRIPTION
Cannot put the fix in `__init__` for some reason. Maybe cr is in a different DB for setup_models().
