### PR TITLE
[TEST] fetch output of failed pip installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
     - flake8 openerp/addons/openupgrade* --max-line-length=120 --exclude=__init__.py
     - flake8 . --max-line-length=120 --filename=pre-*.py,post-*.py
     - npm install -g less less-plugin-clean-css
-    - pip install -q -r requirements.txt
+    - pip install -r requirements.txt
 # don't use pypi's openupgradelib, but the one from source to avoid choking
 # on unreleased features in openupgradelib
     - pip uninstall -q --yes openupgradelib


### PR DESCRIPTION
From https://github.com/OCA/OpenUpgrade/pull/814:

$ pip install -q -r requirements.txt

Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-cCgk9N/pyparsing/

The command "pip install -q -r requirements.txt" exited with 1.

0.43s$ pip uninstall -q --yes openupgradelib

Cannot uninstall requirement openupgradelib, not installed

The command "pip uninstall -q --yes openupgradelib" exited with 1.

