### PR TITLE
[FIX] don't pull openupgradelib in graph.py

### DIFF
--- a/openerp/modules/graph.py
+++ b/openerp/modules/graph.py
@@ -18,7 +18,6 @@ from openerp.tools.translate import _
 
 import zipfile
 import openerp.release as release
-from openupgradelib import openupgrade
 
 import re
 import base64
@@ -68,7 +67,7 @@ class Graph(dict):
         if ('base' in self and additional_data['base']['dbdemo'] and
                 additional_data['base']['installed_version'] <
                 release.major_version):
-            openupgrade.logged_query(cr, "UPDATE ir_module_module SET demo = false")
+            cr.execute("UPDATE ir_module_module SET demo = false")
             for data in additional_data.values():
                 data['dbdemo'] = False
 


### PR DESCRIPTION
the problem with this is that with it, we need to import openerp before we can import something from openupgradelib. This happens to go right when running the server, but not for example when building the documentation.
