### PR TITLE
[FIX] rename renamed xmlids for account types

### DIFF
--- a/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
@@ -652,32 +652,35 @@ DEL account.account.template: account.conf_ovr
 DEL account.account.template: account.conf_rev
 DEL account.account.template: account.conf_stk
 DEL account.account.template: account.conf_xfa
+
+# map renamed xmlids
+DEL account.account.type: account.conf_account_type_equity
+NEW account.account.type: account.data_account_type_equity
+DEL account.account.type: account.data_account_type_income
+NEW account.account.type: account.data_account_type_revenue
+DEL account.account.type: account.data_account_type_bank
+NEW account.account.type: account.data_account_type_liquidity
+
 NEW account.account.type: account.data_account_type_current_assets
 NEW account.account.type: account.data_account_type_current_liabilities
 NEW account.account.type: account.data_account_type_depreciation
 NEW account.account.type: account.data_account_type_direct_costs
-NEW account.account.type: account.data_account_type_equity
 NEW account.account.type: account.data_account_type_expenses
 NEW account.account.type: account.data_account_type_fixed_assets
-NEW account.account.type: account.data_account_type_liquidity
 NEW account.account.type: account.data_account_type_non_current_assets
 NEW account.account.type: account.data_account_type_non_current_liabilities
 NEW account.account.type: account.data_account_type_other_income
 NEW account.account.type: account.data_account_type_prepayments
-NEW account.account.type: account.data_account_type_revenue
 NEW account.account.type: account.data_unaffected_earnings
 DEL account.account.type: account.account_type_asset_view1
 DEL account.account.type: account.account_type_expense_view1
 DEL account.account.type: account.account_type_income_view1
 DEL account.account.type: account.account_type_liability_view1
 DEL account.account.type: account.conf_account_type_chk
-DEL account.account.type: account.conf_account_type_equity
 DEL account.account.type: account.conf_account_type_tax
 DEL account.account.type: account.data_account_type_asset
-DEL account.account.type: account.data_account_type_bank
 DEL account.account.type: account.data_account_type_cash
 DEL account.account.type: account.data_account_type_expense
-DEL account.account.type: account.data_account_type_income
 DEL account.account.type: account.data_account_type_liability
 DEL account.account.type: account.data_account_type_view
 DEL account.analytic.journal: account.analytic_journal_sale

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -47,6 +47,12 @@ table_renames = [
     ('account_statement_operation_template', 'account_operation_template'),
     ('account_tax_code', 'account_tax_group')]
 
+xmlid_renames = [
+    ('account.conf_account_type_equity', 'account.data_account_type_equity'), 
+    ('account.data_account_type_income', 'account.data_account_type_revenue'),
+    ('account.data_account_type_bank', 'account.data_account_type_liquidity'),
+]
+
 PROPERTY_FIELDS = {
     ('product.category', 'property_account_expense_categ',
      'property_account_expense_categ_id'),
@@ -174,6 +180,7 @@ def migrate(cr, version):
     )
     openupgrade.rename_tables(cr, table_renames)
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_xmlids(cr, xmlid_renames)
     openupgrade.copy_columns(cr, column_copies)
     migrate_properties(cr)
     install_account_tax_python(cr)


### PR DESCRIPTION
we missed renaming the xmlids of account types, this way it looks to the user like they were duplicated and it's a pita to clean this up manually.

I only do renames where the equivalences were obvious to me, so if I missed something, I'd appreciate a pointer