### PR TITLE
[9.0] openupgradelib requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ jcconv==0.2.3
 lxml==3.4.1
 mock==1.0.1
 ofxparse==0.14
+openerp-client-lib==1.1.2
 passlib==1.6.2
 psutil==2.2.0
 psycogreen==1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,4 @@ vatnumber==1.2
 vobject==0.6.6
 wsgiref==0.1.2
 xlwt==0.7.5
-openupgradelib>=1.1.0
+openupgradelib>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ setup(
         'mako',
         'mock',
         'ofxparse',
+        'openupgradelib>=1.3.0',
         'passlib',
         'pillow',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'psutil',  # windows binary code.google.com/p/psutil/downloads/list

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ setup(
         'mako',
         'mock',
         'ofxparse',
+        'openerp-client-lib==1.1.2',
         'openupgradelib>=1.3.0',
         'passlib',
         'pillow',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/


### PR DESCRIPTION
Current behavior before PR: Starting a pip installed OpenUpgrade server fails because it misses openupgradelib

Desired behavior after PR is merged: pip installed openupgrade server runs OOTB.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
