### PR TITLE
[FIX] compare_noupdate_xml_records: Don't fail when there's no id on <record>

### DIFF
--- a/scripts/compare_noupdate_xml_records.py
+++ b/scripts/compare_noupdate_xml_records.py
@@ -79,6 +79,8 @@ def get_records(addon_dir):
         record_nodes = data_node.xpath("./record")
         for record in record_nodes:
             xml_id = record.get("id")
+            if not xml_id:
+                continue
             if '.' in xml_id and xml_id.startswith(addon_name + '.'):
                 xml_id = xml_id[len(addon_name) + 1:]
             for records in records_noupdate, records_update:


### PR DESCRIPTION
Example: https://github.com/OCA/OpenUpgrade/blob/43eacb6066ba96e01bc05de6e9dc25d7c67c3fd7/addons/website/data/data.xml#L110