### PR TITLE
[9.0][account_check_printing] migrate the payment method for check printing

### DIFF
--- a/addons/account_check_printing/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_check_printing/migrations/9.0.1.0/post-migration.py
@@ -23,7 +23,8 @@ def update_payments_from_vouchers(env):
     check_method = env.ref(
         'account_check_printing.account_payment_method_check')
 
-    if openupgrade.column_exists(cr, 'account_journal', 'allow_check_writing'):
+    if openupgrade.column_exists(
+            env.cr, 'account_journal', 'allow_check_writing'):
         env.cr.execute(
             """\
             UPDATE account_payment ap

--- a/addons/account_check_printing/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_check_printing/migrations/9.0.1.0/post-migration.py
@@ -23,11 +23,7 @@ def update_payments_from_vouchers(env):
     check_method = env.ref(
         'account_check_printing.account_payment_method_check')
 
-    env.cr.execute("""SELECT column_name
-        FROM information_schema.columns
-        WHERE table_name='account_journal' AND
-        column_name='allow_check_writing'""")
-    if env.cr.fetchone():
+    if openupgrade.column_exists(cr, 'account_journal', 'allow_check_writing'):
         env.cr.execute(
             """\
             UPDATE account_payment ap


### PR DESCRIPTION
The payments that were created in 8.0 associated to journals that were related to check printing should have as payment method 'allow_check_writing'. Now they are being set to 'manual'

![image](https://cloud.githubusercontent.com/assets/7683926/23797107/82e67d0a-059e-11e7-84f3-10c88d0c11a7.png)
