### PR TITLE
[FIX] calendar: Don't halt on non existant constraint

### DIFF
--- a/addons/calendar/migrations/8.0.1.0/post-migration.py
+++ b/addons/calendar/migrations/8.0.1.0/post-migration.py
@@ -78,13 +78,13 @@ def import_crm_meeting(cr):
     # the values we update now caused the new constrained to be invalid
     cr.execute(
         '''alter table meeting_category_rel
-        drop constraint meeting_category_rel_event_id_fkey''')
+        drop constraint if exists meeting_category_rel_event_id_fkey''')
     # we need to disable this constraint temporarily because some new event_id
     # might collide during the update with the old event_id of another row
     # to be updated yet
     cr.execute(
         '''alter table meeting_category_rel
-        drop constraint meeting_category_rel_event_id_type_id_key''')
+        drop constraint if exists meeting_category_rel_event_id_type_id_key''')
     cr.execute(
         '''update meeting_category_rel
         set event_id=calendar_event.id


### PR DESCRIPTION
There can be occasions where the constraint doesn't exist, so with this, we prevent the hang on this error.
