### PR TITLE
7.0 fix partner performance

### DIFF
--- a/openerp/addons/base/__init__.py
+++ b/openerp/addons/base/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 ##############################################################################
-#    
+#
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2004-2009 Tiny SPRL (<http://tiny.be>).
 #
@@ -15,7 +15,7 @@
 #    GNU Affero General Public License for more details.
 #
 #    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.     
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 ##############################################################################
 
@@ -24,6 +24,3 @@ import module
 import res
 import report
 import test
-
-# vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:
-

--- a/openerp/addons/base/migrations/7.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/post-migration.py
@@ -334,6 +334,19 @@ This can be the case if an additional module installed on your database changes
         _insert_partners(cr, pool, partner_store_insert)
         _update_partners(cr, pool, partner_store_update)
 
+        # Update propagate_fields from partner parent
+        # TODO Use propagate_fields = [ 'lang', 'tz', 'customer', 'supplier',]
+        # to generate this query
+        openupgrade.logged_query(
+            cr, "\n"
+            "UPDATE res_partner part "
+            "SET lang = parent.lang, "
+            "tz = parent.tz,"
+            "customer = parent.customer,"
+            "supplier = parent.supplier"
+            "FROM res_partner parent "
+            "WHERE part.parent_id = parent.id"
+            " AND part.parent_id IS NOT NULL")
         # set_address_partner by mass update
         openupgrade.logged_query(
             cr, "\n"

--- a/openerp/addons/base/migrations/7.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/post-migration.py
@@ -346,7 +346,8 @@ This can be the case if an additional module installed on your database changes
             "supplier = parent.supplier "
             "FROM res_partner parent "
             "WHERE part.parent_id = parent.id "
-            " AND part.parent_id IS NOT NULL")
+            " AND part.parent_id IS NOT NULL"
+            " AND part.openupgrade_7_migrated_from_address_id IS NOT NULL")
         # set_address_partner by mass update
         openupgrade.logged_query(
             cr, "\n"

--- a/openerp/addons/base/migrations/7.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/post-migration.py
@@ -202,7 +202,7 @@ def migrate_partner_address(cr, pool):
         "ALTER TABLE res_partner_address "
         "ADD column openupgrade_7_address_processed "
         " BOOLEAN")
-    #To fix bug where category_id is not yet created after module update 
+    # To fix bug where category_id is not yet created after module update
     cr.execute(
         "ALTER TABLE res_partner "
         "ADD column category_id "
@@ -212,9 +212,9 @@ def migrate_partner_address(cr, pool):
         'mobile', 'phone', 'state_id', 'street', 'street2', 'type', 'zip',
         'partner_id', 'name', 'company_id'
     ]
-    propagate_fields = [
-        'lang', 'tz', 'customer', 'supplier',
-    ]
+    # propagate_fields = [
+    #     'lang', 'tz', 'customer', 'supplier',
+    # ]
     partner_found = []
     processed_ids = []
 

--- a/openerp/addons/base/migrations/7.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/post-migration.py
@@ -341,11 +341,11 @@ This can be the case if an additional module installed on your database changes
             cr, "\n"
             "UPDATE res_partner part "
             "SET lang = parent.lang, "
-            "tz = parent.tz,"
-            "customer = parent.customer,"
-            "supplier = parent.supplier"
+            "tz = parent.tz, "
+            "customer = parent.customer, "
+            "supplier = parent.supplier "
             "FROM res_partner parent "
-            "WHERE part.parent_id = parent.id"
+            "WHERE part.parent_id = parent.id "
             " AND part.parent_id IS NOT NULL")
         # set_address_partner by mass update
         openupgrade.logged_query(


### PR DESCRIPTION
Fix partner migration performance by bypassing ORM method and doing mass data update and insert.
This modification allows me to pass migration time of partners from ~ 4.5 hours to 15 mn (about 116000 partner).
