### PR TITLE
[10.0] Replace SQL IN operator by = ANY to format query with lists

### DIFF
--- a/addons/sale/migrations/10.0.1.0/pre-migration.py
+++ b/addons/sale/migrations/10.0.1.0/pre-migration.py
@@ -97,14 +97,14 @@ def warning_update_module_names_partial(cr):
 
     # update ir_model_data, the subselect allows to avoid duplicated XML-IDs
     query = ("UPDATE ir_model_data SET module = %s "
-             "WHERE module = %s AND res_id IN %s AND name NOT IN "
+             "WHERE module = %s AND res_id = ANY(%s) AND name NOT IN "
              "(SELECT name FROM ir_model_data WHERE module = %s)")
     openupgrade.logged_query(cr, query, (new_name, old_name, field_ids,
                                          new_name))
 
     # update ir_translation
     query = ("UPDATE ir_translation SET module = %s "
-             "WHERE module = %s AND res_id IN %s")
+             "WHERE module = %s AND res_id = ANY(%s)")
     openupgrade.logged_query(cr, query, (new_name, old_name, field_ids))
 
 
@@ -126,20 +126,20 @@ def sale_expense_update_module_names_partial(cr):
     cr.execute("""
         SELECT id
         FROM ir_model_fields
-        WHERE model = 'product.template' AND name in %s
+        WHERE model = 'product.template' AND name = ANY(%s)
     """, (moved_fields,))
     field_ids = [r[0] for r in cr.fetchall()]
 
     # update ir_model_data, the subselect allows to avoid duplicated XML-IDs,
     query = ("UPDATE ir_model_data SET module = %s "
-             "WHERE module = %s AND res_id IN %s AND name NOT IN "
+             "WHERE module = %s AND res_id = ANY(%s) AND name NOT IN "
              "(SELECT name FROM ir_model_data WHERE module = %s)")
     openupgrade.logged_query(cr, query, (new_name, old_name, field_ids,
                                          new_name))
 
     # delete ir_translation because the translations changes completely
     query = ("DELETE FROM ir_translation "
-             "WHERE module = %s AND res_id IN %s")
+             "WHERE module = %s AND res_id = ANY(%s)")
     openupgrade.logged_query(cr, query, (old_name, field_ids))
 
 

--- a/addons/stock/migrations/10.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/10.0.1.1/pre-migration.py
@@ -47,14 +47,14 @@ def warning_update_module_names_partial(cr):
     field_ids = [r[0] for r in cr.fetchall()]
     # update ir_model_data, the subselect allows to avoid duplicated XML-IDs
     query = ("UPDATE ir_model_data SET module = %s "
-             "WHERE module = %s AND res_id IN %s AND name NOT IN "
+             "WHERE module = %s AND res_id = ANY(%s) AND name NOT IN "
              "(SELECT name FROM ir_model_data WHERE module = %s)")
-    openupgrade.logged_query(cr, query, (new_name, old_name, tuple(field_ids),
+    openupgrade.logged_query(cr, query, (new_name, old_name, field_ids,
                                          new_name))
     # update ir_translation
     query = ("UPDATE ir_translation SET module = %s "
-             "WHERE module = %s AND res_id IN %s")
-    openupgrade.logged_query(cr, query, (new_name, old_name, tuple(field_ids)))
+             "WHERE module = %s AND res_id = ANY(%s)")
+    openupgrade.logged_query(cr, query, (new_name, old_name, field_ids))
 
 
 @openupgrade.migrate(use_env=True)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Some migrations may fail using the IN operator of postgres with an array. I replace that with  = ANY.

Current behavior before PR:
Migration to version 10 of modules sale and stock may fail

Desired behavior after PR is merged:
Migration work

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
