### PR TITLE
[IMP] Drop website_event_register_free[_with_sale]

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
@@ -81,6 +81,9 @@ def cleanup_modules(cr):
             ('sale_order_back2draft', 'sale'),
             # from OCA/bank-payment
             ('account_payment_sale_stock', 'account_payment_sale'),
+            # from OCA/website
+            ('website_event_register_free', 'website_event'),
+            ('website_event_register_free_with_sale', 'website_event_sale'),
         ], merge_modules=True,
     )
 


### PR DESCRIPTION
Simple migration to remove remainders of these addons that are no longer needed.

See https://github.com/OCA/website/commit/bbbb3dd9012398a7f09161d561515640cb5d1207

@Tecnativa