### PR TITLE
[FIX] project: Create analytic lines from task works if needed

### DIFF
--- a/addons/project/migrations/9.0.1.1/pre-migration.py
+++ b/addons/project/migrations/9.0.1.1/pre-migration.py
@@ -78,7 +78,7 @@ def migrate(cr, version):
     openupgrade.rename_tables(cr, table_renames)
     openupgrade.rename_columns(cr, column_renames)
     openupgrade.rename_xmlids(cr, xmlid_renames)
-    if not openupgrade.is_module_installed('project_timesheet'):
+    if not openupgrade.is_module_installed(cr, 'project_timesheet'):
         recreate_analytic_lines(cr)
     cr.execute(
         '''update ir_module_module set state='to install'


### PR DESCRIPTION
If the module project_timesheet is not installed, we need to convert
project.task.work elements, or we will lose this history.

This is done inserting new records in account_analytic_line, and
adding one extra column work_id in case other modules need to
add more elements for each converted line.