### PR TITLE
[ADD] Allow to run test file without post tests

### DIFF
--- a/openerp/cli/server.py
+++ b/openerp/cli/server.py
@@ -134,8 +134,10 @@ def main(args):
         except openerp.service.db.DatabaseExists:
             pass
 
-    if config["test_file"]:
-        config["test_enable"] = True
+    # OpenUpgrade: don't run post tests if --test-enable is not specified
+    # explicitely (problematic when loading test_data with --test-commit)
+    # if config["test_file"]:
+    #     config["test_enable"] = True
 
     if config["translate_out"]:
         export_translation()

--- a/openerp/service/model.py
+++ b/openerp/service/model.py
@@ -113,7 +113,9 @@ def check(f):
         tries = 0
         while True:
             try:
-                if openerp.registry(dbname)._init and not openerp.tools.config['test_enable']:
+                # OpenUpgrade: test_file does not imply test_enable as it does in upstream Odoo
+                test_mode = openerp.tools.config['test_enable'] or openerp.tools.config['test_file']
+                if openerp.registry(dbname)._init and not test_mode:
                     raise openerp.exceptions.Warning('Currently, this database is not fully loaded and can not be used.')
                 return f(dbname, *args, **kwargs)
             except (OperationalError, QWebException) as e:


### PR DESCRIPTION
The OpenUpgrade test mechanism should be able to load test data more dynamically and incrementally. It uses --test-file + --test-commit to load these files. However, the post tests cannot be committed multiple times so I am proposing to skip these tests when only using --test-file without --test-enable.

I have also proposed this into Odoo as a general improvement as https://github.com/odoo/odoo/pull/13146. 

This change is a prerequisite for https://github.com/OCA/OpenUpgrade/pull/624, which allows Travis to apply test data for the migration of 8.0 to 9.0 that is included in the 9.0 distribution (so that test data can be added in the same PR as the migration scripts).
