### PR TITLE
[FIX] Remove deprecated zsi.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,6 @@ setuptools.setup(
           'vobject',
           'werkzeug',
           'xlwt',
-          'zsi',
       ],
       extras_require = {
           'SSL' : ['pyopenssl'],


### PR DESCRIPTION
Also remove import_sugarcrm, the one module that was using zsi.

zsi requires (for no reason by the way) PyXML, that no longer installs on
up to date debian/ubuntu, at least not in virtualenv. Anyway PyXML is quickly removed from distributions.

The removal of import_sugarcrm is no problem for migration, because the module does not exist in 7.0 any longer anyway.
