### PR TITLE
[FIX] stock: Error executing a post-migration query

### DIFF
--- a/addons/stock/migrations/10.0.1.1/post-migration.py
+++ b/addons/stock/migrations/10.0.1.1/post-migration.py
@@ -39,9 +39,9 @@ def update_picking_type_id(env):
             WHERE warehouse_id = %s AND
                 default_location_dest_id = %s AND
                 default_location_src_id = %s""" % (
-                procurement_rule.warehouse_id,
-                procurement_rule.location_id,
-                procurement_rule.location_src_id,
+                procurement_rule.warehouse_id.id,
+                procurement_rule.location_id.id,
+                procurement_rule.location_src_id.id,
             )
         )
         picking_type_ids = env.cr.fetchone()


### PR DESCRIPTION
Hi,

In the post-migration script was executing a query with objects as parameter instead of integers

Regards

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
