### PR TITLE
[10.0][FIX] Call cursor in _drop_column()

### DIFF
--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -436,7 +436,7 @@ class IrModelFields(models.Model):
                 continue
             # OpenUpgrade: do not drop columns
             openupgrade.message(
-                cr, 'Unknown', False, False,
+                self._cr, 'Unknown', False, False,
                 "Not dropping the column of field %s of model %s", field.name, field.model)
             continue
             model = self.env[field.model]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When the `_drop_column()` method of `ir.model` is executed, an error is raised.

Current behavior before PR:
Cursor is invoked as "old api" stile and an error is raised.

Desired behavior after PR is merged:
The `_drop_column()` method is executed without any error.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
