### PR TITLE
[9.0][hr_expense] - Only recompute hr.expense records when needed

### DIFF
--- a/addons/hr_expense/migrations/9.0.2.0/post-migration.py
+++ b/addons/hr_expense/migrations/9.0.2.0/post-migration.py
@@ -65,8 +65,9 @@ def hr_expense(env):
                 FROM hr_expense where id = %(b)s
             """ % {'a': p, 'b': expense})
     expenses = env['hr.expense'].search([])
-    env.add_todo(env['hr.expense']._fields['total_amount'], expenses)
-    env['hr.expense'].recompute()
+    if expenses:
+        env.add_todo(env['hr.expense']._fields['total_amount'], expenses)
+        env['hr.expense'].recompute()
 
 
 @openupgrade.migrate(use_env=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Will only recompute hr.expense records when needed

Current behavior before PR:
The recompute method is always called. We found that when used together with #663 , if there were no hr.expense records to recompute, it would lead to errors like:
```
2017-02-01 16:32:27,338 22254 CRITICAL ao_odoo_20170109_v921 openerp.service.server: Failed to initialize database `ao_odoo_20170109_v921`.
Traceback (most recent call last):
  File "/opt/openupgrade92/parts/odoo9/openerp/service/server.py", line 892, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/registry.py", line 390, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 406, in load_modules
    force, status, report, loaded_modules, update_module, upg_registry)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 297, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks, upg_registry=upg_registry)
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/loading.py", line 189, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/opt/openupgrade92/parts/odoo9/openerp/modules/migration.py", line 160, in migrate_module
    mod.migrate(self.cr, pkg.installed_version)
  File "/opt/openupgrade92/openupgradelib/openupgradelib/openupgrade.py", line 1112, in wrapped_function
    version)
  File "/opt/openupgrade92/parts/odoo9/addons/hr_expense/migrations/9.0.2.0/post-migration.py", line 75, in migrate
    hr_expense(env)
  File "/opt/openupgrade92/parts/odoo9/addons/hr_expense/migrations/9.0.2.0/post-migration.py", line 69, in hr_expense
    env['hr.expense'].recompute()
  File "/opt/openupgrade92/parts/odoo9/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "/opt/openupgrade92/parts/odoo9/openerp/models.py", line 5905, in recompute
    blacklist = recs[0]._openupgrade_recompute_fields_blacklist
  File "/opt/openupgrade92/parts/odoo9/openerp/models.py", line 5799, in __getitem__
    return self._browse(self.env, (self._ids[key],))
IndexError: tuple index out of range

```

Desired behavior after PR is merged:
The migration using PR #663 completes successfully

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
