### PR TITLE
[9.0][account] conversion of invoice uos_id to uom_id

### DIFF
--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -18,6 +18,9 @@ column_renames = {
     'account_account': [
         ('type', None),
     ],
+    'account_invoice_line': [
+        ('uos_id', 'uom_id'),
+    ],
     'account_cashbox_line': [
         ('pieces', 'coin_value'),
         ('number_opening', None),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The invoice lines use uom_id in v9, instead of uos_id


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
