### PR TITLE
[FIX] Add fix to prevent created xml_id's from being deleted afterwards.

### DIFF
--- a/addons/stock/migrations/8.0.1.1/post-migration.py
+++ b/addons/stock/migrations/8.0.1.1/post-migration.py
@@ -510,6 +510,9 @@ def _migrate_stock_warehouse(cr, registry, res_id):
                     "xml_id %s now points to res_id %d, no longer to %d.",
                     xml_id, res_id, old_res_id
                 )
+        # Avoid the xml id and the associated resource being dropped by the
+        # orm by manually making a hit on it:
+        model_data_obj._update_dummy('stock.picking.type', 'stock', xml_id)
 
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})


### PR DESCRIPTION
After the PR to add missing xml_id's it became clear we needed one additional step to prevent the created data from being thrown away at the end of the update process.
