### PR TITLE
Stock quants' history_ids is not generated in a correct manner

### DIFF
--- a/addons/stock/migrations/8.0.1.1/post-migration.py
+++ b/addons/stock/migrations/8.0.1.1/post-migration.py
@@ -686,7 +686,7 @@ def migrate_stock_qty(cr, registry):
     sql = '''
         UPDATE stock_move SET restrict_lot_id = {}
     '''.format(openupgrade.get_legacy_name('prodlot_id'))
-    openupgrade.logged_query(cr,sql)
+    openupgrade.logged_query(cr, sql)
 
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})

--- a/addons/stock/migrations/8.0.1.1/post-migration.py
+++ b/addons/stock/migrations/8.0.1.1/post-migration.py
@@ -214,8 +214,6 @@ def migrate_stock_picking(cr, registry):
         ADD COLUMN %s INTEGER
         """ % openupgrade.get_legacy_name('move_id'))
     # Recreate stock.pack.operation (only for moves that belongs to a picking)
-    stock_move_obj = registry['stock.move']
-    done_move_ids = stock_move_obj.search(cr, uid, [('state', '=', 'done')])
     if not done_move_ids:
         return
     openupgrade.logged_query(
@@ -229,11 +227,11 @@ def migrate_stock_picking(cr, registry):
             product_uom_qty, %s, date, location_id, location_dest_id, 'true'
         FROM stock_move
         WHERE
-            id IN %%s
+            state = 'done'
             AND picking_id IS NOT NULL
         """ % (openupgrade.get_legacy_name('move_id'),
-               openupgrade.get_legacy_name('prodlot_id')),
-        (tuple(done_move_ids), ))
+               openupgrade.get_legacy_name('prodlot_id')), )
+
     # And link it with moves creating stock.move.operation.link records
     openupgrade.logged_query(
         cr,

--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -2437,7 +2437,7 @@ class stock_move(osv.osv):
                 # Handle pack in pack
                 if not ops.product_id and ops.package_id and ops.result_package_id.id != ops.package_id.parent_id.id:
                     self.pool.get('stock.quant.package').write(cr, SUPERUSER_ID, [ops.package_id.id], {'parent_id': ops.result_package_id.id}, context=context)
-                if not move_qty.get(move.id):
+                if move_qty.get(move.id) is None:
                     raise osv.except_osv(_("Error"), _("The roundings of your Unit of Measures %s on the move vs. %s on the product don't allow to do these operations or you are not transferring the picking at once. ") % (move.product_uom.name, move.product_id.uom_id.name))
                 move_qty[move.id] -= record.qty
         #Check for remaining qtys and unreserve/check move_dest_id in


### PR DESCRIPTION
In Odoo 7 and earlier Serial Number Traceability is assured trough the direct relation `stock.production.lot` -> `stock.move`s. In Odoo 8 the relation is more complex - `stock.production.lot` -> `stock.quant` -> `stock.move`s. The last one is pointed by the `stock.quant`'s field `history_ids`.

Technically speaking - in Odoo 7 there is a many2one relation between stock_move and stock_production_lot. In Odoo 8 there is a many2one relation between `stock.quant` and `stock.production.lot` and one2many relation between `stock.quant' and`stock.move`

With the base migration scripts I have the following problem. 

Before the migration: 

```
Production Lot 1 -> Stock Move A
Production Lot 1 -> Stock Move B
Production Lot 2 -> Stock Move C
Production Lot 2 -> Stock Move D
```

After the migration these relations are wrong. Could be something like that:

```
Production Lot 1 -> Stock Quant A -> Stock Moves A & M
Production Lot 2 -> Stock Quant B -> Stock Moves C & N
```

I fixed this problem setting the stock_move's field `restrict_lot_id` before the process of quants creation.

Additionally you'll find an optimisation of the sql query in the method `migrate_stock_picking(cr, registry)` of the `post-migration.py` script
