### PR TITLE
[ADD] also product uom's decimal precision was renamed

### DIFF
--- a/addons/product/migrations/7.0.1.1/data.xml
+++ b/addons/product/migrations/7.0.1.1/data.xml
@@ -6,5 +6,8 @@
         <record id="decimal_price" model="decimal.precision">
             <field name="name">Product Price</field>
         </record>
+        <record id="decimal_product_uom" model="decimal.precision">
+            <field name="name">Product Unit of Measure</field>
+        </record>
     </data>
 </openerp>


### PR DESCRIPTION
Especially with this dp, we run into problems without this, as it is used in bom lines' product_qty which have a constraint that enforces product_qty > 0. Without this, we get the default precision (2 digits), which breaks if we have smaller values as they will be cast to 0.

Relevant code:
https://github.com/odoo/odoo/blob/6.1/addons/product/product_data.xml#L163
https://github.com/odoo/odoo/blob/7.0/addons/product/product_data.xml#L51
