### PR TITLE
[FIX] [9.0] models: Fix blacklisting of fields when `recs` is false.

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -5902,9 +5902,9 @@ class BaseModel(object):
             # determine the fields to recompute
             fs = self.env[field.model_name]._field_computed[field]
             # OpenUpgrade start:
+            field_key = '%s' % field
             if recs:
                 blacklist = recs[0]._openupgrade_recompute_fields_blacklist
-                field_key = '%s' % field
                 model_name, field_name = field_key.rsplit('.', 1)
                 if field_name in blacklist:
                     _logger.info(


### PR DESCRIPTION
After merger ac6ee71861b you may get an UnboundLocalError:

```
Traceback (most recent call last):
  File "openupgrade/openerp/service/server.py", line 892, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "openupgrade/openerp/modules/registry.py", line 390, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "openupgrade/openerp/modules/loading.py", line 406, in load_modules
    force, status, report, loaded_modules, update_module, upg_registry)
  File "openupgrade/openerp/modules/loading.py", line 297, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks, upg_registry=upg_registry)
  File "openupgrade/openerp/modules/loading.py", line 189, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "openupgrade/openerp/modules/migration.py", line 160, in migrate_module
    mod.migrate(self.cr, pkg.installed_version)
  File "/home/manu/.buildout/eggs/openupgradelib-1.3.0-py2.7.egg/openupgradelib/openupgrade.py", line 1182, in wrapped_function
    if use_env2 else cr, version)
  File "/home/manu/src/merchise/pgi/openupgrade/addons/hr_expense/migrations/9.0.2.0/post-migration.py", line 75, in migrate
    hr_expense(env)
  File "/home/manu/src/merchise/pgi/openupgrade/addons/hr_expense/migrations/9.0.2.0/post-migration.py", line 69, in hr_expense
    env['hr.expense'].recompute()
  File "openupgrade/openerp/api.py", line 248, in wrapper
    return new_api(self, *args, **kwargs)
  File "openupgrade/openerp/models.py", line 5918, in recompute
    (field_key, len(recs))
UnboundLocalError: local variable 'field_key' referenced before assignment
```