### PR TITLE
[10.0][FIX] base_action_rule: otherwise env don't have cr

### DIFF
--- a/addons/base_action_rule/migrations/10.0.1.0/pre-migration.py
+++ b/addons/base_action_rule/migrations/10.0.1.0/pre-migration.py
@@ -5,7 +5,7 @@
 from openupgradelib import openupgrade
 
 
-@openupgrade.migrate()
+@openupgrade.migrate(use_env=True)
 def migrate(env, version):
     env.cr.execute(
         """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
 
after having migrated db from 9.0 to 10.0 , I get the following error trying to login in it:

```
2017-05-29 14:21:24,343 6387 INFO odoo9_openupgrade_migrated OpenUpgrade: base_action_rule: pre-migration script called with version 9.0.1.0
2017-05-29 14:21:24,343 6387 ERROR odoo9_openupgrade_migrated OpenUpgrade: base_action_rule: error in migration script /home/tafaru/dev/envs/buildout/demo10-community/parts/OpenUpgrade/addons/base_action_rule/migrations/10.0.1.0/pre-migration.py: 'psycopg2._psycopg.cursor' object has no attribute 'cr'
2017-05-29 14:21:24,343 6387 ERROR odoo9_openupgrade_migrated OpenUpgrade: 'psycopg2._psycopg.cursor' object has no attribute 'cr'
Traceback (most recent call last):
  File "/home/tafaru/dev/envs/buildout/demo10-community/eggs/openupgradelib-1.2.0-py2.7.egg/openupgradelib/openupgrade.py", line 1086, in wrapped_function
    version)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/OpenUpgrade/addons/base_action_rule/migrations/10.0.1.0/pre-migration.py", line 10, in migrate
    env.cr.execute(
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/sql_db.py", line 141, in wrapper
    return f(self, *args, **kwargs)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/sql_db.py", line 410, in __getattr__
    return getattr(self._obj, name)
AttributeError: 'psycopg2._psycopg.cursor' object has no attribute 'cr'
2017-05-29 14:21:24,344 6387 ERROR odoo9_openupgrade_migrated odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/modules/registry.py", line 82, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/modules/loading.py", line 335, in load_modules
    force, status, report, loaded_modules, update_module)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/modules/loading.py", line 237, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/modules/loading.py", line 121, in load_module_graph
    migrations.migrate_module(package, 'pre')
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/modules/migration.py", line 156, in migrate_module
    migrate(self.cr, pkg.installed_version)
  File "/home/tafaru/dev/envs/buildout/demo10-community/eggs/openupgradelib-1.2.0-py2.7.egg/openupgradelib/openupgrade.py", line 1086, in wrapped_function
    version)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/OpenUpgrade/addons/base_action_rule/migrations/10.0.1.0/pre-migration.py", line 10, in migrate
    env.cr.execute(
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/sql_db.py", line 141, in wrapper
    return f(self, *args, **kwargs)
  File "/home/tafaru/dev/envs/buildout/demo10-community/parts/odoo/odoo/sql_db.py", line 410, in __getattr__
    return getattr(self._obj, name)
AttributeError: 'psycopg2._psycopg.cursor' object has no attribute 'cr'
```


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
