### PR TITLE
[IMP] don't delete the xmlid of an undeletable record

### DIFF
--- a/addons/analytic/migrations/9.0.1.1/tests/test_analytic.py
+++ b/addons/analytic/migrations/9.0.1.1/tests/test_analytic.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# © 2016 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.tests.common import TransactionCase
+
+
+class TestAnalytic(TransactionCase):
+    def test_analytic(self):
+        self.assertTrue(
+            all(
+                self.env['ir.ui.view'].search([
+                    ('model', '=', 'account.analytic.line'),
+                ]).mapped('xml_id')
+            )
+        )

--- a/openerp/addons/base/ir/ir_model.py
+++ b/openerp/addons/base/ir/ir_model.py
@@ -1217,6 +1217,7 @@ class ir_model_data(osv.osv):
         to_unlink = []
         ids.sort()
         ids.reverse()
+        id_by_data = {}
         for data in self.browse(cr, uid, ids, context):
             model = data.model
             res_id = data.res_id
@@ -1224,6 +1225,7 @@ class ir_model_data(osv.osv):
             pair_to_unlink = (model, res_id)
             if pair_to_unlink not in to_unlink:
                 to_unlink.append(pair_to_unlink)
+                id_by_data[pair_to_unlink] = data['id']
 
             if model == 'workflow.activity':
                 # Special treatment for workflow activities: temporarily revert their
@@ -1268,6 +1270,7 @@ class ir_model_data(osv.osv):
                     self.pool[model].unlink(cr, uid, [res_id], context=context)
                 except Exception:
                     _logger.info('Unable to delete %s@%s', res_id, model, exc_info=True)
+                    ids.remove(id_by_data[(model, res_id)])
                     cr.execute('ROLLBACK TO SAVEPOINT record_unlink_save')
                 else:
                     cr.execute('RELEASE SAVEPOINT record_unlink_save')


### PR DESCRIPTION
This is a demo to see if the strategy mentioned in #577 actually works

Marked as invalid because we should get something like this via a merge with upstream. Keep until either this is merged in upstream or we decide to use this anyways.
