### PR TITLE
[IMP] resolves conflict when an account.tax records exists with type …

### DIFF
--- a/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
@@ -467,8 +467,12 @@ account      / account.tax              / tag_ids (many2many)           : NEW re
 account      / account.tax              / tax_code_id (many2one)        : DEL relation: account.tax.code
 account      / account.tax              / tax_group_id (many2one)       : NEW relation: account.tax.group, required: required, req_default: function
 account      / account.tax              / tax_sign (float)              : DEL 
-account      / account.tax              / type (selection)              : selection_keys is now '['division', 'fixed', 'group', 'percent']' ('['balance', 'code', 'fixed', 'none', 'percent']')
 account      / account.tax              / type (selection)              : was renamed to amount_type [nothing to to]
+
+account      / account.tax              / type (selection)              : selection_keys is now '['division', 'fixed', 'group', 'percent']' ('['balance', 'code', 'fixed', 'none', 'percent']')
+# Done: pre-migration: If the selection was 'code', rename to 'group' and install 'account_tax_python'
+# Done: post-migration: If the selection was 'code', rename again from 'group' to 'code'
+
 
 # Post migration script: In v8, if child_depend == True, then in v9, amount_type='group'
 # done in post-migration script

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -320,6 +320,34 @@ def account_partial_reconcile(env):
     models.BaseModel.step_workflow = set_workflow_org
 
 
+def map_account_tax_type(cr):
+    """ See comments in method map_account_tax_type in the pre-migration
+    script."""
+    if not openupgrade.logged_query(cr, """
+        select id FROM account_tax where {name_v8} = 'code'
+    """.format(name_v8=openupgrade.get_legacy_name('type'))):
+        return
+    openupgrade.map_values(
+        cr,
+        openupgrade.get_legacy_name('type'), 'amount_type',
+        [('code', 'code')],
+        table='account_tax', write='sql')
+
+
+def map_account_tax_template_type(cr):
+    """ See comments in method map_account_tax_type in the pre-migration
+    script."""
+    if not openupgrade.logged_query(cr, """
+        select id FROM account_tax where {name_v8} = 'code'
+    """.format(name_v8=openupgrade.get_legacy_name('type'))):
+        return
+    openupgrade.map_values(
+        cr,
+        openupgrade.get_legacy_name('type'), 'amount_type',
+        [('code', 'code')],
+        table='account_tax_template', write='sql')
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
@@ -401,3 +429,5 @@ def migrate(env, version):
     parent_id_to_tag(env, 'account.account', recursive=True)
     account_internal_type(env)
     account_partial_reconcile(env)
+    map_account_tax_type(cr)
+    map_account_tax_template_type(cr)

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -35,9 +35,11 @@ column_copies = {
     ],
     'account_tax': [
         ('type_tax_use', None, None),
+        ('type', None, None),
     ],
     'account_tax_template': [
         ('type_tax_use', None, None),
+        ('type', None, None),
     ],
 }
 

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -71,6 +71,38 @@ def migrate_properties(cr):
             """.format(name_v8=name_v8, name_v9=name_v9))
 
 
+def install_account_tax_python(cr):
+    """ Type tax type 'code' is in v9 introduced by module
+    'account_tax_python. So, if we find an existing tax using this type,
+    we know that we have to install the module."""
+    openupgrade.logged_query(
+        cr, "update ir_module_module set state='to install' "
+        "where name='account_tax_python' "
+        "and state in ('uninstalled', 'to remove') "
+        "and exists (select id FROM account_tax where type = 'code')")
+
+
+def map_account_tax_type(cr):
+    """ The tax type 'code' is not an option in the account module for v9.
+    We need to assign a temporary 'dummy' value until module
+    account_tax_python is installed. In post-migration we will
+    restore the original value."""
+    openupgrade.map_values(
+        cr,
+        openupgrade.get_legacy_name('type'), 'type',
+        [('code', 'group')],
+        table='account_tax', write='sql')
+
+
+def map_account_tax_template_type(cr):
+    """Same comments as in map_account_tax_type"""
+    openupgrade.map_values(
+        cr,
+        openupgrade.get_legacy_name('type'), 'type',
+        [('code', 'group')],
+        table='account_tax_template', write='sql')
+
+
 @openupgrade.migrate()
 def migrate(cr, version):
     # 9.0 introduces a constraint enforcing this
@@ -82,3 +114,6 @@ def migrate(cr, version):
     openupgrade.rename_columns(cr, column_renames)
     openupgrade.copy_columns(cr, column_copies)
     migrate_properties(cr)
+    install_account_tax_python(cr)
+    map_account_tax_type(cr)
+    map_account_tax_template_type(cr)


### PR DESCRIPTION
The tax type 'code' is not an option in the account module for v9. We need to assign a temporary 'dummy' value and install module account_tax_python. In post-migration we will restore the original value.
