### PR TITLE
[FIX] graph: Fix AttributeError

### DIFF
--- a/openerp/modules/graph.py
+++ b/openerp/modules/graph.py
@@ -90,7 +90,7 @@ class Graph(dict):
         forced_deps = tools.config.get_misc('openupgrade',
                                             'force_deps_' + release.version,
                                             forced_deps)
-        forced_deps = tools.safe_eval.safe_eval(forced_deps)
+        forced_deps = eval(forced_deps)
 
         for module in module_list:
             # This will raise an exception if no/unreadable descriptor file.


### PR DESCRIPTION
Fixes the following error:

```
Traceback (most recent call last):
  ...
  File "openupgrade/openerp/modules/graph.py", line 93, in add_modules
    forced_deps = tools.safe_eval.safe_eval(forced_deps)
AttributeError: 'function' object has no attribute 'safe_eval'
```