### PR TITLE
[9.0][purchase] double validation

### DIFF
--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -73,14 +73,8 @@ def pre_create_po_double_validation(cr, env):
     po_double_validation_amount = 5000.0
     if double_validation_transition:
         po_double_validation = 'two_step'
-        condition = False
-        if double_validation_transition.condition.find('>=') >= 0:
-            condition = '>='
-        elif double_validation_transition.condition.find('>=') >= 0:
-            condition = '<'
-        if condition:
-            po_double_validation_amount = (
-                double_validation_transition.condition.split(condition, 1)[1])
+        po_double_validation_amount = (
+            double_validation_transition.condition.split('>=', 1)[1])
     else:
         po_double_validation = 'one_step'
 

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -46,7 +46,7 @@ def pre_create_po_double_validation(cr, env):
         cr.execute(
             """
             ALTER TABLE res_company ADD COLUMN po_double_validation
-            boolean;
+            character varying;
             COMMENT ON COLUMN res_company.po_double_validation IS
             'Levels of Approvals';
             """)

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -65,7 +65,7 @@ def pre_create_po_double_validation(cr, env):
             'Double validation amount';
             """)
 
-    double_validation_transition = env['ir.model.data'].ref(
+    double_validation_transition = env.ref(
         'purchase_double_validation.trans_confirmed_double_gt')
     po_double_validation_amount = 5000.0
     if double_validation_transition:

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -31,7 +31,66 @@ def map_order_state(cr):
         WHERE l.order_id = o.id""")
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+def pre_create_po_double_validation(cr, env):
+    """ In v8 when you install the module 'purchase_double_validation'
+    the po workflow is altered to put conditions to change the po status to
+    waiting approval if a condition is met. In v9 this is handled without
+    workflow."""
+
+    cr.execute("""SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name='res_company' AND
+    column_name='po_double_validation'""")
+
+    if not cr.fetchone():
+        cr.execute(
+            """
+            ALTER TABLE res_company ADD COLUMN po_double_validation
+            boolean;
+            COMMENT ON COLUMN res_company.po_double_validation IS
+            'Levels of Approvals';
+            """)
+
+    cr.execute("""SELECT column_name
+    FROM information_schema.columns
+    WHERE table_name='res_company' AND
+    column_name='po_double_validation_amount'""")
+
+    if not cr.fetchone():
+        cr.execute(
+            """
+            ALTER TABLE res_company ADD COLUMN po_double_validation_amount
+            float;
+            COMMENT ON COLUMN res_company.po_double_validation_amount IS
+            'Double validation amount';
+            """)
+
+    double_validation_transition = env['ir.model.data'].ref(
+        'purchase_double_validation.trans_confirmed_double_gt')
+    po_double_validation_amount = 5000.0
+    if double_validation_transition:
+        po_double_validation = 'two_step'
+        condition = False
+        if double_validation_transition.condition.find('>=') >= 0:
+            condition = '>='
+        elif double_validation_transition.condition.find('>=') >= 0:
+            condition = '<'
+        if condition:
+            po_double_validation_amount = (
+                double_validation_transition.condition.split(condition, 1)[1])
+    else:
+        po_double_validation = 'one_step'
+
+    cr.execute("""
+        UPDATE res_company
+        SET po_double_validation = %s,
+            po_double_validation_amount = %s
+    """ % (po_double_validation, po_double_validation_amount))
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.copy_columns(cr, column_copies)
     map_order_state(cr)
+    pre_create_po_double_validation(cr, env)

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -65,8 +65,11 @@ def pre_create_po_double_validation(cr, env):
             'Double validation amount';
             """)
 
-    double_validation_transition = env.ref(
-        'purchase_double_validation.trans_confirmed_double_gt')
+    try:
+        double_validation_transition = env.ref(
+            'purchase_double_validation.trans_confirmed_double_gt')
+    except ValueError:
+        double_validation_transition = False
     po_double_validation_amount = 5000.0
     if double_validation_transition:
         po_double_validation = 'two_step'

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -83,7 +83,7 @@ def pre_create_po_double_validation(cr, env):
 
     cr.execute("""
         UPDATE res_company
-        SET po_double_validation = %s,
+        SET po_double_validation = '%s',
             po_double_validation_amount = %s
     """ % (po_double_validation, po_double_validation_amount))
 

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -31,19 +31,19 @@ def map_order_state(cr):
         WHERE l.order_id = o.id""")
 
 
-def pre_create_po_double_validation(cr, env):
+def pre_create_po_double_validation(env):
     """ In v8 when you install the module 'purchase_double_validation'
     the po workflow is altered to put conditions to change the po status to
     waiting approval if a condition is met. In v9 this is handled without
     workflow."""
 
-    cr.execute("""SELECT column_name
+    env.cr.execute("""SELECT column_name
     FROM information_schema.columns
     WHERE table_name='res_company' AND
     column_name='po_double_validation'""")
 
-    if not cr.fetchone():
-        cr.execute(
+    if not env.cr.fetchone():
+        env.cr.execute(
             """
             ALTER TABLE res_company ADD COLUMN po_double_validation
             character varying;
@@ -51,13 +51,13 @@ def pre_create_po_double_validation(cr, env):
             'Levels of Approvals';
             """)
 
-    cr.execute("""SELECT column_name
+    env.cr.execute("""SELECT column_name
     FROM information_schema.columns
     WHERE table_name='res_company' AND
     column_name='po_double_validation_amount'""")
 
-    if not cr.fetchone():
-        cr.execute(
+    if not env.cr.fetchone():
+        env.cr.execute(
             """
             ALTER TABLE res_company ADD COLUMN po_double_validation_amount
             float;
@@ -78,7 +78,7 @@ def pre_create_po_double_validation(cr, env):
     else:
         po_double_validation = 'one_step'
 
-    cr.execute("""
+    env.cr.execute("""
         UPDATE res_company
         SET po_double_validation = '%s',
             po_double_validation_amount = %s
@@ -90,4 +90,4 @@ def migrate(env, version):
     cr = env.cr
     openupgrade.copy_columns(cr, column_copies)
     map_order_state(cr)
-    pre_create_po_double_validation(cr, env)
+    pre_create_po_double_validation(env)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
In v8 the module 'purchase_double_validation' allows you to change the PO approval workflow and set a limit by which PO's will change to state 'Waiting Approval'.

As of v9 this logic has been integrated into the 'purchase' module.

Current behavior before PR:
If you migrate a DB where module 'purchase_double_validation' is installed, the migrated database assumes that you are not doing a double validation.

Desired behavior after PR is merged:
If you migrate a DB where module 'purchase_double_validation' is installed, the migrated database assumes that you are doing a double validation, and keeps the same validation threshold.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
