### PR TITLE
[FIX] Set is_timesheet on analytic lines

### DIFF
--- a/addons/hr_timesheet/migrations/9.0.1.0/post-migration.py
+++ b/addons/hr_timesheet/migrations/9.0.1.0/post-migration.py
@@ -2,6 +2,7 @@
 # © 2015 Eficent Business and IT Consulting Services S.L. -
 # Jordi Ballester Alomar
 # © 2015 Serpent Consulting Services Pvt. Ltd. - Darshan Patel
+# © 2016 Opener B.V. - Stefan Rijnhart
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
@@ -12,10 +13,11 @@ def set_timesheet(cr):
     # Set is_timesheet account.analytic.line value from use_timesheets of
     # account.analytic.account
     cr.execute("""
-        UPDATE account_analytic_line l
-        SET is_timesheet = a.use_timesheets
-        FROM account_analytic_account a
-        WHERE a.id = l.account_id""")
+        UPDATE account_analytic_line aal
+        SET is_timesheet = TRUE
+        FROM hr_analytic_timesheet hat
+        WHERE hat.line_id = aal.id
+    """)
 
 
 @openupgrade.migrate()

--- a/addons/hr_timesheet/migrations/9.0.1.0/tests/test_hr_timesheet.py
+++ b/addons/hr_timesheet/migrations/9.0.1.0/tests/test_hr_timesheet.py
@@ -1,0 +1,11 @@
+# coding: utf-8
+from openerp.tests.common import TransactionCase
+
+
+class TestHrTimesheet(TransactionCase):
+    def test_hr_timesheet(self):
+        self.env.cr.execute(
+            "SELECT line_id FROM hr_analytic_timesheet LIMIT 1")
+        line_id, = self.env.cr.fetchone()
+        line = self.env['account.analytic.line'].browse(line_id)
+        self.assertTrue(line.is_timesheet)


### PR DESCRIPTION
Setting the is_timesheet marker only for analytic lines that were linked to an actual timesheet line in 8.0. The previous solution would assign the marker to all analytic lines for any project that uses timesheets, but that setting 'use_timesheet' on analytic accounts does not preclude that other analytic lines are present.
