### PR TITLE
[IMP] Add openerp-client-lib to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ wsgiref==0.1.2
 XlsxWriter==0.7.7
 xlwt==0.7.5
 openupgradelib>=1.2.0
+openerp-client-lib==1.1.2


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If the environment is created from requirements.txt, this library
wasn't installed and it prevented the OpenUpgrade Records addon
from being installed

Current behavior before PR:
OpenUpgrade Records failed to install.

Desired behavior after PR is merged:
Creating an environment from requirements.txt allows installation
of OpenUpgrade Records.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
