### PR TITLE
[IMP] mail migrations: Avoid inserting orphan followers.

### DIFF
--- a/addons/mail/migrations/9.0.1.0/post-migration.py
+++ b/addons/mail/migrations/9.0.1.0/post-migration.py
@@ -28,7 +28,7 @@ def migrate(cr, version):
     cr.execute("""
     INSERT INTO mail_channel_partner (channel_id, partner_id)
     SELECT res_id, partner_id from mail_followers
-    WHERE res_model = 'mail.channel'
+    WHERE res_model = 'mail.channel' AND res_id IN (SELECT id FROM mail_channel);
     """)
     # notifications and stars are plain many2many fields by now
     cr.execute(


### PR DESCRIPTION
Since the mail_followers table does not have (can't have) a foreign key restriction, some followers may be subscribed to long gone mail_groups.  This kind of error does not show up in the application and may passed undetected to users.

However, when inserting the followers into channels the query fails with a non-existent channel.  This commit avoids the error and, nevertheless, there won't be a loss of information from the application's users viewpoint.