### PR TITLE
9.0 account check printing

### DIFF
--- a/addons/account_check_printing/__openerp__.py
+++ b/addons/account_check_printing/__openerp__.py
@@ -10,7 +10,10 @@ It must be used as a dependency for modules that provide country-specific check 
 The check settings are located in the accounting journals configuration page.
     """,
     'website': 'https://www.odoo.com/page/accounting',
-    'depends' : ['account'],
+    'depends' : [
+        'account',
+        'account_voucher',  # Not for normal Odoo, but needed for migration
+    ],
     'data': [
         'data/check_printing.xml',
         'views/account_journal_dashboard_view.xml',

--- a/addons/account_check_printing/__openerp__.py
+++ b/addons/account_check_printing/__openerp__.py
@@ -8,6 +8,14 @@
 This module offers the basic functionalities to make payments by printing checks.
 It must be used as a dependency for modules that provide country-specific check templates.
 The check settings are located in the accounting journals configuration page.
+
+OpenUpgrade specific: we set account_voucher here as a dependency for
+account_check_printing. account_voucher was an actual dependency for
+account_check_writing in 8.0. Therefore, when upgrading this module, we can
+be sure account_voucher is also installed. But we have to make sure
+account_voucher is loaded before account_check_printing, because the migration
+of check information uses the results of account_voucher migration. To be
+specific: the account_payment records created by account_voucher migration.
     """,
     'website': 'https://www.odoo.com/page/accounting',
     'depends' : [

--- a/addons/account_check_printing/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_check_printing/migrations/9.0.1.0/post-migration.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# © 2016 Therp BV <http://therp.nl>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def update_payments_from_vouchers(env):
+    """Update account.payment rows from corresponding account.voucher rows."""
+    # Use the fact that id of migrated account_payment is id of original
+    # account_voucher.
+    # Do not set: check_number = av.number
+    # new check_number is integer value, av.number was text filled from
+    # sequence.
+    env.cr.execute(
+        """\
+        UPDATE account_payment ap
+        SET
+            check_amount_in_words = av.amount_in_word
+        FROM account_voucher av
+        WHERE ap.id = av.id
+        """
+    )
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    """Control function for account_voucher migration."""
+    update_payments_from_vouchers(env)

--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -53,7 +53,8 @@ def create_payments_from_vouchers(env):
         WHERE av.voucher_type IN ('receipt', 'payment')
         AND av.state in ('draft', 'posted')
         """,
-        (receipt_method.id, payment_method.id)
+        (receipt_method.id,
+         payment_method.id)
     )
     env.cr.execute(
         """SELECT COALESCE(MAX(id), 0) AS max_id FROM account_payment"""
@@ -85,16 +86,6 @@ def create_payments_from_vouchers(env):
     )
 
 
-def delete_payment_vouchers(env):
-    """Delete payment_vouchers. Info is now in account_payment."""
-    env.cr.execute(
-        """\
-        DELETE from account_voucher
-        WHERE voucher_type IN ('receipt', 'payment')
-        """
-    )
-
-
 def create_voucher_line_tax_lines(env):
     """Migrate tax information on voucher lines to m2m relation."""
     env.cr.execute(
@@ -110,5 +101,4 @@ def create_voucher_line_tax_lines(env):
 def migrate(env, version):
     """Control function for account_voucher migration."""
     create_payments_from_vouchers(env)
-    delete_payment_vouchers(env)
     create_voucher_line_tax_lines(env)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: migrate amount in words for check from account_voucher to account_payment

Current behavior before PR: check_amount_in_words is empty in migrated payment

Desired behavior after PR is merged: check_amount_in_words in payment is filled from migrated account_voucher row, field amount_in_words.

This branch builds on the branch to migrate account_voucher data
## 

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
