### PR TITLE
[FIX] website: Set as updateable website main entry

### DIFF
--- a/addons/website/migrations/9.0.1.0/pre-migration.py
+++ b/addons/website/migrations/9.0.1.0/pre-migration.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    # Change noupdate flag for ir.ui.menu entry
+    env.ref('website.menu_website').noupdate = False


### PR DESCRIPTION
In Odoo v8, the website main entry is flagged as noupdate=1, and
this causes that changes made in v9 (action and web_icon), are not
updated and thus is hidden in migrated instance.

cc @Tecnativa