### PR TITLE
[9.0][FIX] Change the query that links the account move lines with the pay…

### DIFF
--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -67,34 +67,19 @@ def create_payments_from_vouchers(env):
     # Statement below works because new payments have same id as old vouchers
     env.cr.execute(
         """\
-        WITH Q1 AS (
-            SELECT av.id as av_id, aml.id as aml_id
-            FROM account_move_line aml
-            INNER JOIN account_move am ON am.id = aml.move_id
-            INNER JOIN account_voucher av ON av.move_id = am.id
-        )
-        UPDATE account_move_line aml
+        UPDATE account_move_line aml2
         SET payment_id = av.id
-        FROM account_voucher_line avl
-        JOIN account_voucher av ON av.id = avl.voucher_id
-        WHERE avl.move_line_id = aml.id
-        AND av.voucher_type IN ('receipt', 'payment')
-        AND av.state IN ('draft', 'posted')
-        AND (aml.id IN (
-                SELECT credit_move_id
-                FROM account_partial_reconcile
-                WHERE debit_move_id IN (
-                    SELECT aml_id FROM Q1 WHERE av_id = av.id
-                )
-            ) OR
-            aml.id IN (
-                SELECT debit_move_id
-                FROM account_partial_reconcile
-                WHERE credit_move_id IN (
-                    SELECT aml_id FROM Q1 WHERE av_id = av.id
-                )
-            )
-        )
+        FROM account_voucher av
+        JOIN account_move am
+        ON am.id = av.move_id
+        JOIN account_move_line aml
+        ON am.id = aml.move_id
+        WHERE av.voucher_type IN ('receipt', 'payment')
+        AND (av.writeoff_acc_id != aml.account_id 
+             OR av.writeoff_acc_id IS NULL)
+        AND av.state in ('draft', 'posted')
+        AND aml.id = aml2.id        
+        
         """
     )
     # Also recreate link from invoice to payment

--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -75,11 +75,10 @@ def create_payments_from_vouchers(env):
         JOIN account_move_line aml
         ON am.id = aml.move_id
         WHERE av.voucher_type IN ('receipt', 'payment')
-        AND (av.writeoff_acc_id != aml.account_id 
+        AND (av.writeoff_acc_id != aml.account_id
              OR av.writeoff_acc_id IS NULL)
         AND av.state in ('draft', 'posted')
-        AND aml.id = aml2.id        
-        
+        AND aml.id = aml2.id
         """
     )
     # Also recreate link from invoice to payment


### PR DESCRIPTION
The prior approach was adding to the move lines of the invoice that was being paid the payment_id (Originator payment). This does not make sense. 

The field "Originator payment" in account move lines is intended to be used as the link that relates the move lines to the payment that originated them.

See: 
https://github.com/odoo/odoo/blob/9.0/addons/account/models/account_payment.py#L511
https://github.com/odoo/odoo/blob/9.0/addons/account/models/account_payment.py#L521


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
