### PR TITLE
[FIX][9.0][point_of_sale] error due to wrong assignment in 'update_barcodes_nomenclatures'

### DIFF
--- a/addons/point_of_sale/migrations/9.0.1.0.1/post-migration.py
+++ b/addons/point_of_sale/migrations/9.0.1.0.1/post-migration.py
@@ -22,7 +22,8 @@ def update_barcodes_nomenclatures(env):
     for pos_config in pos_configs:
         barcode_nomenclature = env['barcode.nomenclature'].create({
             'name': pos_config.name,
-            'upc_ean_conv': 'always'
+            'upc_ean_conv': 'always',
+            'rule_ids': [(6, 0, [1])]
         })
         old_barcode_product = openupgrade.get_legacy_name('barcode_product')
         old_barcode_cashier = openupgrade.get_legacy_name('barcode_cashier')

--- a/addons/point_of_sale/migrations/9.0.1.0.1/post-migration.py
+++ b/addons/point_of_sale/migrations/9.0.1.0.1/post-migration.py
@@ -22,8 +22,7 @@ def update_barcodes_nomenclatures(env):
     for pos_config in pos_configs:
         barcode_nomenclature = env['barcode.nomenclature'].create({
             'name': pos_config.name,
-            'upc_ean_conv': 'always',
-            'rule_ids': 1,
+            'upc_ean_conv': 'always'
         })
         old_barcode_product = openupgrade.get_legacy_name('barcode_product')
         old_barcode_cashier = openupgrade.get_legacy_name('barcode_cashier')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fixes bug in the post-migration script of 'point_of_sale'.

`2017-01-10 18:00:22,781 19687 CRITICAL ao_odoo_20170109_v92 openerp.service.server: Failed to initialize database `ao_odoo_20170109_v92`.
Traceback (most recent call last):
  File "/opt/openupgrade92/parts/odoo9/openerp/service/server.py", line 892, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/registry.py", line 390, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 406, in load_modules
    force, status, report, loaded_modules, update_module, upg_registry)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 297, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks, upg_registry=upg_registry)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 189, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/migration.py", line 160, in migrate_module
    mod.migrate(self.cr, pkg.installed_version)
  File "/opt/openupgrade92/openupgradelib/openupgradelib/openupgrade.py", line 1112, in wrapped_function
    version)
  File "/opt/openupgrade92/parts/odoo9/addons/point_of_sale/migrations/9.0.1.0.1/post-migration.py", line 62, in migrate
    update_barcodes_nomenclatures(env)
  File "/opt/openupgrade92/parts/odoo9/addons/point_of_sale/migrations/9.0.1.0.1/post-migration.py", line 26, in update_barcodes_nomenclatures
    'rule_ids': 1,
  File "/opt/openupgrade92/parts/odoo9/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/openupgrade92/parts/connector-telephony9/base_phone/fields.py", line 134, in create
    return original_create(self, vals)
  File "/opt/openupgrade92/parts/odoo9/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/openupgrade92/parts/odoo9/openerp/models.py", line 4199, in create
    record = self.browse(self._create(old_vals))
  File "/opt/openupgrade92/parts/odoo9/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/openupgrade92/parts/odoo9/openerp/api.py", line 490, in new_api
    result = method(self._model, cr, uid, *args, **old_kwargs)
  File "/opt/openupgrade92/parts/odoo9/openerp/models.py", line 4390, in _create
    result += self._columns[field].set(cr, self, id_new, field, vals[field], user, rel_context) or []
  File "/opt/openupgrade92/parts/odoo9/openerp/osv/fields.py", line 852, in set
    for act in values:
TypeError: 'int' object is not iterable`

Current behavior before PR:
Error breaks the migration.

Desired behavior after PR is merged:

point_of_sale module migrates successfully.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
