### PR TITLE
[FIX] don't choke if we have custom states and there are no records with state picking_except

### DIFF
--- a/addons/mrp/migrations/8.0.1.1/pre-migration.py
+++ b/addons/mrp/migrations/8.0.1.1/pre-migration.py
@@ -52,24 +52,12 @@ def check_production_state(cr):
     """Check if a record with a state that is no longer supported
     (picking_except) exists in mrp_production and adjust it (to draft).
     """
-    if openupgrade.check_values_selection_field(
-            cr, 'mrp_production', 'state',
-            ['cancel', 'confirmed', 'done', 'draft', 'in_production',
-             'ready']):
-        # if selection value doesn't exist, perform nothing
-        return
     # Set picking_except to draft
-    sql = """
-        SELECT id
-        FROM mrp_production
-        WHERE state = 'picking_except'"""
-    cr.execute(sql)
-    prod_ids = tuple([x for x, in tuple(cr.fetchall())])
     sql = """
         UPDATE mrp_production
         SET state = 'draft'
-        WHERE id in %s"""
-    openupgrade.logged_query(cr, sql, (tuple(prod_ids), ))
+        WHERE state = 'picking_except'"""
+    openupgrade.logged_query(cr, sql)
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
In this case, production orders have a custom state added, so `check_values_selection_field` fails, and given there are no production orders in state `picking_except`, migration fails on the update call.

I think it's not a good idea anyways to check for all known states, so I propose to remove the call to `check_values_selection_field` altogether and only check if we have ids.

Then what should be changed independently from accepting the above or not is copying the id list to a tuple several times.
