### PR TITLE
[FIX][9.0][point_of_sale] wrong table name 'pos.config'

### DIFF
--- a/addons/point_of_sale/migrations/9.0.1.0.1/pre-migration.py
+++ b/addons/point_of_sale/migrations/9.0.1.0.1/pre-migration.py
@@ -8,7 +8,7 @@ column_renames = {
     'account_journal': [
         ('self_checkout_payment_method', None),
     ],
-    'pos.config': [
+    'pos_config': [
         ('barcode_cashier', None),
         ('barcode_customer', None),
         ('barcode_discount', None),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Migrating a DB from v8 to v9 where module "point_of_sale" is installed, you get the following error:

`2017-01-10 11:59:41,921 9128 CRITICAL ao_odoo_20170109_v92 openerp.service.server: Failed to initialize database `ao_odoo_20170109_v92`.
Traceback (most recent call last):
  File "/opt/openupgrade92/parts/odoo9/openerp/service/server.py", line 892, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/registry.py", line 390, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 406, in load_modules
    force, status, report, loaded_modules, update_module, upg_registry)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 297, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks, upg_registry=upg_registry)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 137, in load_module_graph
    migrations.migrate_module(package, 'pre')
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/migration.py", line 160, in migrate_module
    mod.migrate(self.cr, pkg.installed_version)
  File "/opt/openupgrade92/openupgradelib/openupgradelib/openupgrade.py", line 1112, in wrapped_function
    version)
  File "/opt/openupgrade92/parts/odoo9/addons/point_of_sale/migrations/9.0.1.0.1/pre-migration.py", line 32, in migrate
    openupgrade.rename_columns(cr, column_renames)
  File "/opt/openupgrade92/openupgradelib/openupgradelib/openupgrade.py", line 332, in rename_columns
    'ALTER TABLE "%s" RENAME "%s" TO "%s"' % (table, old, new,))
  File "/opt/openupgrade92/parts/odoo9/openerp/sql_db.py", line 141, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/openupgrade92/parts/odoo9/openerp/sql_db.py", line 220, in execute
    res = self._obj.execute(query, params)
ProgrammingError: relation "pos.config" does not exist
`
Current behavior before PR:
Cannot proceed with migration.

Desired behavior after PR is merged:
The migration of POS is completed sucessfully.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
