### PR TITLE
[9.0] Speed up computation of voucher lines price_subtotal when voucher has no taxes.

### DIFF
--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -2,6 +2,8 @@
 # © 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+from openerp.addons.account_voucher.account_voucher import \
+    account_voucher_line
 
 
 def create_payments_from_vouchers(env):
@@ -110,3 +112,11 @@ def migrate(env, version):
     """Control function for account_voucher migration."""
     create_payments_from_vouchers(env)
     create_voucher_line_tax_lines(env)
+
+    if 'price_subtotal' in account_voucher_line._openupgrade_recompute_fields_blacklist:
+        # This means we have no taxes and we can update the price_subtotal
+        # quite simply.
+        openupgrade.logged_query(
+            env.cr,
+            'UPDATE account_voucher_line SET price_subtotal = quantity * price_unit'
+        )

--- a/addons/account_voucher/migrations/9.0.1.0/pre-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/pre-migration.py
@@ -2,6 +2,11 @@
 # © 2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+from openerp.addons.account_voucher.account_voucher import \
+    account_voucher_line
+
+account_voucher_line._openupgrade_recompute_fields_blacklist = []
+
 
 column_copies = {
     'account_voucher': [
@@ -26,3 +31,15 @@ def migrate(cr, version):
     cr.execute("update account_voucher_line set name='/' where name is null")
     openupgrade.copy_columns(cr, column_copies)
     delete_payment_views(cr)
+
+    cr.execute('SELECT count(*) FROM account_voucher WHERE tax_id IS NOT NULL')
+    taxed_vouchers = cr.fetchone()[0]
+    if not taxed_vouchers:
+        # If you have a DB where all account vouchers have no tax applied (we
+        # do), the new field price_subtotal can be computed from price_unit
+        # (amount) and quantity (1).
+        #
+        # See the post migration script to have the full idea.
+        account_voucher_line._openupgrade_recompute_fields_blacklist.append(
+            'price_subtotal'
+        )


### PR DESCRIPTION
`price_subtotal` can be simply computed by `quantity * price_unit` when the voucher line has no taxes.  The ``tax_ids`` field is a new M2M relation that we simply copy from the parent voucher's ``tax_id``.  So we may see that if there's no voucher with a ``tax_id`` we can blacklist the `price_subtotal` and fill it with the simpler formula.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
