### PR TITLE
[ADD] email_template: Merged in mail

### DIFF
--- a/addons/mail/migrations/9.0.1.0/pre-migration.py
+++ b/addons/mail/migrations/9.0.1.0/pre-migration.py
@@ -22,6 +22,9 @@ column_renames = {
 
 @openupgrade.migrate()
 def migrate(cr, version):
+    openupgrade.update_module_names(
+        cr, [('email_template', 'mail')], merge_modules=True,
+    )
     openupgrade.rename_models(cr, model_renames)
     openupgrade.rename_tables(cr, table_renames)
     openupgrade.rename_columns(cr, column_renames)


### PR DESCRIPTION
With this, we avoid one dangled module when finishing the migration, and this helps also for relocating xml-ids, translations, and so on.