### PR TITLE
[ADD] create location path with company if possible

### DIFF
--- a/addons/stock/migrations/8.0.1.1/post-migration.py
+++ b/addons/stock/migrations/8.0.1.1/post-migration.py
@@ -158,6 +158,8 @@ def migrate_stock_location(cr, registry):
             vals['picking_type_id'] = warehouse.out_type_id.id
         else:
             vals['picking_type_id'] = warehouse.int_type_id.id
+        if warehouse and warehouse[0].company_id:
+            vals['company_id'] = warehouse[0].company_id.id
         path_obj.create(cr, uid, vals)
 
 


### PR DESCRIPTION
The issue here is that actually, all paths should have a company id, because we call `action_done` on the moves later (https://github.com/hbrunn/OpenUpgrade/blob/70d6603cd055f4e5a468f9441e57e77c5b149181/addons/stock/migrations/8.0.1.1/post-migration.py#L748),  which calls `action_confirm` (https://github.com/OCA/OCB/blob/8.0/addons/stock/stock.py#L2431), which calls `_push_apply` (https://github.com/OCA/OCB/blob/8.0/addons/stock/stock.py#L2270) which will finally copy the move (https://github.com/OCA/OCB/blob/8.0/addons/stock/stock.py#L3855) with new values, where the company id comes from the path: https://github.com/OCA/OCB/blob/8.0/addons/stock/stock.py#L3830

This then breaks without `company_id` because it's required: https://github.com/OCA/OCB/blob/8.0/addons/stock/stock.py#L1816
