### PR TITLE
[FIX] Prevent transaction lockups

### DIFF
--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -121,6 +121,7 @@ def load_module_graph(cr, graph, status=None, perform_checks=True, skip_modules=
     cr.commit = lambda *args: None
     cr.rollback_org = cr.rollback
     cr.rollback = lambda *args: None
+    openerp.osv.fields.set_migration_cursor(cr)
 
     # register, instantiate and initialize models for each modules
     t0 = time.time()
@@ -236,6 +237,7 @@ def load_module_graph(cr, graph, status=None, perform_checks=True, skip_modules=
 
     cr.commit = cr.commit_org
     cr.commit()
+    openerp.osv.fields.set_migration_cursor()
 
     return loaded_modules, processed_modules
 


### PR DESCRIPTION
... when Odoo tries to figure out about a  specific decimal precision
after these have been written when loading module
data (product module). These lockups occur because OpenUpgrade does not
commit after loading this data, and Odoo uses a separate cursor (most likely
from another connection cq. transaction) to query the precision when views
are validated. The solution is to use the migration cursor instead.

Fixes #433
