### PR TITLE
[FIX] Calendar: Disable temporarily violated unique constraint during…

### DIFF
--- a/addons/calendar/migrations/8.0.1.0/post-migration.py
+++ b/addons/calendar/migrations/8.0.1.0/post-migration.py
@@ -79,6 +79,12 @@ def import_crm_meeting(cr):
     cr.execute(
         '''alter table meeting_category_rel
         drop constraint meeting_category_rel_event_id_fkey''')
+    # we need to disable this constraint temporarily because some new event_id
+    # might collide during the update with the old event_id of another row
+    # to be updated yet
+    cr.execute(
+        '''alter table meeting_category_rel
+        drop constraint meeting_category_rel_event_id_type_id_key''')
     cr.execute(
         '''update meeting_category_rel
         set event_id=calendar_event.id
@@ -86,6 +92,11 @@ def import_crm_meeting(cr):
             openupgrade.get_legacy_name('crm_meeting_id'),
         )
     )
+    # restore the disabled unique constraint
+    cr.execute(
+        '''alter table meeting_category_rel
+        add constraint meeting_category_rel_event_id_type_id_key
+        UNIQUE(event_id, type_id)''')
     # recreate the constraint as odoo would do it
     cr.execute(
         '''alter table meeting_category_rel


### PR DESCRIPTION
… update of meeting_category_rel

Fixes #215 

The unique constraint has to be broken mid-update when the new event_id (pointing to events) is the same than the old event_id (pointing to meetings) of a row to be updated yet. The fix disables temporarily that contraint
