### PR TITLE
[8.0] 'purchase' improve reception to invoice computation (stock picking field)

### DIFF
--- a/addons/purchase/migrations/8.0.1.1/pre-migration.py
+++ b/addons/purchase/migrations/8.0.1.1/pre-migration.py
@@ -17,7 +17,12 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 ##############################################################################
+
+import logging
 from openerp.openupgrade import openupgrade
+
+logger = logging.getLogger('OpenUpgrade.purchase')
+
 
 column_renames = {
     'procurement_order': [('purchase_id', None)],
@@ -25,6 +30,15 @@ column_renames = {
     }
 
 
+def create_field_reception_to_invoice(cr):
+    cr.execute("""
+        ALTER TABLE "stock_picking"
+        ADD COLUMN "reception_to_invoice" bool DEFAULT False""")
+    logger.info(
+        "Fast creation of the field stock_picking.reception_to_invoice")
+
+
 @openupgrade.migrate()
 def migrate(cr, version):
     openupgrade.rename_columns(cr, column_renames)
+    create_field_reception_to_invoice(cr)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

In V8, purchase module introduce a new computed & stored field reception_to_invoice. For the time being, the computation of this field is managed by the ORM.

**Current behavior before PR:**

In a OpenUpgrade regular migration, the computation is done for all the picking, even if the compute is irrelevant for out picking. (sale picking). Therefore, the computation of this field takes too much time unnecessarily.

**Desired behavior after PR is merged:**
Make the purchase upgrade migration faster.
- create the field is the pre-migration field, with default False value.
- recompute the field only for relevant picking. (pickings that have move with puchase_line_id defined, and invoice_method set to 'picking').

See the the compute method for more information : 
https://github.com/OCA/OpenUpgrade/blob/8.0/addons/purchase/stock.py#L200



BTW, I don't understand why this new field doesn't appear in the analysis file.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
