### PR TITLE
Fix for older versions of openupgrade where default isn't env

### DIFF
--- a/addons/base_setup/migrations/10.0.1.0/pre-migration.py
+++ b/addons/base_setup/migrations/10.0.1.0/pre-migration.py
@@ -10,6 +10,6 @@ _xmlid_renames = [
 ]
 
 
-@openupgrade.migrate()
+@openupgrade.migrate(use_env=True)
 def migrate(env, version):
     openupgrade.rename_xmlids(env.cr, _xmlid_renames)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

explictly writing use_env for those instances still running openupgradelib without  https://github.com/OCA/openupgradelib/pull/69