### PR TITLE
[FIX] coerce False to None for writing null values

### DIFF
--- a/addons/stock/migrations/10.0.1.1/post-migration.py
+++ b/addons/stock/migrations/10.0.1.1/post-migration.py
@@ -38,10 +38,12 @@ def update_picking_type_id(env):
             SELECT id from stock_picking_type
             WHERE warehouse_id = %s AND
                 default_location_dest_id = %s AND
-                default_location_src_id = %s""" % (
-                procurement_rule.warehouse_id.id,
-                procurement_rule.location_id.id,
-                procurement_rule.location_src_id.id,
+                default_location_src_id = %s
+            """,
+            (
+                procurement_rule.warehouse_id.id or None,
+                procurement_rule.location_id.id or None,
+                procurement_rule.location_src_id.id or None,
             )
         )
         picking_type_ids = env.cr.fetchone()


### PR DESCRIPTION
none of those fields is required, so we need to pass `None` to psycopg2: https://github.com/OCA/OpenUpgrade/blob/9.0/addons/stock/procurement.py#L34-L51

(note that this won't semantically fix the query because `= null` will never be true, but rules without those set are probably bogus rules anyways)