### PR TITLE
9.0 issue 744 voucher payment invoice link

### DIFF
--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -76,6 +76,17 @@ def create_payments_from_vouchers(env):
         AND av.state in ('draft', 'posted')
         """
     )
+    # Also recreate link from invoice to payment
+    env.cr.execute(
+        """\
+        INSERT INTO account_invoice_payment_rel (payment_id, invoice_id)
+        SELECT aml.payment_id, ai.id
+        FROM account_move_line aml
+        JOIN account_invoice ai ON aml.move_id = ai.move_id
+        WHERE NOT aml.payment_id IS NULL
+        GROUP BY aml.payment_id, ai.id
+        """
+    )
 
 
 def create_voucher_line_tax_lines(env):

--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -71,9 +71,10 @@ def create_payments_from_vouchers(env):
         SET payment_id = av.id
         FROM account_voucher_line avl
         JOIN account_voucher av ON av.id = avl.voucher_id
-        WHERE avl.move_line_id=aml.id
+        WHERE avl.move_line_id = aml.id
         AND av.voucher_type IN ('receipt', 'payment')
-        AND av.state in ('draft', 'posted')
+        AND av.state IN ('draft', 'posted')
+        AND avl.reconcile
         """
     )
     # Also recreate link from invoice to payment

--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -67,6 +67,12 @@ def create_payments_from_vouchers(env):
     # Statement below works because new payments have same id as old vouchers
     env.cr.execute(
         """\
+        WITH Q1 AS (
+            SELECT av.id as av_id, aml.id as aml_id
+            FROM account_move_line aml
+            INNER JOIN account_move am ON am.id = aml.move_id
+            INNER JOIN account_voucher av ON av.move_id = am.id
+        )
         UPDATE account_move_line aml
         SET payment_id = av.id
         FROM account_voucher_line avl
@@ -74,7 +80,21 @@ def create_payments_from_vouchers(env):
         WHERE avl.move_line_id = aml.id
         AND av.voucher_type IN ('receipt', 'payment')
         AND av.state IN ('draft', 'posted')
-        AND avl.reconcile
+        AND (aml.id IN (
+                SELECT credit_move_id
+                FROM account_partial_reconcile
+                WHERE debit_move_id IN (
+                    SELECT aml_id FROM Q1 WHERE av_id = av.id
+                )
+            ) OR
+            aml.id IN (
+                SELECT debit_move_id
+                FROM account_partial_reconcile
+                WHERE credit_move_id IN (
+                    SELECT aml_id FROM Q1 WHERE av_id = av.id
+                )
+            )
+        )
         """
     )
     # Also recreate link from invoice to payment


### PR DESCRIPTION
Description of the issue/feature this PR addresses: https://github.com/OCA/OpenUpgrade/issues/744

Current behavior before PR: After migration links between invoices and payments are lost

Desired behavior after PR is merged: Link between payments and invoices restored
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
