### PR TITLE
[7.0][FIX] Was a reference to the wrong field

### DIFF
--- a/addons/poweremail/migrations/7.0.99.0/post-migration.py
+++ b/addons/poweremail/migrations/7.0.99.0/post-migration.py
@@ -68,10 +68,10 @@ def migrate_templates(cr, pool):
             'body_html': row[3] if row[3] else plaintext2html(row[1] or '')
             }
 
-        if row[11]:
+        if row[12]:
             cr.execute(
                 "SELECT name, email_id FROM poweremail_core_accounts "
-                "WHERE id = %s", (row[11],))
+                "WHERE id = %s", (row[12],))
             vals['email_from'] = "%s <%s>" % cr.fetchone()
 
         template_id = pool['email.template'].create(


### PR DESCRIPTION
There is a typo in the poweremail migration which fails the migration with a type mismatch.
