### PR TITLE
[9.0][account_voucher] Fixes migration of memo field in payments from vouchers

### DIFF
--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -28,7 +28,7 @@ def create_payments_from_vouchers(env):
             name, amount, payment_type, payment_reference
         )
         SELECT
-            av.id, av.create_date, av.comment, av.company_id,
+            av.id, av.create_date, COALESCE(av.name, av.comment), av.company_id,
             av.payment_rate_currency_id, av.partner_id,
             CASE
                WHEN av.voucher_type = 'receipt' THEN 'customer'


### PR DESCRIPTION
in 8.0 the field 'memo' of the voucher is stored in the field 'name'. In v9 the field 'memo' is stored in the field 'communication'. Prior to this the memos in payments in v9 showed the content in field 'comment' of the voucher, which often contained something meaningless like 'write-off'. 