### PR TITLE
[FIX] crm: remove rename phonecall_id

### DIFF
--- a/addons/crm/migrations/9.0.1.0/pre-migration.py
+++ b/addons/crm/migrations/9.0.1.0/pre-migration.py
@@ -25,9 +25,6 @@ column_renames = {
     'section_stage_rel': [
         ('section_id', 'team_id'),
     ],
-    'calendar_event': [
-        ('phonecall_id', None),
-    ],
 }
 
 column_copys = {


### PR DESCRIPTION
Now it's not necessary.

cc @Tecnativa
