### PR TITLE
Rename account_analytic_plan_required

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -3,6 +3,8 @@ to help the matching process
 """
 
 renamed_modules = {
+    # OCA/account-analytic
+    'account_analytic_plan_required': 'account_analytic_distribution_required',
 }
 
 renamed_models = {


### PR DESCRIPTION
Module  account_analytic_plan_required is renamed to account_analytic_distribution_required

cc @Tecnativa
