### PR TITLE
[9.0] [FIX] Be safer while creating property_purchase_currency_id from the purchase pricelist

### DIFF
--- a/addons/purchase/migrations/9.0.1.2/post-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/post-migration.py
@@ -26,10 +26,12 @@ def set_dummy_product(env):
 
 def pricelist_property(cr, env):
     # Created res.currency properties from Purchase Pricelist
-    property_rec = env['ir.property'].\
-        search([('name', '=', 'property_product_pricelist_purchase'),
-                '|', ('res_id', 'like', 'res.partner%'), ('res_id', '=',
-                                                          False)])
+    property_rec = env['ir.property'].search(
+        [('name', '=', 'property_product_pricelist_purchase'),
+         '|',
+         ('res_id', 'like', 'res.partner%'),
+         ('res_id', '=', False)]
+    )
     pricelist = []
     partner = []
     currency = []
@@ -41,6 +43,11 @@ def pricelist_property(cr, env):
             pricelist_id = int(pricelist_id)
             currency_rec = env['product.pricelist'].\
                 search_read([('id', 'in', [pricelist_id])], ['currency_id'])
+            if not currency_rec:
+                # Some DB may have incorrect pricelist ids in this
+                # property.  It seems that some old bug left ir.properties
+                # when pricelists where deleted.
+                continue
             currency.append(currency_rec[0]['currency_id'][0])
             pricelist.append(pricelist_id)
             if res_partner:


### PR DESCRIPTION
Avoid getting IndexError if the pricelist in the `property_product_pricelist_purchase` is missing:

```
Traceback (most recent call last):
  File "openupgrade/openerp/service/server.py", line 988, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "openupgrade/openerp/modules/registry.py", line 390, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "openupgrade/openerp/modules/loading.py", line 408, in load_modules
    force, status, report, loaded_modules, update_module, upg_registry)
  File "openupgrade/openerp/modules/loading.py", line 299, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks, upg_registry=upg_registry)
  File "openupgrade/openerp/modules/loading.py", line 189, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "openupgrade/openerp/modules/migration.py", line 169, in migrate_module
    mod.migrate(self.cr, pkg.installed_version)
  File "/home/manu/.buildout/eggs/openupgradelib-1.3.0-py2.7.egg/openupgradelib/openupgrade.py", line 1182, in wrapped_function
    if use_env2 else cr, version)
  File "/home/manu/src/merchise/pgi/openupgrade/addons/purchase/migrations/9.0.1.2/post-migration.py", line 92, in migrate
    pricelist_property(cr, env)
  File "/home/manu/src/merchise/pgi/openupgrade/addons/purchase/migrations/9.0.1.2/post-migration.py", line 44, in pricelist_property
    currency.append(currency_rec[0]['currency_id'][0])
IndexError: list index out of range
```

### Sidenote

The cause of why there are such properties in the DB I'm migrating are still under investigation.  The code of `unlink` does take care of removing ir_properties.