### PR TITLE
[FIX] purchase: Fill currency_id with the related value from pricelist

### DIFF
--- a/addons/purchase/migrations/8.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/purchase/migrations/8.0.1.1/openupgrade_analysis_work.txt
@@ -7,9 +7,11 @@ purchase     / procurement.order        / purchase_line_id (many2one)   : NEW re
 purchase     / purchase.order.line      / procurement_ids (one2many)    : NEW relation: procurement.order
 # DONE: match procurements with purchase order lines based on stock move connection or product_id
 
+purchase     / purchase.order           / currency_id (many2one)        : not a function anymore
+# DONE: Fill currency_id from related pricelist
+
 purchase     / purchase.order           / bid_date (date)               : NEW
 purchase     / purchase.order           / bid_validity (date)           : NEW
-purchase     / purchase.order           / currency_id (many2one)        : not a function anymore
 purchase     / purchase.order           / date_order (date)             : type is now 'datetime' ('date')
 purchase     / purchase.order           / incoterm_id (many2one)        : NEW relation: stock.incoterms
 # NOTHING TO DO

--- a/addons/purchase/migrations/8.0.1.1/post-migration.py
+++ b/addons/purchase/migrations/8.0.1.1/post-migration.py
@@ -78,6 +78,21 @@ def create_workitem_picking(cr, uid, pool):
                 (wkf_activity, wkf_instance, 'complete',))
 
 
+def migrate_purchase_order(cr):
+    """Copy currency_id from pricelist, as the field was a related non-stored
+    one.
+    :param cr: Database cursor
+    """
+    openupgrade.logged_query(
+        cr, """
+            UPDATE purchase_order po
+            SET currency_id = pp.currency_id
+            FROM product_pricelist pp
+            WHERE pp.id = po.pricelist_id
+            AND pp.currency_id != po.currency_id
+        """)
+
+
 def migrate_product_supply_method(cr):
     """
     Procurements of products: change the supply_method for the matching route
@@ -191,6 +206,7 @@ def migrate_stock_warehouse(cr, pool):
 def migrate(cr, version):
     pool = pooler.get_pool(cr.dbname)
     create_workitem_picking(cr, uid, pool)
+    migrate_purchase_order(cr)
     migrate_product_supply_method(cr)
     migrate_procurement_order(cr)
     migrate_stock_warehouse(cr, pool)


### PR DESCRIPTION
As currency_id was in v7 a non stored related field, when passing to v8,
we lose the associated value, and thus, the default one is used. With
this patch, we restore it later the value expected taking it from the
related pricelist.