### PR TITLE
[FIX] mail: Remove noupdate ir.rule

### DIFF
--- a/addons/mail/migrations/9.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/mail/migrations/9.0.1.0/openupgrade_analysis_work.txt
@@ -100,6 +100,9 @@ mail         / res.users                / display_groups_suggestions (boolean): 
 # Nothing to do
 
 ---XML records in module 'mail'---
+DEL ir.rule: mail.mail_group_public_and_joined
+# Done: Remove rule as it's a noupdate record that is not automatically removed
+
 NEW ir.actions.act_window: mail.action_contacts
 NEW ir.actions.act_window: mail.action_email_template_tree_all
 NEW ir.actions.act_window: mail.action_view_mail_tracking_value
@@ -148,7 +151,6 @@ DEL ir.model.access: mail.access_mail_notification_user
 NEW ir.rule: mail.mail_channel_rule
 NEW ir.rule: mail.mail_message_subtype_rule_public
 DEL ir.rule: mail.mail_followers_read_write_others
-DEL ir.rule: mail.mail_group_public_and_joined
 DEL ir.rule: mail.mail_notification_read_write_own
 NEW ir.ui.menu: mail.mail_channel_menu_root_chat
 NEW ir.ui.menu: mail.mail_channel_menu_settings

--- a/addons/mail/migrations/9.0.1.0/pre-migration.py
+++ b/addons/mail/migrations/9.0.1.0/pre-migration.py
@@ -20,11 +20,14 @@ column_renames = {
 }
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
     openupgrade.update_module_names(
-        cr, [('email_template', 'mail')], merge_modules=True,
+        env.cr, [('email_template', 'mail')], merge_modules=True,
     )
-    openupgrade.rename_models(cr, model_renames)
-    openupgrade.rename_tables(cr, table_renames)
-    openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_models(env.cr, model_renames)
+    openupgrade.rename_tables(env.cr, table_renames)
+    openupgrade.rename_columns(env.cr, column_renames)
+    # Remove noupdate ir.rule
+    rule = env.ref('mail.mail_group_public_and_joined')
+    rule.unlink()


### PR DESCRIPTION
There's an ir.rule that has noupdate flag in its XML-ID entry, making that on migrated DBs, is not removed by default, and thus, there are access errors.

cc @Tecnativa