### PR TITLE
[DEL] no placeholders, files will be merged from older branches by

### DIFF
--- a/odoo/openupgrade/doc/source/modules50-60.rst
+++ b/odoo/openupgrade/doc/source/modules50-60.rst
@@ -1,4 +1,0 @@
-Module coverage 5.0 -> 6.0
-==========================
-
-This is a placeholder for the aggregated documentation published at https://doc.therp.nl/openupgrade/modules50-60.html

--- a/odoo/openupgrade/doc/source/modules60-61.rst
+++ b/odoo/openupgrade/doc/source/modules60-61.rst
@@ -1,4 +1,0 @@
-Module coverage 6.0 -> 6.1
-==========================
-
-This is a placeholder for the aggregated documentation published at https://doc.therp.nl/openupgrade/modules60-61.html

--- a/odoo/openupgrade/doc/source/modules61-70.rst
+++ b/odoo/openupgrade/doc/source/modules61-70.rst
@@ -1,4 +1,0 @@
-Module coverage 6.1 -> 7.0
-==========================
-
-This is a placeholder for the aggregated documentation published at https://doc.therp.nl/openupgrade/modules61-70.html

--- a/odoo/openupgrade/doc/source/modules70-80.rst
+++ b/odoo/openupgrade/doc/source/modules70-80.rst
@@ -1,4 +1,0 @@
-Module coverage 7.0 -> 8.0
-==========================
-
-This is a placeholder for the aggregated documentation published at https://doc.therp.nl/openupgrade/modules70-80.html

--- a/odoo/openupgrade/doc/source/modules80-90.rst
+++ b/odoo/openupgrade/doc/source/modules80-90.rst
@@ -1,4 +1,0 @@
-Module coverage 8.0 -> 9.0
-==========================
-
-This is a placeholder for the aggregated documentation published at https://doc.therp.nl/openupgrade/modules80-90.html


### PR DESCRIPTION
build_openupgrade_docs
Fixes #807

@StefanRijnhart what was your rationale for 283ea545d15351b4aa33b84e5315a7f2a0e179dc? The build script copies the folder from every branch in ascending order, so the last version of some file wins. We need this to be able to update the documentation, but then we can't overwrite module coverage files because we need the latest version from the branch it originates from: https://github.com/OCA/OpenUpgrade/blob/10.0/scripts/build_openupgrade_docs#L26