### PR TITLE
[FIX][9.0] Admin user should access technical features

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/noupdate_changes.xml
+++ b/openerp/addons/base/migrations/9.0.1.3/noupdate_changes.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8'?>
+<openerp>
+    <data>
+        <record model="res.groups" id="group_user">
+            <field name="implied_ids" eval="[(4, ref('group_no_one'))]"/>
+        </record>
+    </data>
+</openerp>

--- a/openerp/addons/base/migrations/9.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/post-migration.py
@@ -121,3 +121,4 @@ def migrate(cr, version):
     set_filter_active(cr)
     precalculate_checksum(cr)
     remove_obsolete_modules(cr, ('web_gantt', 'web_graph', 'web_tests'))
+    openupgrade.load_data(cr, 'base', 'migrations/9.0.1.3/noupdate_changes.xml')


### PR DESCRIPTION
Fixes the error by which the admin user is not assigned by default to group "Technical features".
Seems that during the upgrade the changes to XMLID 'group_user' of model 'res.group' (https://github.com/odoo/odoo/blob/9.0/openerp/addons/base/security/base_security.xml#L45) were not updated, even when these records are not supposed to be "noupdate=True".

So, we treat them as if they were noupdate=True.

Perhaps this only occurs with "implied_ids"?¿ Not sure. Anyway this quick and dirty solution works.
