### PR TITLE
[WIP][ENH] Easy way to prevent unneeded field recomputation.

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5902,16 +5902,17 @@ class BaseModel(object):
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
             # OpenUpgrade start:
-            blacklist = recs[0]._openupgrade_recompute_fields_blacklist
-            field_key = '%s' % field
-            model_name, field_name = field_key.rsplit('.', 1)
-            if field_name in blacklist:
-                _logger.info(
-                    "Recompute of field %s for %d recs blacklisted." %
-                    (field_key, len(recs))
-                )
-                map(recs._recompute_done, fs)
-                continue
+            if recs:
+                blacklist = recs[0]._openupgrade_recompute_fields_blacklist
+                field_key = '%s' % field
+                model_name, field_name = field_key.rsplit('.', 1)
+                if field_name in blacklist:
+                    _logger.info(
+                        "Recompute of field %s for %d recs blacklisted." %
+                        (field_key, len(recs))
+                    )
+                    map(recs._recompute_done, fs)
+                    continue
             _logger.info(
                 "Actual recompute of field %s for %d recs." %
                 (field_key, len(recs))

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -342,6 +342,7 @@ class BaseModel(object):
 
     _table = None
     _sql_constraints = []
+    _openupgrade_recompute_fields_blacklist = []
 
     # model dependencies, for models backed up by sql views:
     # {model_name: field_names, ...}
@@ -5901,9 +5902,19 @@ class BaseModel(object):
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
             # OpenUpgrade start:
+            blacklist = recs[0]._openupgrade_recompute_fields_blacklist
+            field_key = '%s' % field
+            model_name, field_name = field_key.rsplit('.', 1)
+            if field_name in blacklist:
+                _logger.info(
+                    "Recompute of field %s for %d recs blacklisted." %
+                    (field_key, len(recs))
+                )
+                map(recs._recompute_done, fs)
+                continue
             _logger.info(
                 "Actual recompute of field %s for %d recs." %
-                (field, len(recs))
+                (field_key, len(recs))
             )
             # OpenUpgrade end
             ns = [f.name for f in fs if f.store]

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5897,6 +5897,9 @@ class BaseModel(object):
         """ Recompute stored function fields. The fields and records to
             recompute have been determined by method :meth:`modified`.
         """
+        # OpenUpgrade start:
+        openupgrade_models_with_blacklist = {}
+        # OpenUpgrade end
         while self.env.has_todo():
             field, recs = self.env.get_todo()
             # determine the fields to recompute
@@ -5911,6 +5914,7 @@ class BaseModel(object):
                     (field_key, len(recs))
                 )
                 map(recs._recompute_done, fs)
+                openupgrade_models_with_blacklist[model_name] = recs[0]
                 continue
             _logger.info(
                 "Actual recompute of field %s for %d recs." %
@@ -5929,6 +5933,10 @@ class BaseModel(object):
                     recs.browse(ids)._write(dict(vals))
             # mark computed fields as done
             map(recs._recompute_done, fs)
+        # OpenUpgrade start, reset blacklists:
+        for model_obj in openupgrade_models_with_blacklist.itervalues():
+            model_obj._openupgrade_recompute_fields_blacklist = []
+        # OpenUpgrade end
 
     #
     # Generic onchange method

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5897,9 +5897,6 @@ class BaseModel(object):
         """ Recompute stored function fields. The fields and records to
             recompute have been determined by method :meth:`modified`.
         """
-        # OpenUpgrade start:
-        openupgrade_models_with_blacklist = {}
-        # OpenUpgrade end
         while self.env.has_todo():
             field, recs = self.env.get_todo()
             # determine the fields to recompute
@@ -5914,7 +5911,6 @@ class BaseModel(object):
                     (field_key, len(recs))
                 )
                 map(recs._recompute_done, fs)
-                openupgrade_models_with_blacklist[model_name] = recs[0]
                 continue
             _logger.info(
                 "Actual recompute of field %s for %d recs." %
@@ -5933,10 +5929,6 @@ class BaseModel(object):
                     recs.browse(ids)._write(dict(vals))
             # mark computed fields as done
             map(recs._recompute_done, fs)
-        # OpenUpgrade start, reset blacklists:
-        for model_obj in openupgrade_models_with_blacklist.itervalues():
-            model_obj._openupgrade_recompute_fields_blacklist = []
-        # OpenUpgrade end
 
     #
     # Generic onchange method

--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5902,9 +5902,9 @@ class BaseModel(object):
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
             # OpenUpgrade start:
+            field_key = '%s' % field
             if recs:
                 blacklist = recs[0]._openupgrade_recompute_fields_blacklist
-                field_key = '%s' % field
                 model_name, field_name = field_key.rsplit('.', 1)
                 if field_name in blacklist:
                     _logger.info(

--- a/openerp/modules/module.py
+++ b/openerp/modules/module.py
@@ -315,6 +315,14 @@ def init_module_models(cr, module_name, obj_list):
         openerp.models.BaseModel.step_workflow = lambda *args, **kwargs: None
         # end OpenUpgrade
         obj_list[0].recompute(cr, openerp.SUPERUSER_ID, {})
+        # OpenUpgrade start, reset blacklists:
+        for obj in obj_list:
+            if obj._openupgrade_recompute_fields_blacklist:
+                obj._openupgrade_recompute_fields_blacklist = []
+                _logger.info(
+                    "Blacklist reset for model %s." % obj._name
+                )
+        # OpenUpgrade end
         # OpenUpgrade: reenable workflow triggers
         openerp.models.BaseModel.step_workflow = set_workflow_org
         # end OpenUpgrade


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Recomputation of fields can take a long time, which is problematic when those fields will be filled with the correct values anyway.

Current behavior before PR: Only way to prevent long running unneeded computations was to create fields through SQL, which has the danger of not all attributes taken into account (like indexes) etc. Also takes a lot of code.

Desired behavior after PR is merged: It will be easy to supress feld recompute.

Example use:
```
def blacklist_field_recomputation(env):                                        
    from openerp.addons.account.models.account_invoice import AccountInvoice
    AccountInvoice._openupgrade_recompute_fields_blacklist = [
        'payment_move_line_ids',
        'price_subtotal_signed',
    ]


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
