### PR TITLE
[9.0] [base] Remove pre-calculate checksum

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/post-migration.py
@@ -21,7 +21,6 @@
 ##############################################################################
 
 import logging
-import base64
 from openupgradelib import openupgrade
 from openerp.modules.registry import RegistryManager
 from openerp import SUPERUSER_ID

--- a/openerp/addons/base/migrations/9.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/post-migration.py
@@ -134,5 +134,5 @@ def migrate(cr, version):
     clear_inherit_id(cr)
     rename_your_company(cr)
     set_filter_active(cr)
-    precalculate_checksum(cr)
+    # precalculate_checksum(cr)
     remove_obsolete_modules(cr, ('web_gantt', 'web_graph', 'web_tests'))

--- a/openerp/addons/base/migrations/9.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/post-migration.py
@@ -21,6 +21,7 @@
 ##############################################################################
 
 import logging
+import base64
 from openupgradelib import openupgrade
 from openerp.modules.registry import RegistryManager
 from openerp import SUPERUSER_ID
@@ -90,17 +91,6 @@ def set_filter_active(cr):
         """)
 
 
-def precalculate_checksum(cr):
-    pool = RegistryManager.get(cr.dbname)
-    ir_attachment = pool['ir.attachment']
-    for attach_id in ir_attachment.search(cr, SUPERUSER_ID, []):
-        attach = ir_attachment.browse(cr, SUPERUSER_ID, attach_id)
-        # as done in ir_attachment._data_set()
-        value = attach.db_datas
-        bin_data = value and value.decode('base64') or ''  # empty string to compute its hash
-        attach.checksum = attach._compute_checksum(bin_data)
-
-
 def remove_obsolete_modules(cr, modules_to_remove):
     pool = RegistryManager.get(cr.dbname)
     ir_module_module = pool['ir.module.module']
@@ -119,6 +109,5 @@ def migrate(cr, version):
     clear_inherit_id(cr)
     rename_your_company(cr)
     set_filter_active(cr)
-    precalculate_checksum(cr)
     remove_obsolete_modules(cr, ('web_gantt', 'web_graph', 'web_tests'))
     openupgrade.load_data(cr, 'base', 'migrations/9.0.1.3/noupdate_changes.xml')

--- a/openerp/addons/base/migrations/9.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/post-migration.py
@@ -91,31 +91,6 @@ def set_filter_active(cr):
         """)
 
 
-def decode_base64(data):
-    """Decode base64, padding being optional.
-
-    :param data: Base64 data as an ASCII byte string
-    :returns: The decoded byte string.
-
-    """
-    missing_padding = len(data) % 4
-    if missing_padding != 0:
-        data += b'=' * (4 - missing_padding)
-    return base64.decodestring(data)
-
-
-def precalculate_checksum(cr):
-    pool = RegistryManager.get(cr.dbname)
-    ir_attachment = pool['ir.attachment']
-
-    for attach_id in ir_attachment.search(cr, SUPERUSER_ID, []):
-        attach = ir_attachment.browse(cr, SUPERUSER_ID, attach_id)
-        # as done in ir_attachment._data_set()
-        value = attach.db_datas
-        bin_data = value and decode_base64(value) or ''  # empty string to compute its hash
-        attach.checksum = attach._compute_checksum(bin_data)
-
-
 def remove_obsolete_modules(cr, modules_to_remove):
     pool = RegistryManager.get(cr.dbname)
     ir_module_module = pool['ir.module.module']
@@ -134,5 +109,4 @@ def migrate(cr, version):
     clear_inherit_id(cr)
     rename_your_company(cr)
     set_filter_active(cr)
-    # precalculate_checksum(cr)
     remove_obsolete_modules(cr, ('web_gantt', 'web_graph', 'web_tests'))


### PR DESCRIPTION
The 'checksum' field is not a required field. To pre-calculate checksums on all existing attachments is a very time consuming process. I have experienced that in databases with hundreds of thousands of attachments the migration lasts for more than 2 days just calculating the checksum, which is a totally unacceptable time delay for a migration.

We have migrated a database excluding the calculation of checksum, and the attachments can be correctly recovered.
