### PR TITLE
[9.0][account] Improve speed of automatic reconciliation

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -579,23 +579,6 @@ def account_partial_reconcile(env):
         WHERE apr.debit_move_id IN %s
     """ % (tuple(inv_move_to_link_ids), ))
 
-    # Set the residual amount to 0 for the corresponding invoices
-    cr.execute("""
-        SELECT DISTINCT account_invoice_id
-        FROM account_invoice_account_move_line_rel
-        WHERE account_move_line_id in %s
-    """ % (tuple(move_line_ids_reconciled), ))
-    invoice_ids = [inv_id for inv_id, in cr.fetchall()]
-
-    openupgrade.logged_query(cr, """
-        UPDATE account_invoice
-        SET
-            residual = 0.0,
-            residual_signed = 0.0,
-            residual_company_signed = 0.0
-        WHERE id IN %s
-    """ % (tuple(invoice_ids), ))
-
     # Migrate partially reconciled items
     move_line_map = {}
     cr.execute("SELECT COALESCE(reconcile_id, reconcile_partial_id), id "

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -378,13 +378,12 @@ def auto_reconcile_lines(env, move_lines, amount_residual):
     amount_residual[sm_debit_move.id]['amount_residual'] -= amount_reconcile
     amount_residual[sm_credit_move.id]['amount_residual'] -= amount_reconcile
 
-    env['account.partial.reconcile'].with_context(recompute=False).create({
-        'debit_move_id': sm_debit_move.id,
-        'credit_move_id': sm_credit_move.id,
-        'amount': amount_reconcile,
-        'amount_currency': amount_reconcile_currency,
-        'currency_id': currency,
-    })
+    openupgrade.logged_query(env.cr, """
+        INSERT INTO account_partial_reconcile
+        SET debit_move_id, credit_move_id, amount, amount_currency, currency_id
+        VALUES (%s, %s, %s, %s, %s)
+    """ % (sm_debit_move.id, sm_credit_move.id, amount_reconcile,
+           amount_reconcile_currency, currency))
 
     # Iterate process again on self
     return auto_reconcile_lines(env, move_lines, amount_residual)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -355,7 +355,7 @@ def account_partial_reconcile(env):
         Q5.company_id, 0.0
         FROM Q5
         INNER JOIN account_move_reconcile AS amr
-        ON amr.reconcile_id = amr.id
+        ON Q5.reconcile_id = amr.id
         WHERE debit_move_id > 0 AND credit_move_id > 0
     """)
 

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -382,14 +382,16 @@ def account_partial_reconcile(env):
                "WHERE (reconcile_id IS NOT NULL "
                "OR reconcile_partial_id IS NOT NULL) "
                "AND id NOT IN %s" % (tuple(move_line_ids), ))
+    recs = [rec_id for rec_id, move_line_id in cr.fetchall()]
+    num_recs = len(recs)
+    i = 1
     for rec_id, move_line_id in cr.fetchall():
         move_line_map.setdefault(rec_id, []).append(move_line_id)
     to_recompute = env['account.move.line']
     for _rec_id, move_line_ids in move_line_map.iteritems():
         move_lines = env['account.move.line'].browse(move_line_ids)
         move_lines.auto_reconcile_lines()
-        msg = 'Reconciling %s with moves: %s' % (_rec_id, ','.join(map(
-            str, move_line_ids)))
+        msg = 'Reconciling %s of %s' % (i, num_recs)
         openupgrade.message(cr, 'account', 'account_partial_reconcile',
                             'id', msg)
         to_recompute += move_lines

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -579,12 +579,13 @@ def account_partial_reconcile(env):
         WHERE apr.debit_move_id IN %s
     """ % (tuple(inv_move_to_link_ids), ))
 
-    # Recompute the corresponding invoices
+    # Set the residual amount to 0 for the corresponding invoices
     cr.execute("""
-        SELECT account_invoice_id
+        SELECT DISTINCT account_invoice_id
         FROM account_invoice_account_move_line_rel
         WHERE account_move_line_id in %s
     """ % (tuple(move_line_ids_reconciled), ))
+    invoice_ids = [inv_id for inv_id, in cr.fetchall()]
 
     openupgrade.logged_query(cr, """
         UPDATE account_invoice
@@ -593,7 +594,7 @@ def account_partial_reconcile(env):
             residual_signed = 0.0,
             residual_company_signed = 0.0
         WHERE id IN %s
-    """ % (tuple(move_line_ids_reconciled), ))
+    """ % (tuple(invoice_ids), ))
 
     # Migrate partially reconciled items
     move_line_map = {}

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -609,8 +609,7 @@ def account_partial_reconcile(env):
 
 
 def invoice_recompute(env):
-    invoice_ids = env['account.invoice'].search([])
-    to_recompute = env['account.invoice'].browse(invoice_ids)
+    to_recompute = env['account.invoice'].search([])
     for field in ['residual', 'residual_signed', 'residual_company_signed']:
         env.add_todo(env['account.invoice']._fields[field], to_recompute)
     env['account.move.line'].recompute()

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -380,7 +380,8 @@ def auto_reconcile_lines(env, move_lines, amount_residual):
 
     openupgrade.logged_query(env.cr, """
         INSERT INTO account_partial_reconcile
-        SET debit_move_id, credit_move_id, amount, amount_currency, currency_id
+        SET (debit_move_id, credit_move_id, amount, amount_currency,
+        currency_id)
         VALUES (%s, %s, %s, %s, %s)
     """ % (sm_debit_move.id, sm_credit_move.id, amount_reconcile,
            amount_reconcile_currency, currency))

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -384,7 +384,7 @@ def auto_reconcile_lines(env, move_lines, amount_residual):
         currency_id, company_id)
         VALUES (%s, %s, %s, %s, %s, %s)
     """ % (sm_debit_move.id, sm_credit_move.id, amount_reconcile,
-           amount_reconcile_currency, currency or None,
+           amount_reconcile_currency, currency or 'null',
            sm_debit_move.company_id.id))
 
     # Iterate process again on self

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -393,12 +393,11 @@ def account_partial_reconcile(env):
         (account_invoice_id, account_move_line_id)
         SELECT ai.id, apr.debit_move_id
         FROM account_partial_reconcile AS apr
-        INNER JOIN account_invoice AS ai
-        ON apr.credit_move_id = ai.move_id
-        WHERE ai.move_id in (
-            SELECT DISTINCT move_id
-            FROM account_move_line
-            WHERE id IN %s)
+        INNER JOIN account_move_line as aml
+        ON aml.id = apr.credit_move_id
+        INNER JOIN account_invoice as ai
+        ON ai.move_id = aml.move_id
+        WHERE apr.credit_move_id IN %s
     """ % (tuple(move_line_ids), ))
 
     openupgrade.logged_query(cr, """
@@ -406,12 +405,11 @@ def account_partial_reconcile(env):
         (account_invoice_id, account_move_line_id)
         SELECT ai.id, apr.credit_move_id
         FROM account_partial_reconcile AS apr
-        INNER JOIN account_invoice AS ai
-        ON apr.debit_move_id = ai.move_id
-        WHERE ai.move_id in (
-            SELECT DISTINCT move_id
-            FROM account_move_line
-            WHERE id IN %s)
+        INNER JOIN account_move_line as aml
+        ON aml.id = apr.debit_move_id
+        INNER JOIN account_invoice as ai
+        ON ai.move_id = aml.move_id
+        WHERE apr.debit_move_id IN %s
     """ % (tuple(move_line_ids), ))
 
     move_line_map = {}

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -396,7 +396,7 @@ def account_partial_reconcile(env):
             WHERE id IN %s)
     """ % (tuple(move_line_ids), ))
 
-    invoice_ids = [move_line_id for move_line_id, in cr.fetchall()]
+    invoice_ids = [invoice_id for invoice_id, in cr.fetchall()]
     to_recompute = env['account.invoice'].browse(invoice_ids)
     for field in ['payment_move_line_ids']:
         env.add_todo(env['account.invoice']._fields[field], to_recompute)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -377,7 +377,7 @@ def account_partial_reconcile(env):
                "FROM account_move_line "
                "WHERE reconcile_id IS NOT NULL "
                "OR reconcile_partial_id IS NOT NULL "
-               "AND id NOT IN %s" % (tuple(move_line_ids)))
+               "AND id NOT IN %s" % (tuple(move_line_ids), ))
     for rec_id, move_line_id in cr.fetchall():
         move_line_map.setdefault(rec_id, []).append(move_line_id)
     to_recompute = env['account.move.line']

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -587,7 +587,7 @@ def account_partial_reconcile(env):
     """ % (tuple(move_line_ids_reconciled), ))
 
     openupgrade.logged_query(cr, """
-        UPDATE account_invoice_id
+        UPDATE account_invoice
         SET
             residual = 0.0,
             residual_signed = 0.0,

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -526,7 +526,6 @@ def account_partial_reconcile(env):
     """ % (tuple(move_line_ids_reconciled), ))
 
     # Update the table that relates invoices with payments made
-
     openupgrade.logged_query(cr, """
         INSERT INTO account_invoice_account_move_line_rel
         (account_invoice_id, account_move_line_id)
@@ -537,7 +536,11 @@ def account_partial_reconcile(env):
         INNER JOIN account_invoice as ai
         ON ai.move_id = aml.move_id
         WHERE apr.credit_move_id IN %s
-    """ % (tuple(move_line_ids_reconciled), ))
+        AND NOT EXISTS (
+            SELECT account_move_line_id
+            FROM account_invoice_account_move_line_rel
+            WHERE account_move_line_id IN %s)
+    """ % (tuple(move_line_ids_reconciled), tuple(move_line_ids_reconciled)))
 
     openupgrade.logged_query(cr, """
         INSERT INTO account_invoice_account_move_line_rel
@@ -549,7 +552,11 @@ def account_partial_reconcile(env):
         INNER JOIN account_invoice as ai
         ON ai.move_id = aml.move_id
         WHERE apr.debit_move_id IN %s
-    """ % (tuple(move_line_ids_reconciled), ))
+        AND NOT EXISTS (
+            SELECT account_move_line_id
+            FROM account_invoice_account_move_line_rel
+            WHERE account_move_line_id IN %s)
+    """ % (tuple(move_line_ids_reconciled), tuple(move_line_ids_reconciled)))
 
     move_line_map = {}
     cr.execute("SELECT COALESCE(reconcile_id, reconcile_partial_id), id "

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -484,15 +484,6 @@ def account_partial_reconcile(env):
     move_line_ids_reconciled = [move_line_id for move_line_id,
                                 in cr.fetchall()]
 
-    # The previous move lines must be flagged as reconciled. The residual
-    # amount is 0.
-    move_lines = env['account.move.line'].with_context(recompute=False).browse(
-        move_line_ids_reconciled)
-    for move_line in move_lines:
-        move_line.reconciled = True
-        move_line.amount_residual = 0.0
-        move_line.amount_residual_currency = 0.0
-
     move_line_map = {}
     cr.execute("SELECT reconcile_id, id "
                "FROM account_move_line "
@@ -527,6 +518,15 @@ def account_partial_reconcile(env):
         auto_reconcile_lines(env, move_lines, amount_residual_d)
         i += 1
         move_line_ids_reconciled += move_line_ids
+
+    # The previous move lines must be flagged as reconciled. The residual
+    # amount is 0.
+    move_lines = env['account.move.line'].with_context(recompute=False).browse(
+        move_line_ids_reconciled)
+    for move_line in move_lines:
+        move_line.reconciled = True
+        move_line.amount_residual = 0.0
+        move_line.amount_residual_currency = 0.0
 
     # Update the table that relates invoices with payments made
     openupgrade.logged_query(cr, """

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -513,6 +513,7 @@ def account_partial_reconcile(env):
         msg = 'Step 2. Reconciling %s of %s' % (i, num_recs)
         openupgrade.message(cr, 'account', 'account_partial_reconcile',
                             'id', msg)
+        i += 1
         move_line_ids_reconciled += move_line_ids
 
     # The previous move lines must be flagged as reconciled

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -348,7 +348,7 @@ def account_partial_reconcile(env):
             GROUP BY reconcile_id, company_id
         )
         INSERT INTO account_partial_reconcile
-        (debit_move_id, credit_move_id, amount, currency_id)
+        (debit_move_id, credit_move_id, amount, company_id)
         SELECT debit_move_id, credit_move_id, amount, company_id
             FROM Q5
             WHERE debit_move_id > 0 AND credit_move_id > 0

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -346,7 +346,7 @@ def account_partial_reconcile(env):
             sum(credit_move_id) as credit_move_id, sum(amount) as amount,
             company_id, company_currency_id
             FROM Q4
-            GROUP BY reconcile_id, company_id
+            GROUP BY reconcile_id, company_id, company_currency_id
         )
         INSERT INTO account_partial_reconcile
         (debit_move_id, credit_move_id, amount, company_id, currency_id)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -295,13 +295,15 @@ def account_internal_type(env):
 
 def _get_pair_to_reconcile(moves, amount_residual):
 
-    #field is either 'amount_residual' or 'amount_residual_currency'
+    # field is either 'amount_residual' or 'amount_residual_currency'
     # (if the reconciled account has a secondary currency set)
     field = moves[0].account_id.currency_id \
             and 'amount_residual_currency' or 'amount_residual'
     rounding = moves[0].company_id.currency_id.rounding
-    if moves[0].currency_id and all([x.amount_currency and x.currency_id ==
-            moves[0].currency_id for x in moves]):
+    if moves[0].currency_id \
+            and all([x.amount_currency and
+                    x.currency_id == moves[0].currency_id
+                     for x in moves]):
         # or if all lines share the same currency
         field = 'amount_residual_currency'
         rounding = moves[0].currency_id.rounding

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -486,9 +486,10 @@ def account_partial_reconcile(env):
     # The previous move lines must be flagged as reconciled. The residual
     # amount is 0.
     move_lines = env['account.move.line'].browse(move_line_ids_reconciled)
-    move_lines.reconciled = True
-    move_lines.amount_residual = 0.0
-    move_lines.amount_residual_currency = 0.0
+    for move_line in move_lines:
+        move_line.reconciled = True
+        move_line.amount_residual = 0.0
+        move_line.amount_residual_currency = 0.0
 
     move_line_map = {}
     cr.execute("SELECT reconcile_id, id "

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -584,7 +584,7 @@ def account_partial_reconcile(env):
         SELECT account_invoice_id
         FROM account_invoice_account_move_line_rel
         WHERE account_move_line_id in %s
-    """ % (tuple(move_line_ids_reconciled, )))
+    """ % (tuple(move_line_ids_reconciled), ))
 
     invoice_ids = [invoice_id for invoice_id, in cr.fetchall()]
     to_recompute_invoices = env['account.invoice'].browse(invoice_ids)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -381,10 +381,11 @@ def auto_reconcile_lines(env, move_lines, amount_residual):
     openupgrade.logged_query(env.cr, """
         INSERT INTO account_partial_reconcile
         (debit_move_id, credit_move_id, amount, amount_currency,
-        currency_id)
-        VALUES (%s, %s, %s, %s, %s)
+        currency_id, company_id)
+        VALUES (%s, %s, %s, %s, %s, %s)
     """ % (sm_debit_move.id, sm_credit_move.id, amount_reconcile,
-           amount_reconcile_currency, currency))
+           amount_reconcile_currency, currency or None,
+           sm_debit_move.company_id.id))
 
     # Iterate process again on self
     return auto_reconcile_lines(env, move_lines, amount_residual)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -350,7 +350,6 @@ def account_partial_reconcile(env):
         SELECT debit_move_id, credit_move_id, amount, company_id
             FROM Q5
             WHERE debit_move_id > 0 AND credit_move_id > 0
-        )
     """)
 
     # We want to exclude the moves that were included in the step above from

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -510,7 +510,9 @@ def account_partial_reconcile(env):
                 move_line.currency_id and move_line.currency_id.round(
                     amount_residual_currency * sign) or 0.0
         auto_reconcile_lines(env, move_lines, amount_residual_d)
-        msg = 'Step 2. Reconciling %s of %s' % (i, num_recs)
+        msg = 'Reconciliation step 2 (%s of %s). ' \
+              'Resolving account.move.reconcile %s.' % \
+              (i, num_recs, _rec_id)
         openupgrade.message(cr, 'account', 'account_partial_reconcile',
                             'id', msg)
         i += 1
@@ -565,7 +567,8 @@ def account_partial_reconcile(env):
     for _rec_id, move_line_ids in move_line_map.iteritems():
         move_lines = env['account.move.line'].browse(move_line_ids)
         move_lines.auto_reconcile_lines()
-        msg = 'Step 3. Reconciling %s of %s' % (i, num_recs)
+        msg = 'SReconciliation step 3 (%s of %s). ' \
+              'Resolving account.move.reconcile %s.' % (i, num_recs, _rec_id)
         openupgrade.message(cr, 'account', 'account_partial_reconcile',
                             'id', msg)
         i += 1

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -382,10 +382,11 @@ def account_partial_reconcile(env):
                "WHERE (reconcile_id IS NOT NULL "
                "OR reconcile_partial_id IS NOT NULL) "
                "AND id NOT IN %s" % (tuple(move_line_ids), ))
-    num_recs = 0
+    rec_l = {}
     for rec_id, move_line_id in cr.fetchall():
         move_line_map.setdefault(rec_id, []).append(move_line_id)
-        num_recs += 1
+        rec_l[rec_id] = True
+    num_recs = len(rec_l.keys())
     to_recompute = env['account.move.line']
     i = 1
     for _rec_id, move_line_ids in move_line_map.iteritems():

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -325,7 +325,7 @@ def account_partial_reconcile(env):
         ),
         Q3 AS (
             SELECT aml.reconcile_id, aml.id, aml.debit,
-            aml.credit, aml.company_id, aml.company_currency_id
+            aml.credit, aml.company_id
             FROM account_move_line AS aml
             INNER JOIN Q2
             ON Q2.reconcile_id = aml.reconcile_id
@@ -335,23 +335,21 @@ def account_partial_reconcile(env):
             CASE WHEN debit > 0.0
             THEN id ELSE Null END as debit_move_id, CASE WHEN credit > 0.0
             THEN id ELSE Null END as credit_move_id,
-            CASE WHEN debit > 0.0 THEN debit END as amount, company_id,
-            company_currency_id
+            CASE WHEN debit > 0.0 THEN debit END as amount, company_id
             FROM Q3
             GROUP BY reconcile_id, debit_move_id, credit_move_id, amount,
-            company_id, company_currency_id
+            company_id
         ),
         Q5 AS (
             SELECT reconcile_id, sum(debit_move_id) as debit_move_id,
             sum(credit_move_id) as credit_move_id, sum(amount) as amount,
-            company_id, company_currency_id
+            company_id
             FROM Q4
-            GROUP BY reconcile_id, company_id, company_currency_id
+            GROUP BY reconcile_id, company_id
         )
         INSERT INTO account_partial_reconcile
-        (debit_move_id, credit_move_id, amount, company_id, currency_id)
-        SELECT debit_move_id, credit_move_id, amount, company_id,
-        company_currency_id
+        (debit_move_id, credit_move_id, amount, company_id, amount_currency)
+        SELECT debit_move_id, credit_move_id, amount, company_id, 0.0
             FROM Q5
             WHERE debit_move_id > 0 AND credit_move_id > 0
     """)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -313,6 +313,9 @@ def account_partial_reconcile(env):
     for _rec_id, move_line_ids in move_line_map.iteritems():
         move_lines = env['account.move.line'].browse(move_line_ids)
         move_lines.auto_reconcile_lines()
+        msg = 'Reconciling %s with moves: %s', (_rec_id, tuple(move_line_ids))
+        openupgrade.message(cr, 'account', 'account_partial_reconcile',
+                            'id', msg)
         to_recompute += move_lines
     for field in ['amount_residual', 'amount_residual_currency', 'reconciled']:
         env.add_todo(env['account.move.line']._fields[field], to_recompute)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -376,7 +376,15 @@ def account_partial_reconcile(env):
         INNER JOIN Q2
         ON Q2.reconcile_id = aml.reconcile_id
     """)
+
     move_line_ids = [move_line_id for move_line_id, in cr.fetchall()]
+
+    # The previous move lines must be flagged as reconciled
+    openupgrade.logged_query(cr, """
+        UPDATE account_move_line
+        SET reconciled = True
+        WHERE id IN %s
+    """ % (tuple(move_line_ids)))
 
     move_line_map = {}
     cr.execute("SELECT COALESCE(reconcile_id, reconcile_partial_id), id "

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -380,7 +380,7 @@ def auto_reconcile_lines(env, move_lines, amount_residual):
 
     openupgrade.logged_query(env.cr, """
         INSERT INTO account_partial_reconcile
-        SET (debit_move_id, credit_move_id, amount, amount_currency,
+        (debit_move_id, credit_move_id, amount, amount_currency,
         currency_id)
         VALUES (%s, %s, %s, %s, %s)
     """ % (sm_debit_move.id, sm_credit_move.id, amount_reconcile,

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -546,7 +546,7 @@ def account_partial_reconcile(env):
     openupgrade.logged_query(cr, """
         INSERT INTO account_invoice_account_move_line_rel
         (account_invoice_id, account_move_line_id)
-        SELECT ai.id, apr.debit_move_id
+        SELECT DISTINCT ai.id, apr.debit_move_id
         FROM account_partial_reconcile AS apr
         INNER JOIN account_move_line as aml
         ON aml.id = apr.credit_move_id
@@ -570,7 +570,7 @@ def account_partial_reconcile(env):
     openupgrade.logged_query(cr, """
         INSERT INTO account_invoice_account_move_line_rel
         (account_invoice_id, account_move_line_id)
-        SELECT ai.id, apr.credit_move_id
+        SELECT DISTINCT ai.id, apr.credit_move_id
         FROM account_partial_reconcile AS apr
         INNER JOIN account_move_line as aml
         ON aml.id = apr.debit_move_id

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -382,12 +382,12 @@ def account_partial_reconcile(env):
                "WHERE (reconcile_id IS NOT NULL "
                "OR reconcile_partial_id IS NOT NULL) "
                "AND id NOT IN %s" % (tuple(move_line_ids), ))
-    recs = [rec_id for rec_id, move_line_id in cr.fetchall()]
-    num_recs = len(recs)
-    i = 1
+    num_recs = 0
     for rec_id, move_line_id in cr.fetchall():
         move_line_map.setdefault(rec_id, []).append(move_line_id)
+        num_recs += 1
     to_recompute = env['account.move.line']
+    i = 1
     for _rec_id, move_line_ids in move_line_map.iteritems():
         move_lines = env['account.move.line'].browse(move_line_ids)
         move_lines.auto_reconcile_lines()

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -339,7 +339,7 @@ def account_partial_reconcile(env):
             company_currency_id
             FROM Q3
             GROUP BY reconcile_id, debit_move_id, credit_move_id, amount,
-            company_id
+            company_id, company_currency_id
         ),
         Q5 AS (
             SELECT reconcile_id, sum(debit_move_id) as debit_move_id,

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -527,19 +527,6 @@ def account_partial_reconcile(env):
         move_line_ids_reconciled += move_line_ids
 
     # Update the table that relates invoices with payments made
-
-    # Exclude from the query the records that are already contained in the
-    # table account_invoice_account_move_line_rel
-    cr.execute("""
-        SELECT DISTINCT account_move_line_id
-        FROM account_invoice_account_move_line_rel
-        WHERE account_move_line_id IN %s
-    """ % (tuple(move_line_ids_reconciled),))
-    inv_move_linked_ids = [move_id for move_id, in cr.fetchall()]
-    inv_move_to_link_ids = \
-        [move_id for move_id in move_line_ids_reconciled
-         if move_id not in inv_move_linked_ids]
-
     openupgrade.logged_query(cr, """
         INSERT INTO account_invoice_account_move_line_rel
         (account_invoice_id, account_move_line_id)
@@ -550,19 +537,7 @@ def account_partial_reconcile(env):
         INNER JOIN account_invoice as ai
         ON ai.move_id = aml.move_id
         WHERE apr.credit_move_id IN %s
-    """ % (tuple(inv_move_to_link_ids),))
-
-    # Exclude from the query the records that are already contained in the
-    # table account_invoice_account_move_line_rel
-    cr.execute("""
-        SELECT DISTINCT account_move_line_id
-        FROM account_invoice_account_move_line_rel
-        WHERE account_move_line_id IN %s
     """ % (tuple(move_line_ids_reconciled),))
-    inv_move_linked_ids = [move_id for move_id, in cr.fetchall()]
-    inv_move_to_link_ids = \
-        [move_id for move_id in move_line_ids_reconciled
-         if move_id not in inv_move_linked_ids]
 
     openupgrade.logged_query(cr, """
         INSERT INTO account_invoice_account_move_line_rel
@@ -574,7 +549,7 @@ def account_partial_reconcile(env):
         INNER JOIN account_invoice as ai
         ON ai.move_id = aml.move_id
         WHERE apr.debit_move_id IN %s
-    """ % (tuple(inv_move_to_link_ids), ))
+    """ % (tuple(move_line_ids_reconciled), ))
 
     # Migrate partially reconciled items
     move_line_map = {}

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -574,7 +574,7 @@ def account_partial_reconcile(env):
         ON ai.move_id = aml.move_id
         WHERE apr.debit_move_id IN %s
     """ % (tuple(inv_move_to_link_ids), ))
-
+    to_recompute = env['account.move.line'].browse(move_line_ids_reconciled)
     move_line_map = {}
     cr.execute("SELECT COALESCE(reconcile_id, reconcile_partial_id), id "
                "FROM account_move_line "
@@ -586,7 +586,6 @@ def account_partial_reconcile(env):
         move_line_map.setdefault(rec_id, []).append(move_line_id)
         rec_l[rec_id] = True
     num_recs = len(rec_l.keys())
-    to_recompute = env['account.move.line']
     i = 1
     for _rec_id, move_line_ids in move_line_map.iteritems():
         msg = 'Reconciliation step 3 (%s of %s). ' \

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -335,8 +335,7 @@ def account_partial_reconcile(env):
             CASE WHEN debit > 0.0
             THEN id ELSE Null END as debit_move_id, CASE WHEN credit > 0.0
             THEN id ELSE Null END as credit_move_id,
-            CASE WHEN debit > 0.0 THEN debit WHEN credit > 0.0
-            THEN credit END as amount, company_id
+            CASE WHEN debit > 0.0 THEN debit END as amount, company_id
             FROM Q3
             GROUP BY reconcile_id, debit_move_id, credit_move_id, amount,
             company_id

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -387,14 +387,15 @@ def account_partial_reconcile(env):
     """ % (tuple(move_line_ids), ))
 
     # Recompute the payment_move_line_ids in associated invoices
-    cr.execute(cr, """
+    cr.execute("""
         SELECT id
         FROM account_invoice
         WHERE move_id IN (
             SELECT DISTINCT move_id
             FROM account_move_line
-            WHERE id in %s)
+            WHERE id IN %s)
     """ % (tuple(move_line_ids), ))
+
     invoice_ids = [move_line_id for move_line_id, in cr.fetchall()]
     to_recompute = env['account.invoice'].browse(invoice_ids)
     for field in ['payment_move_line_ids']:

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -588,7 +588,8 @@ def account_partial_reconcile(env):
 
     invoice_ids = [invoice_id for invoice_id, in cr.fetchall()]
     to_recompute_invoices = env['account.invoice'].browse(invoice_ids)
-    for field in ['reconciled']:
+    for field in ['reconciled', 'residual', 'residual_signed',
+                  'residual_company_signed']:
         env.add_todo(env['account.invoice']._fields[field],
                      to_recompute_invoices)
     env['account.invoice'].recompute()

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -348,10 +348,15 @@ def account_partial_reconcile(env):
             GROUP BY reconcile_id, company_id
         )
         INSERT INTO account_partial_reconcile
-        (debit_move_id, credit_move_id, amount, company_id, amount_currency)
-        SELECT debit_move_id, credit_move_id, amount, company_id, 0.0
-            FROM Q5
-            WHERE debit_move_id > 0 AND credit_move_id > 0
+        (create_uid, create_date, write_uid, write_date, debit_move_id,
+        credit_move_id, amount, company_id, amount_currency)
+        SELECT amr.create_uid, amr.create_date, amr.write_uid,
+        amr.write_date, Q5.debit_move_id, Q5.credit_move_id, Q5.amount,
+        Q5.company_id, 0.0
+        FROM Q5
+        INNER JOIN account_move_reconcile AS amr
+        ON amr.reconcile_id = amr.id
+        WHERE debit_move_id > 0 AND credit_move_id > 0
     """)
 
     # We want to exclude the moves that were included in the step above from

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -579,11 +579,13 @@ def account_partial_reconcile(env):
         WHERE apr.debit_move_id IN %s
     """ % (tuple(inv_move_to_link_ids), ))
 
+    # Recompute the corresponding invoices
     cr.execute("""
         SELECT account_invoice_id
         FROM account_invoice_account_move_line_rel
         WHERE account_move_line_id in %s
-    """ % (tuple(move_line_ids_reconciled,)))
+    """ % (tuple(move_line_ids_reconciled, )))
+
     invoice_ids = [invoice_id for invoice_id, in cr.fetchall()]
     to_recompute_invoices = env['account.invoice'].browse(invoice_ids)
     for field in ['reconciled']:

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -608,6 +608,14 @@ def account_partial_reconcile(env):
     models.BaseModel.step_workflow = set_workflow_org
 
 
+def invoice_recompute(env):
+    invoice_ids = env['account.invoice'].search([])
+    to_recompute = env['account.invoice'].browse(invoice_ids)
+    for field in ['residual', 'residual_signed', 'residual_company_signed']:
+        env.add_todo(env['account.invoice']._fields[field], to_recompute)
+    env['account.move.line'].recompute()
+
+
 def map_account_tax_type(cr):
     """ See comments in method map_account_tax_type in the pre-migration
     script."""
@@ -717,5 +725,6 @@ def migrate(env, version):
     parent_id_to_tag(env, 'account.account', recursive=True)
     account_internal_type(env)
     account_partial_reconcile(env)
+    invoice_recompute(env)
     map_account_tax_type(cr)
     map_account_tax_template_type(cr)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -612,7 +612,7 @@ def invoice_recompute(env):
     to_recompute = env['account.invoice'].search([])
     for field in ['residual', 'residual_signed', 'residual_company_signed']:
         env.add_todo(env['account.invoice']._fields[field], to_recompute)
-    env['account.move.line'].recompute()
+    env['account.invoice'].recompute()
 
 
 def map_account_tax_type(cr):

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -313,7 +313,7 @@ def account_partial_reconcile(env):
     for _rec_id, move_line_ids in move_line_map.iteritems():
         move_lines = env['account.move.line'].browse(move_line_ids)
         move_lines.auto_reconcile_lines()
-        msg = 'Reconciling %s with moves: %s', (_rec_id, ','.join(map(
+        msg = 'Reconciling %s with moves: %s' % (_rec_id, ','.join(map(
             str, move_line_ids)))
         openupgrade.message(cr, 'account', 'account_partial_reconcile',
                             'id', msg)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -303,10 +303,69 @@ def account_partial_reconcile(env):
     set_workflow_org = models.BaseModel.step_workflow
     models.BaseModel.step_workflow = lambda *args, **kwargs: None
     cr = env.cr
+
+    # Execute a direct reconciliation for the most common and easiest use
+    # case, that involves reconciling two moves, for the full amount, and in
+    # the company currency. This will dramatically improve the overall
+    # performance of the migration of reconciliations.
+    openupgrade.logged_query(cr, """
+        WITH Q1 AS (SELECT reconcile_id, sum(debit-credit) as balance,
+        count(id) as num_moves
+        FROM account_move_line
+        where reconcile_id IS NOT NULL
+        AND currency_id IS NULL
+        GROUP BY reconcile_id, currency_id),
+        Q2 AS (SELECT reconcile_id
+        FROM Q1
+        WHERE balance = 0.0
+        AND num_moves = 2),
+        Q3 AS (SELECT aml.reconcile_id, aml.id, aml.debit,
+        aml.credit, aml.company_id
+        FROM account_move_line AS aml
+        INNER JOIN Q2
+        ON Q2.reconcile_id = aml.reconcile_id),
+        Q5 AS (SELECT reconcile_id, CASE WHEN debit > 0.0
+        THEN id ELSE Null END as debit_move_id, CASE WHEN credit > 0.0
+        THEN id ELSE Null END as credit_move_id, company_id
+        FROM Q3
+        GROUP BY reconcile_id, debit_move_id, credit_move_id, company_id),
+        Q6 AS (SELECT reconcile_id, sum(debit_move_id) as debit_move_id,
+        sum(credit_move_id) as credit_move_id, company_id
+        FROM Q5
+        GROUP BY reconcile_id, company_id)
+        INSERT INTO account_partial_reconcile (debit_move_id, credit_move_id,
+        amount, company_id)
+        VALUES (SELECT debit_move_id, credit_move_id, company_id
+        FROM Q6
+        WHERE debit_move_id > 0 AND credit_move_id > 0)
+    """)
+
+    # We want to exclude the moves that were included in the step above from
+    # the next reconciliation step.
+    cr.execute("""
+        WITH Q1 AS (SELECT reconcile_id, sum(debit-credit) as balance,
+        count(id) as num_moves
+        FROM account_move_line
+        where reconcile_id IS NOT NULL
+        AND currency_id IS NULL
+        GROUP BY reconcile_id, currency_id),
+        Q2 AS (SELECT reconcile_id
+        FROM Q1
+        WHERE balance = 0.0
+        AND num_moves = 2)
+        SELECT aml.id
+        FROM account_move_line AS aml
+        INNER JOIN Q2
+        ON Q2.reconcile_id = aml.reconcile_id
+    """)
+    move_line_ids = [move_line_id for move_line_id, in cr.fetchall()]
+
     move_line_map = {}
     cr.execute("SELECT COALESCE(reconcile_id, reconcile_partial_id), id "
-               "FROM account_move_line WHERE "
-               "reconcile_id IS NOT NULL or reconcile_partial_id IS NOT NULL")
+               "FROM account_move_line "
+               "WHERE reconcile_id IS NOT NULL "
+               "OR reconcile_partial_id IS NOT NULL "
+               "AND id NOT IN %s" % (tuple(move_line_ids)))
     for rec_id, move_line_id in cr.fetchall():
         move_line_map.setdefault(rec_id, []).append(move_line_id)
     to_recompute = env['account.move.line']

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -581,10 +581,13 @@ def account_partial_reconcile(env):
 
 
 def invoice_recompute(env):
+    set_workflow_org = models.BaseModel.step_workflow
+    models.BaseModel.step_workflow = lambda *args, **kwargs: None
     to_recompute = env['account.invoice'].search([])
     for field in ['residual', 'residual_signed', 'residual_company_signed']:
         env.add_todo(env['account.invoice']._fields[field], to_recompute)
     env['account.invoice'].recompute()
+    models.BaseModel.step_workflow = set_workflow_org
 
 
 def map_account_tax_type(cr):

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -485,7 +485,8 @@ def account_partial_reconcile(env):
 
     # The previous move lines must be flagged as reconciled. The residual
     # amount is 0.
-    move_lines = env['account.move.line'].browse(move_line_ids_reconciled)
+    move_lines = env['account.move.line'].with_context(recompute=False).browse(
+        move_line_ids_reconciled)
     for move_line in move_lines:
         move_line.reconciled = True
         move_line.amount_residual = 0.0

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -394,6 +394,7 @@ def account_partial_reconcile(env):
         msg = 'Reconciling %s of %s' % (i, num_recs)
         openupgrade.message(cr, 'account', 'account_partial_reconcile',
                             'id', msg)
+        i += 1
         to_recompute += move_lines
     for field in ['amount_residual', 'amount_residual_currency', 'reconciled']:
         env.add_todo(env['account.move.line']._fields[field], to_recompute)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -495,6 +495,11 @@ def account_partial_reconcile(env):
     num_recs = len(rec_l.keys())
     i = 1
     for _rec_id, move_line_ids in move_line_map.iteritems():
+        msg = 'Reconciliation step 2 (%s of %s). ' \
+              'Resolving account.move.reconcile %s.' % \
+              (i, num_recs, _rec_id)
+        openupgrade.message(cr, 'account', 'account_partial_reconcile',
+                            'id', msg)
         move_lines = env['account.move.line'].browse(move_line_ids)
         amount_residual_d = {}
         for move_line in move_lines:
@@ -510,11 +515,6 @@ def account_partial_reconcile(env):
                 move_line.currency_id and move_line.currency_id.round(
                     amount_residual_currency * sign) or 0.0
         auto_reconcile_lines(env, move_lines, amount_residual_d)
-        msg = 'Reconciliation step 2 (%s of %s). ' \
-              'Resolving account.move.reconcile %s.' % \
-              (i, num_recs, _rec_id)
-        openupgrade.message(cr, 'account', 'account_partial_reconcile',
-                            'id', msg)
         i += 1
         move_line_ids_reconciled += move_line_ids
 
@@ -565,12 +565,12 @@ def account_partial_reconcile(env):
     to_recompute = env['account.move.line']
     i = 1
     for _rec_id, move_line_ids in move_line_map.iteritems():
-        move_lines = env['account.move.line'].browse(move_line_ids)
-        move_lines.auto_reconcile_lines()
-        msg = 'SReconciliation step 3 (%s of %s). ' \
+        msg = 'Reconciliation step 3 (%s of %s). ' \
               'Resolving account.move.reconcile %s.' % (i, num_recs, _rec_id)
         openupgrade.message(cr, 'account', 'account_partial_reconcile',
                             'id', msg)
+        move_lines = env['account.move.line'].browse(move_line_ids)
+        move_lines.auto_reconcile_lines()
         i += 1
         to_recompute += move_lines
     for field in ['amount_residual', 'amount_residual_currency', 'reconciled']:

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -390,7 +390,10 @@ def account_partial_reconcile(env):
     cr.execute(cr, """
         SELECT id
         FROM account_invoice
-        WHERE move_id IN %s
+        WHERE move_id IN (
+            SELECT DISTINCT move_id
+            FROM account_move_line
+            WHERE id in %s)
     """ % (tuple(move_line_ids), ))
     invoice_ids = [move_line_id for move_line_id, in cr.fetchall()]
     to_recompute = env['account.invoice'].browse(invoice_ids)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -347,6 +347,8 @@ def account_partial_reconcile(env):
             FROM Q4
             GROUP BY reconcile_id, company_id
         )
+        INSERT INTO account_partial_reconcile
+        (debit_move_id, credit_move_id, amount, currency_id)
         SELECT debit_move_id, credit_move_id, amount, company_id
             FROM Q5
             WHERE debit_move_id > 0 AND credit_move_id > 0

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -485,14 +485,10 @@ def account_partial_reconcile(env):
 
     # The previous move lines must be flagged as reconciled. The residual
     # amount is 0.
-    openupgrade.logged_query(cr, """
-        UPDATE account_move_line
-        SET
-            reconciled = True,
-            amount_residual = 0.0,
-            amount_residual_currency = 0.0
-        WHERE id IN %s
-    """ % (tuple(move_line_ids_reconciled), ))
+    move_lines = env['account.move.line'].browse(move_line_ids_reconciled)
+    move_lines.reconciled = True
+    move_lines.amount_residual = 0.0
+    move_lines.amount_residual_currency = 0.0
 
     move_line_map = {}
     cr.execute("SELECT reconcile_id, id "

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -325,7 +325,7 @@ def account_partial_reconcile(env):
         ),
         Q3 AS (
             SELECT aml.reconcile_id, aml.id, aml.debit,
-            aml.credit, aml.company_id
+            aml.credit, aml.company_id, aml.company_currency_id
             FROM account_move_line AS aml
             INNER JOIN Q2
             ON Q2.reconcile_id = aml.reconcile_id
@@ -335,7 +335,8 @@ def account_partial_reconcile(env):
             CASE WHEN debit > 0.0
             THEN id ELSE Null END as debit_move_id, CASE WHEN credit > 0.0
             THEN id ELSE Null END as credit_move_id,
-            CASE WHEN debit > 0.0 THEN debit END as amount, company_id
+            CASE WHEN debit > 0.0 THEN debit END as amount, company_id,
+            company_currency_id
             FROM Q3
             GROUP BY reconcile_id, debit_move_id, credit_move_id, amount,
             company_id
@@ -343,13 +344,14 @@ def account_partial_reconcile(env):
         Q5 AS (
             SELECT reconcile_id, sum(debit_move_id) as debit_move_id,
             sum(credit_move_id) as credit_move_id, sum(amount) as amount,
-            company_id
+            company_id, company_currency_id
             FROM Q4
             GROUP BY reconcile_id, company_id
         )
         INSERT INTO account_partial_reconcile
-        (debit_move_id, credit_move_id, amount, company_id)
-        SELECT debit_move_id, credit_move_id, amount, company_id
+        (debit_move_id, credit_move_id, amount, company_id, currency_id)
+        SELECT debit_move_id, credit_move_id, amount, company_id,
+        company_currency_id
             FROM Q5
             WHERE debit_move_id > 0 AND credit_move_id > 0
     """)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -346,7 +346,7 @@ def account_partial_reconcile(env):
         INSERT INTO account_partial_reconcile (debit_move_id, credit_move_id,
         amount, company_id) (
             SELECT debit_move_id, credit_move_id, company_id
-            FROM Q6
+            FROM Q5
             WHERE debit_move_id > 0 AND credit_move_id > 0
         )
     """)

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -311,10 +311,9 @@ def account_partial_reconcile(env):
     openupgrade.logged_query(cr, """
         WITH Q1 AS (
             SELECT reconcile_id, sum(debit-credit) as balance,
-            count(id) as num_moves
+            count(id) as num_moves, count(currency_id) as num_currencies
             FROM account_move_line
             WHERE reconcile_id IS NOT NULL
-            AND currency_id IS NULL
             GROUP BY reconcile_id, currency_id
         ),
         Q2 AS (
@@ -322,6 +321,7 @@ def account_partial_reconcile(env):
             FROM Q1
             WHERE balance = 0.0
             AND num_moves = 2
+            AND num_currencies = 0
         ),
         Q3 AS (
             SELECT aml.reconcile_id, aml.id, aml.debit,

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -388,7 +388,7 @@ def account_partial_reconcile(env):
 
     # Update the table that relates invoices with payments made
 
-    cr.execute("""
+    openupgrade.logged_query(cr, """
         INSERT INTO account_invoice_account_move_line_rel
         (account_invoice_id, account_move_line_id)
         SELECT ai.id, apr.debit_move_id
@@ -401,7 +401,7 @@ def account_partial_reconcile(env):
             WHERE id IN %s)
     """ % (tuple(move_line_ids), ))
 
-    cr.execute("""
+    openupgrade.logged_query(cr, """
         INSERT INTO account_invoice_account_move_line_rel
         (account_invoice_id, account_move_line_id)
         SELECT ai.id, apr.credit_move_id

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -313,7 +313,8 @@ def account_partial_reconcile(env):
     for _rec_id, move_line_ids in move_line_map.iteritems():
         move_lines = env['account.move.line'].browse(move_line_ids)
         move_lines.auto_reconcile_lines()
-        msg = 'Reconciling %s with moves: %s', (_rec_id, tuple(move_line_ids))
+        msg = 'Reconciling %s with moves: %s', (_rec_id, ','.join(map(
+            str, move_line_ids)))
         openupgrade.message(cr, 'account', 'account_partial_reconcile',
                             'id', msg)
         to_recompute += move_lines

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -384,7 +384,7 @@ def account_partial_reconcile(env):
         UPDATE account_move_line
         SET reconciled = True
         WHERE id IN %s
-    """ % (tuple(move_line_ids)))
+    """ % (tuple(move_line_ids), ))
 
     move_line_map = {}
     cr.execute("SELECT COALESCE(reconcile_id, reconcile_partial_id), id "

--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -485,15 +485,17 @@ def account_partial_reconcile(env):
                                 in cr.fetchall()]
 
     move_line_map = {}
-    cr.execute("SELECT reconcile_id, id "
-               "FROM account_move_line "
-               "WHERE reconcile_id IS NOT NULL "
-               "AND id NOT IN %s" % (tuple(move_line_ids_reconciled), ))
-    rec_l = {}
-    for rec_id, move_line_id in cr.fetchall():
-        move_line_map.setdefault(rec_id, []).append(move_line_id)
-        rec_l[rec_id] = True
-    num_recs = len(rec_l.keys())
+    num_recs = 0
+    if move_line_ids_reconciled:
+        cr.execute("SELECT reconcile_id, id "
+                   "FROM account_move_line "
+                   "WHERE reconcile_id IS NOT NULL "
+                   "AND id NOT IN %s" % (tuple(move_line_ids_reconciled), ))
+        rec_l = {}
+        for rec_id, move_line_id in cr.fetchall():
+            move_line_map.setdefault(rec_id, []).append(move_line_id)
+            rec_l[rec_id] = True
+        num_recs = len(rec_l.keys())
     i = 1
     for _rec_id, move_line_ids in move_line_map.iteritems():
         msg = 'Reconciliation step 2 (%s of %s). ' \


### PR DESCRIPTION
The automatic reconciliation process used by Odoo is very slow, and in a database with hundreds of thousands of reconciliations, it takes days to complete a reconciliation. This PR aims to improve the reconciliation process by creating reconciliations for the most common scenario (an invoice is fully paid, in the company currency). This has proved to improve dramatically the overall reconciliation process.
