### PR TITLE
[ADD] product_images was renamed for 8

### DIFF
--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -20,6 +20,8 @@ renamed_modules = {
         'account_bank_statement_import_mt940_nl_ing',
     'account_banking_nl_rabo_mt940':
         'account_bank_statement_import_mt940_nl_rabo',
+    # OCA/product-attribute
+    'product_images': 'product_multi_image',
 }
 
 renamed_models = {


### PR DESCRIPTION
cf https://github.com/OCA/product-attribute/tree/8.0/product_multi_image and https://github.com/OCA/product-attribute/tree/7.0/product_images
