### PR TITLE
[9.0] product type stockable

### DIFF
--- a/addons/product/migrations/9.0.1.2/post-migration.py
+++ b/addons/product/migrations/9.0.1.2/post-migration.py
@@ -99,7 +99,7 @@ def update_product_template(cr):
     # product.product instead of product.template.
 
     cr.execute("""
-        SELECT id
+        SELECT imf.id
         FROM ir_model_fields as imf
         INNER JOIN ir_model as im
         ON imf.model_id = im.id

--- a/addons/product/migrations/9.0.1.2/post-migration.py
+++ b/addons/product/migrations/9.0.1.2/post-migration.py
@@ -146,6 +146,20 @@ def update_product_product(cr):
         """)
 
 
+def map_product_template_type(cr):
+    """ See comments in method map_product_template_type in the pre-migration
+    script."""
+    if not openupgrade.logged_query(cr, """
+        select id FROM product_template where {name_v8} = 'product'
+    """.format(name_v8=openupgrade.get_legacy_name('type'))):
+        return
+    openupgrade.map_values(
+        cr,
+        openupgrade.get_legacy_name('type'), 'type',
+        [('product', 'product')],
+        table='product_template', write='sql')
+
+
 @openupgrade.migrate()
 def migrate(cr, version):
     map_base(cr)
@@ -153,3 +167,4 @@ def migrate(cr, version):
     update_product_pricelist_item(cr)
     update_product_product(cr)
     update_product_template(cr)
+    map_product_template_type(cr)

--- a/addons/product/migrations/9.0.1.2/pre-migration.py
+++ b/addons/product/migrations/9.0.1.2/pre-migration.py
@@ -18,6 +18,24 @@ column_renames = {
     ],
 }
 
+column_copies = {
+    'product_template': [
+        ('type', None, None),
+    ],
+}
+
+
+def map_product_template_type(cr):
+    """ The product template type value 'stockable' is not an option in the
+    product module for v9. We need to assign a temporary 'dummy' value
+    until module stock is installed. In post-migration we will
+    restore the original value."""
+    openupgrade.map_values(
+        cr,
+        openupgrade.get_legacy_name('type'), 'type',
+        [('product', 'consu')],
+        table='account_tax', write='sql')
+
 
 @openupgrade.migrate()
 def migrate(cr, version):
@@ -83,3 +101,5 @@ def migrate(cr, version):
         """)
 
     cr.execute("update product_template set state=NULL where state=''")
+
+    map_product_template_type(cr)

--- a/addons/product/migrations/9.0.1.2/pre-migration.py
+++ b/addons/product/migrations/9.0.1.2/pre-migration.py
@@ -34,7 +34,7 @@ def map_product_template_type(cr):
         cr,
         openupgrade.get_legacy_name('type'), 'type',
         [('product', 'consu')],
-        table='account_tax', write='sql')
+        table='product_template', write='sql')
 
 
 @openupgrade.migrate()

--- a/addons/product/migrations/9.0.1.2/pre-migration.py
+++ b/addons/product/migrations/9.0.1.2/pre-migration.py
@@ -66,6 +66,7 @@ def migrate(cr, version):
         """)
 
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.copy_columns(cr, column_copies)
 
     # Add default value when it is null, as Product name / Package Logistic
     # Unit name

--- a/addons/stock/migrations/9.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/9.0.1.1/pre-migration.py
@@ -11,8 +11,7 @@ column_renames = {
     'product_template': [
         ('loc_case', None),
         ('loc_rack', None),
-        ('loc_row', None),
-        ('type', None),
+        ('loc_row', None)
     ],
     'stock_pack_operation': [
         ('cost', None),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Wrong migration of product type and standard cost.

Current behavior before PR:

When migrating from 8.0 to 9.0 a stockable product, with modules 'product' and 'stock' installed, the type 'stockable' becomes 'consumable'. The standard cost updated in v8 (e.g. 100) becomes 0 in v9.

Desired behavior after PR is merged:
When migrating from 8.0 to 9.0 a stockable product, with modules 'product' and 'stock' installed, the type 'stockable' is maintained. The standard cost updated in v8 (e.g. 100) is respected in v9.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
