### PR TITLE
[9.0] More account speed ups

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -450,17 +450,19 @@ def fill_blacklisted_fields(cr):
             SELECT
                 ail.id,
                 ail.price_subtotal,
-                CASE
+                (CASE
                     WHEN ai.type IN ('in_refund', 'out_refund')
                     THEN ROUND(-ail.price_subtotal * er.effective_rate, 2)
                     ELSE ROUND(ail.price_subtotal  * er.effective_rate, 2)
-                END
+                END) AS price_subtotal_signed,
+                ai.currency_id AS currency_id
             FROM account_invoice_line ail
             JOIN account_invoice ai ON ail.invoice_id = ai.id
             JOIN effective_rates er ON ai.id = er.invoice_id
         )
         UPDATE account_invoice_line
-        SET price_subtotal_signed = subquery.price_subtotal_signed
+        SET price_subtotal_signed = subquery.price_subtotal_signed,
+            currency_id = subquery.currency_id
         FROM subquery
         WHERE account_invoice_line.id = subquery.id
         """

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -208,6 +208,7 @@ def blacklist_field_recomputation(env):
     ]
     AccountInvoiceLine._openupgrade_recompute_fields_blacklist = [
         'price_subtotal_signed',
+        'currency_id',
     ]
 
 

--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -2,6 +2,8 @@
 # © 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+from openerp.addons.account_voucher.account_voucher import \
+    account_voucher_line
 
 
 def create_payments_from_vouchers(env):
@@ -110,3 +112,11 @@ def migrate(env, version):
     """Control function for account_voucher migration."""
     create_payments_from_vouchers(env)
     create_voucher_line_tax_lines(env)
+
+    if 'price_subtotal' in account_voucher_line._openupgrade_recompute_fields_blacklist:
+        # This means we have no taxes and we can update the price_subtotal
+        # quite simply.
+        openupgrade.logged_query(
+            env.cr,
+            'UPDATE account_voucher_line SET price_subtotal = quantity * price_unit'
+        )

--- a/addons/account_voucher/migrations/9.0.1.0/pre-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/pre-migration.py
@@ -2,6 +2,11 @@
 # © 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+from openerp.addons.account_voucher.account_voucher import \
+    account_voucher_line
+
+account_voucher_line._openupgrade_recompute_fields_blacklist = []
+
 
 column_copies = {
     'account_voucher': [
@@ -26,3 +31,15 @@ def migrate(cr, version):
     cr.execute("update account_voucher_line set name='/' where name is null")
     openupgrade.copy_columns(cr, column_copies)
     delete_payment_views(cr)
+
+    cr.execute('SELECT count(*) FROM account_voucher WHERE tax_id IS NOT NULL')
+    taxed_vouchers = cr.fetchone()[0]
+    if not taxed_vouchers:
+        # If you have a DB where all account vouchers have no tax applied (we
+        # do), the new field price_subtotal can be computed from price_unit
+        # (amount) and quantity (1).
+        #
+        # See the post migration script to have the full idea.
+        account_voucher_line._openupgrade_recompute_fields_blacklist.append(
+            'price_subtotal'
+        )


### PR DESCRIPTION
Copy the `currency_id` in invoice lines from the parent invoice.   It's a related field anyways.  For DBs with many invoice lines this saves a lot of time.

Compute the voucher line `price_subtotal` via SQL, only when all the vouchers have no taxes.