### PR TITLE
[IMP] don't autoinstall nonexisting modules

### DIFF
--- a/openerp/openupgrade/openupgrade_loading.py
+++ b/openerp/openupgrade/openupgrade_loading.py
@@ -27,6 +27,7 @@ from openerp import models
 from openerp.osv import fields
 from openupgradelib.openupgrade_tools import table_exists
 from openerp.tools import config, safe_eval
+from openerp.modules.module import get_module_path
 
 # A collection of functions used in
 # openerp/modules/loading.py
@@ -99,7 +100,10 @@ def add_module_dependencies(cr, module_list):
                 WHERE d.module_id = m.id
                 AND name NOT IN %s)
          """, (tuple(modules),))
-    auto_modules = [row[0] for row in cr.fetchall()]
+    auto_modules = [
+        row[0] for row in cr.fetchall()
+        if get_module_path(row[0])
+    ]
     if auto_modules:
         logger.info(
             "Selecting autoinstallable modules %s", ','.join(auto_modules))


### PR DESCRIPTION
without this, OpenUpgrade will try to install email_template for example, and whatever other junk records exist from previous versions
