### PR TITLE
[9.0] Small fixes for migrations

### DIFF
--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -119,7 +119,8 @@ def remove_account_moves_from_special_periods(cr):
         AND fiscalyear_id = (SELECT id FROM account_fiscalyear
         ORDER BY date_start ASC LIMIT 1) ORDER BY date_start ASC LIMIT 1
     """)
-    first_nsp_id = cr.fetchone()[0] or False
+    first_nsp_id = cr.fetchone()
+    first_nsp_id = first_nsp_id and first_nsp_id[0]
 
     if first_nsp_id and move_ids:
         openupgrade.logged_query(cr, """

--- a/addons/project/migrations/9.0.1.1/pre-migration.py
+++ b/addons/project/migrations/9.0.1.1/pre-migration.py
@@ -49,7 +49,10 @@ def recreate_analytic_lines(cr):
     """
     cr.execute("ALTER TABLE account_analytic_line ADD task_id integer")
     cr.execute("ALTER TABLE account_analytic_line ADD work_id integer")
-    cr.execute("ALTER TABLE account_analytic_line ADD is_timesheet boolean")
+    if not openupgrade.column_exists(cr, 'account_analytic_line',
+                                     'is_timesheet'):
+        cr.execute(
+            "ALTER TABLE account_analytic_line ADD is_timesheet boolean")
     # TODO: Calculate line cost according employee data
     openupgrade.logged_query(
         cr,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Fixes our case when the first fiscal year of the database has no periods
- Fixes #750 when is_timesheet is already in database before migration

Current behavior before PR:

- Migration crashes when one of the two above cases is met.

Desired behavior after PR is merged:

- Migration passes for the two cases above


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
