### PR TITLE
[10.0][MIG] web: Nothing to do

### DIFF
--- a/addons/web/migrations/10.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/web/migrations/10.0.1.0/openupgrade_analysis_work.txt
@@ -1,0 +1,8 @@
+---Fields in module 'web'---
+---XML records in module 'web'---
+NEW ir.ui.view: web.assets_frontend
+NEW ir.ui.view: web.less_helpers
+NEW ir.ui.view: web.pdf_js_lib
+NEW ir.ui.view: web.webclient_script
+DEL ir.ui.view: web.bootstrap
+# NOTHING TO DO


### PR DESCRIPTION
Added `openupgrade_analysis.txt` and set the `Nothing to do` flag.

I assume someone already went through this module, because the 'Nothing to do' in the documentation was/is already set.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
