### PR TITLE
Rename addon account_refund_original to account_invoice_refund_link

### DIFF
--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -17,6 +17,8 @@ renamed_modules = {
     'runbot_secure': 'runbot_relative',
     # not exactly a module rename, but they do the same
     'account_check_writing': 'account_check_printing',
+    # OCA/account-invoicing
+    'account_refund_original': 'account_invoice_refund_link',
 }
 
 renamed_models = {


### PR DESCRIPTION
account_refund_original comes from OCA/l10n-spain in v8 and changes its name and repo
Depends on https://github.com/OCA/account-invoicing/pull/172
