### PR TITLE
[10.0] openupgradelib requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ script:
     - pip install -q -r requirements.txt
     # this crashes if there is no test data
     - if [ -s ../test_data90.yml ]; then ./openerp-server --database=$DB --test-file=`readlink -f ../test_data90.yml` --test-commit --stop-after-init; fi
-    # Line below may fail occasionaly due to Travis bug:
+    # Line below may fail quite often due to Travis bug:
     - git reset -q --hard $TRAVIS_COMMIT
     # Install Python requirements of target release
     - pip install -q -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ vatnumber==1.2
 vobject==0.9.3
 Werkzeug==0.11.11
 wsgiref==0.1.2
-openupgradelib>=1.2.0
+openupgradelib>=1.3.0
 XlsxWriter==0.9.3
 xlwt==1.1.2
 xlrd==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ ofxparse==0.15
 passlib==1.6.5
 Pillow==3.4.1
 psutil==4.3.1
+openerp-client-lib==1.1.2
 psycogreen==1.0
 psycopg2==2.6.2
 pydot==1.2.3

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ setup(
         'mako',
         'mock',
         'ofxparse',
+        'openerp-client-lib==1.1.2',
         'openupgradelib>=1.3.0',
         'passlib',
         'pillow',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/

--- a/setup.py
+++ b/setup.py
@@ -145,6 +145,7 @@ setup(
         'mako',
         'mock',
         'ofxparse',
+        'openupgradelib>=1.3.0',
         'passlib',
         'pillow',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'psutil',  # windows binary code.google.com/p/psutil/downloads/list


### PR DESCRIPTION
Current behavior before PR: Pip installed version of OpenUpgrade server does not run, because of missing openupgradelib

Desired behavior after PR is merged: Pip installed OpenUpgrade server runs correctly

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
