### PR TITLE
[FIX] delete the renamed channel rule

### DIFF
--- a/addons/mail/migrations/9.0.1.0/post-migration.py
+++ b/addons/mail/migrations/9.0.1.0/post-migration.py
@@ -41,8 +41,3 @@ def migrate(cr, version):
         '(mail_message_id, res_partner_id) '
         'select distinct message_id, partner_id from mail_notification '
         'where starred')
-    # with this, the rule and the xmlid will be cleaned up at the end of
-    # the migration
-    cr.execute(
-        'update ir_model_data set noupdate=False where '
-        "module='mail' and name='mail_group_public_and_joined'")

--- a/addons/mail/migrations/9.0.1.0/post-migration.py
+++ b/addons/mail/migrations/9.0.1.0/post-migration.py
@@ -41,3 +41,8 @@ def migrate(cr, version):
         '(mail_message_id, res_partner_id) '
         'select distinct message_id, partner_id from mail_notification '
         'where starred')
+    # with this, the rule and the xmlid will be cleaned up at the end of
+    # the migration
+    cr.execute(
+        'update ir_model_data set noupdate=False where '
+        "module='mail' and name='mail_group_public_and_joined'")

--- a/addons/mail/migrations/9.0.1.0/pre-migration.py
+++ b/addons/mail/migrations/9.0.1.0/pre-migration.py
@@ -28,3 +28,8 @@ def migrate(cr, version):
     openupgrade.rename_models(cr, model_renames)
     openupgrade.rename_tables(cr, table_renames)
     openupgrade.rename_columns(cr, column_renames)
+    # with this, the rule and the xmlid will be cleaned up at the end of
+    # the migration
+    cr.execute(
+        'update ir_model_data set noupdate=False where '
+        "module='mail' and name='mail_group_public_and_joined'")


### PR DESCRIPTION
the problem is that this rule won't be touched by the migration because it's noupdate, and it will cause access errors when trying to use mail channels afterwards.
Alternative would be to rename the xmlid to the new one, and clean out the noupdate flag, but I don't see the advantage of this. Manual changes will be gone in any case.