### PR TITLE
[9.0][product] migrate pricelist_partnerinfo

### DIFF
--- a/addons/product/migrations/9.0.1.2/post-migration.py
+++ b/addons/product/migrations/9.0.1.2/post-migration.py
@@ -193,9 +193,9 @@ def update_product_supplierinfo(env):
         psi.sequence, ppi.min_quantity, ppi.price,  psi.product_tmpl_id,
         psi.delay, psi.company_id
         FROM product_supplierinfo AS psi
-        INNER JOIN %s AS ppi
+        INNER JOIN pricelist_partnerinfo AS ppi
         ON ppi.suppinfo_id = psi.id
-    """ % openupgrade.get_legacy_name('pricelist_partnerinfo'))
+    """)
     to_delete_ids = []
     for id, name, product_name, product_code, sequence, min_quantity, price, \
             product_tmpl_id, delay, company_id in env.cr.fetchall():

--- a/addons/product/migrations/9.0.1.2/post-migration.py
+++ b/addons/product/migrations/9.0.1.2/post-migration.py
@@ -219,10 +219,11 @@ def update_product_supplierinfo(env):
                 'company_id': company_id,
                 'currency_id': currency_id
         })
-    env.cr.execute("""
-        DELETE FROM product_supplierinfo
-        WHERE id IN %s
-    """, (tuple(to_delete_ids),))
+    if to_delete_ids:
+        env.cr.execute("""
+            DELETE FROM product_supplierinfo
+            WHERE id IN %s
+        """, (tuple(to_delete_ids),))
 
 
 @openupgrade.migrate(use_env=True)

--- a/addons/product/migrations/9.0.1.2/post-migration.py
+++ b/addons/product/migrations/9.0.1.2/post-migration.py
@@ -186,6 +186,45 @@ def map_product_template_type(cr):
         table='product_template', write='sql')
 
 
+def update_product_supplierinfo(env):
+
+    env.cr.execute("""
+        SELECT psi.id, psi.name, psi.product_name, psi.product_code,
+        psi.sequence, ppi.min_quantity, ppi.price,  psi.product_tmpl_id,
+        psi.delay, psi.company_id
+        FROM product_supplierinfo AS psi
+        INNER JOIN %s AS ppi
+        ON ppi.suppinfo_id = psi.id
+    """ % openupgrade.get_legacy_name('pricelist_partnerinfo'))
+    to_delete_ids = []
+    for id, name, product_name, product_code, sequence, min_quantity, price, \
+            product_tmpl_id, delay, company_id in env.cr.fetchall():
+        to_delete_ids.append(id)
+        env.cr.execute("""
+            SELECT currency_id
+            FROM res_company
+            WHERE id = %s
+        """ % company_id)
+        currency_id = env.cr.fetchall()[0]
+
+        env['product.supplierinfo'].create({
+                'name': name,
+                'product_name': product_name,
+                'product_code': product_code,
+                'sequence': sequence,
+                'min_qty': min_quantity,
+                'price': price,
+                'product_tmpl_id': product_tmpl_id,
+                'delay': delay,
+                'company_id': company_id,
+                'currency_id': currency_id
+        })
+    env.cr.execute("""
+        DELETE FROM product_supplierinfo
+        WHERE id IN %s
+    """, (tuple(to_delete_ids),))
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     map_base(env.cr)
@@ -199,3 +238,4 @@ def migrate(env, version):
         'update product_pricelist_item set price_discount=-price_discount*100'
     )
     openupgrade_90.convert_binary_field_to_attachment(env, attachment_fields)
+    update_product_supplierinfo(env)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The data stored in pricelist_partnerinfo is not being migrated to v9. This PR migrates it into the product_supplierinfo

v8:
![image](https://cloud.githubusercontent.com/assets/7683926/22188708/f51b0b5a-e0d4-11e6-98f6-77b7f7a565e7.png)


v9 (after migration):
![image](https://cloud.githubusercontent.com/assets/7683926/22188718/05769f32-e0d5-11e6-92ec-80643fd68d52.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
