### PR TITLE
[ADD] try to avoid using addresses with names as company address

### DIFF
--- a/openerp/addons/base/migrations/7.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/7.0.1.3/post-migration.py
@@ -359,8 +359,14 @@ This can be the case if an additional module installed on your database changes
 
     # Process all addresses, default type first
     process_address_type(cr, pool, fields.copy(), "type = 'default'")
+    # then try the ones without type and without name
     process_address_type(
-        cr, pool, fields.copy(), "(type IS NULL OR type = '')")
+        cr, pool, fields.copy(),
+        "(type IS NULL OR type = '') AND (name IS NULL OR name = '')")
+    # and only then just without type
+    process_address_type(
+        cr, pool, fields.copy(),
+        "(type IS NULL OR type = '') AND name <> ''")
     # Not in clause is very slow. we replace them by an ubptade on a new column
     set_address_processed(processed_ids)
     process_address_type(


### PR DESCRIPTION
the rationale here is that addresses with names might be contact persons, while we can be quite sure an address without a name has something to do with the company itself.