### PR TITLE
[IMP] delivery: Alternative migration

### DIFF
--- a/addons/delivery/migrations/9.0.1.0/post-migration.py
+++ b/addons/delivery/migrations/9.0.1.0/post-migration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # © 2016 Therp BV <http://therp.nl>
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openupgradelib import openupgrade
 
 
@@ -27,24 +29,20 @@ def rename_property(cr, model, old_name, new_name):
 @openupgrade.migrate()
 def migrate(cr, version):
     cr.execute(
-        "update delivery_price_rule r set carrier_id=g.carrier_id "
-        "from delivery_grid g where r.grid_id=g.id")
-    cr.execute(
-        "insert into delivery_carrier_country_rel (carrier_id, country_id) "
-        "select carrier_id, country_id from "
-        "delivery_grid_country_rel r join delivery_grid g on r.grid_id=g.id")
-    cr.execute(
-        "insert into delivery_carrier_state_rel (carrier_id, state_id) "
-        "select carrier_id, state_id from "
-        "delivery_grid_state_rel r join delivery_grid g on r.grid_id=g.id")
-    cr.execute(
-        "update delivery_carrier set delivery_type='base_on_rule' "
-        "where use_detailed_pricelist")
-    cr.execute(
-        "update delivery_carrier c set "
-        "zip_from=coalesce(c.zip_from, g.zip_from), "
-        "zip_to=coalesce(c.zip_to, g.zip_to) "
-        "from delivery_grid g where g.carrier_id=c.id")
+        """
+        UPDATE delivery_carrier dc
+        SET delivery_type='base_on_rule',
+            free_if_more_than = old_dc.free_if_more_than,
+            fixed_price = old_dc.normal_price
+        FROM %s old_dc
+        WHERE old_dc.use_detailed_pricelist
+            AND old_dc.id = dc.%s
+        """ % (
+            openupgrade.get_legacy_name('delivery_carrier'),
+            openupgrade.get_legacy_name('carrier_id'),
+        )
+    )
     rename_property(
         cr, 'res.partner', 'property_delivery_carrier',
-        'property_delivery_carrier_id')
+        'property_delivery_carrier_id',
+    )

--- a/addons/delivery/migrations/9.0.1.0/pre-migration.py
+++ b/addons/delivery/migrations/9.0.1.0/pre-migration.py
@@ -1,11 +1,24 @@
 # -*- coding: utf-8 -*-
 # © 2016 Therp BV <http://therp.nl>
+# Copyright 2016 Pedro M. Baeza <pedro.baeza@tecnativa.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openupgradelib import openupgrade
 
 column_renames = {
     'delivery_grid_line': [
         ('type', 'variable'),
+        ('grid_id', 'carrier_id'),
+        ('price_type', None),
+    ],
+    'delivery_grid': [
+        ('carrier_id', None),
+    ],
+    'delivery_grid_country_rel': [
+        ('grid_id', 'carrier_id'),
+    ],
+    'delivery_grid_state_rel': [
+        ('grid_id', 'carrier_id'),
     ],
 }
 
@@ -16,12 +29,62 @@ column_copies = {
 }
 
 table_renames = [
+    ('delivery_carrier', None),
+    ('delivery_grid', 'delivery_carrier'),
     ('delivery_grid_line', 'delivery_price_rule'),
+    ('delivery_grid_country_rel', 'delivery_carrier_country_rel'),
+    ('delivery_grid_state_rel', 'delivery_carrier_state_rel'),
 ]
+
+
+def correct_object_references(cr):
+    """Point sale order and stock picking to grid records (that will be
+    renamed as carrier objects)."""
+    openupgrade.lift_constraints(cr, 'sale_order', 'carrier_id')
+    openupgrade.logged_query(
+        cr, """
+        UPDATE sale_order so SET carrier_id = dg.id
+        FROM delivery_grid dg, delivery_carrier dc
+        WHERE dg.carrier_id = dc.id AND so.carrier_id = dc.id
+        """,
+    )
+    openupgrade.lift_constraints(cr, 'stock_picking', 'carrier_id')
+    openupgrade.logged_query(
+        cr, """
+        UPDATE stock_picking sp SET carrier_id = dg.id
+        FROM delivery_grid dg, delivery_carrier dc
+        WHERE dg.carrier_id = dc.id AND sp.carrier_id = dc.id
+        """,
+    )
+
+
+def correct_rule_prices(cr):
+    """Version 8 only allows to put a fixed or variable price, not both.
+    Now version 9 have a field for each option. We copy the value on both
+    fields and zero the field that doesn't correspond to the version in 8.
+    """
+    openupgrade.copy_columns(cr, column_copies)
+    cr.execute(
+        """
+        UPDATE delivery_grid_line
+        SET list_price = 0
+        WHERE {0} = 'fixed'
+        """.format(openupgrade.get_legacy_name('price_type'))
+    )
+    cr.execute(
+        """
+        UPDATE delivery_grid_line
+        SET list_base_price = 0
+        WHERE {0} = 'variable'
+        """.format(openupgrade.get_legacy_name('price_type'))
+    )
 
 
 @openupgrade.migrate()
 def migrate(cr, version):
+    correct_object_references(cr)
     openupgrade.rename_columns(cr, column_renames)
-    openupgrade.copy_columns(cr, column_copies)
+    correct_rule_prices(cr)
     openupgrade.rename_tables(cr, table_renames)
+    # TODO: if the same product is used for multiple carriers, duplicate it
+    # for having a correct structure of 1 product = 1 carrier


### PR DESCRIPTION
Renaming delivery_grid to delivery_carrier and taking this table as the main object, makes the operation cleaner, as the number of fields to copy, the numbers of records to insert and so on are less than with old approach.

This also allows to keep old delivery_carrier table for other modules that can take advantage of it, like *delivery_multi_destination*