### PR TITLE
[ENH] Actually show time needed to actually recompute fields.

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5901,8 +5901,8 @@ class BaseModel(object):
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
             _logger.info(
-                "Actual recompute of field %s in model %s." %
-                (field.model_name, field)
+                "Actual recompute of field %s in model %s. for %d recs" %
+                (field.model_name, field, len(recs))
             )
             ns = [f.name for f in fs if f.store]
             # evaluate fields, and group record ids by update

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5900,6 +5900,10 @@ class BaseModel(object):
             field, recs = self.env.get_todo()
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
+            _logger.info(
+                "Actual recompute of field %s in model %s." %
+                (field.model_name, field)
+            )
             ns = [f.name for f in fs if f.store]
             # evaluate fields, and group record ids by update
             updates = defaultdict(set)

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5901,8 +5901,8 @@ class BaseModel(object):
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
             _logger.info(
-                "Actual recompute of field %s in model %s. for %d recs" %
-                (field.model_name, field, len(recs))
+                "Actual recompute of field %s for %d recs." %
+                (field, len(recs))
             )
             ns = [f.name for f in fs if f.store]
             # evaluate fields, and group record ids by update

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5900,10 +5900,12 @@ class BaseModel(object):
             field, recs = self.env.get_todo()
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
+            # OpenUpgrade start:
             _logger.info(
                 "Actual recompute of field %s for %d recs." %
                 (field, len(recs))
             )
+            # OpenUpgrade end
             ns = [f.name for f in fs if f.store]
             # evaluate fields, and group record ids by update
             updates = defaultdict(set)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When it takes a long time to recompute newly added computed or related fields, there is no real information on which fields take how much time.

Current behavior before PR: No information

Desired behavior after PR is merged: Migration log will show per recomputed field how much time recomputation actually took

This makes it possible for fields that take a long time to recompute to look for alternatives, like creating the fields beforehand and filling them with SQL. 
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
