### PR TITLE
[7.0] Model openupgrade.record inherited from itself

### DIFF
--- a/openerp/addons/openupgrade_records/model/openupgrade_record.py
+++ b/openerp/addons/openupgrade_records/model/openupgrade_record.py
@@ -52,7 +52,7 @@ class openupgrade_attribute(Model):
 
 
 class openupgrade_record(Model):
-    _inherit = 'openupgrade.record'
+    _name = 'openupgrade.record'
 
     _columns = {
         'name': fields.char('Name', size=256, readonly=True),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Model `openupgrade.record` was using `_inherit` where it meant `_name`

Current behavior before PR:

Module openupgrade_records wasn't installable, failed with: TypeError: The model "openupgrade.record" specifies an unexisting parent class "openupgrade.record"
You may need to add a dependency on the parent class' module.

Desired behavior after PR is merged:

Module openupgrade_records is installable.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
