### PR TITLE
[9.0][IMP] openupgrade: apriori file. Rename account_payment_term_mul…

### DIFF
--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -28,7 +28,7 @@ renamed_modules = {
     'sale_product_variants': 'sale_variant_configurator',
     'sale_stock_product_variants': 'sale_stock_variant_configurator',
     'purchase_product_variants': 'purchase_variant_configurator',
-    # OCA/account-payment
+    # OCA/account-payment - Module merged in OCA/account-financial-tools
     'account_payment_term_multi_day': 'account_payment_term_extension',
 }
 

--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -28,6 +28,8 @@ renamed_modules = {
     'sale_product_variants': 'sale_variant_configurator',
     'sale_stock_product_variants': 'sale_stock_variant_configurator',
     'purchase_product_variants': 'purchase_variant_configurator',
+    # OCA/account-payment
+    'account_payment_term_multi_day': 'account_payment_term_extension',
 }
 
 renamed_models = {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Rename account_payment_term_multi_day to account_payment_term_extension in apriori.py file

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
cc @tecnativa