### PR TITLE
[FIX] Don't migrate tables when initializing a new database

### DIFF
--- a/openerp/openupgrade/openupgrade_loading_90.py
+++ b/openerp/openupgrade/openupgrade_loading_90.py
@@ -23,14 +23,12 @@
 # This module provides simple tools for OpenUpgrade migration, specific for
 # the 8.0 -> 9.0 migration. It is kept in later editions to keep all the API
 # docs in the latest release.
+from openupgradelib.openupgrade_tools import table_exists, column_exists
 
 
 def migrate_model_tables(cr):
-    cr.execute("""SELECT 1 FROM information_schema.columns
-                  WHERE table_name='ir_model' AND column_name='transient'
-                  """)
-    found = cr.fetchone()
-    if not found:
+    if table_exists(cr, 'ir_model') and not column_exists(
+            cr, 'ir_model', 'transient'):
         # ir_model needs to be updated
         cr.execute("""ALTER TABLE ir_model
                       ADD COLUMN transient boolean


### PR DESCRIPTION
Fixes exception during database initialization caused by the attempt to inject the base_sql changes into the database.

```
Traceback (most recent call last):
  File "/home/buildout/ou90/parts/odoo/openerp/service/server.py", line 892, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "/home/buildout/ou90/parts/odoo/openerp/modules/registry.py", line 376, in new
    registry = Registry(db_name)
  File "/home/buildout/ou90/parts/odoo/openerp/modules/registry.py", line 71, in __init__
    openupgrade_loading_90.migrate_model_tables(cr)
  File "/home/buildout/ou90/parts/odoo/openerp/openupgrade/openupgrade_loading_90.py", line 37, in migrate_model_tables
    """)
  File "/home/buildout/ou90/parts/odoo/openerp/sql_db.py", line 141, in wrapper
    return f(self, *args, **kwargs)
  File "/home/buildout/ou90/parts/odoo/openerp/sql_db.py", line 220, in execute
    res = self._obj.execute(query, params)
ProgrammingError: relation "ir_model" does not exist
```

Depends on https://github.com/OCA/openupgradelib/pull/57
