### PR TITLE
[9.0][FIX] account: Correct invoice line price_subtotal_signed

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -452,8 +452,8 @@ def fill_blacklisted_fields(cr):
                 ail.price_subtotal,
                 (CASE
                     WHEN ai.type IN ('in_refund', 'out_refund')
-                    THEN ROUND(-ail.price_subtotal * er.effective_rate, 2)
-                    ELSE ROUND(ail.price_subtotal  * er.effective_rate, 2)
+                    THEN ROUND(-ail.price_subtotal / er.effective_rate, 2)
+                    ELSE ROUND(ail.price_subtotal  / er.effective_rate, 2)
                 END) AS price_subtotal_signed,
                 ai.currency_id AS currency_id
             FROM account_invoice_line ail


### PR DESCRIPTION
Correction in calculation of price_subtotal_signed field in account.invoice.line model



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
