### PR TITLE
[9.0][FIX]account voucher. Delete inherited views first

### DIFF
--- a/addons/account_voucher/migrations/9.0.1.0/pre-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/pre-migration.py
@@ -15,6 +15,13 @@ def delete_payment_views(cr):
     cr.execute(
         """\
         DELETE FROM ir_ui_view
+        WHERE inherit_id in (
+        SELECT id FROM ir_ui_view WHERE name like '%account.voucher.payment%')
+        """
+    )
+    cr.execute(
+        """\
+        DELETE FROM ir_ui_view
         WHERE name like '%account.voucher.payment%'
         """
     )


### PR DESCRIPTION
Description of the issue/feature this PR addresses: There may exist some custom modules that inherits from the account.voucher.payment views

Current behavior before PR: Tried to migrate a database with a custom module that inherits a view from account.voucher.payment. Constraint Error when executing the query that deletes the view because there are some other views that inherit the original one.

Desired behavior after PR is merged: Delete all the views for account.voucher.payment. First, the inherited ones and then the standard ones.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
