### PR TITLE
[7.0][FIX] Rate for ZRZ violates decimal range for its field

### DIFF
--- a/openerp/addons/base/currency_data.xml
+++ b/openerp/addons/base/currency_data.xml
@@ -1413,11 +1413,6 @@
             <field name="rounding">0.01</field>
             <field name="accuracy">4</field>
         </record>
-        <record id="rateZRZ" model="res.currency.rate">
-            <field name="currency_id" ref="ZRZ" />
-            <field eval="time.strftime('%Y-01-01')" name="name"/>
-            <field name="rate">1148948.76</field>
-        </record>
         
         <record id="MZN" model="res.currency">
             <field name="name">MZN</field>


### PR DESCRIPTION
Same issue as https://github.com/odoo/odoo/pull/11383 (value of rate violates data model), affects upgrades for databases that do not have this record in ir.model.data.
