### PR TITLE
[10.0][FIX] compare_noupdate_xml_records: <data> tag as root

### DIFF
--- a/scripts/compare_noupdate_xml_records.py
+++ b/scripts/compare_noupdate_xml_records.py
@@ -110,11 +110,11 @@ def get_records(addon_dir):
                 tree = etree.parse(os.path.join(addon_dir, *xml_path))
             except etree.XMLSyntaxError:
                 continue
-            # Support xml files with root Element either odoo or openerp, supporting v9.0 and v1.0
-            # Condition: each xml file should have only one root element {<odoo> or <openerp>};
+            # Support xml files with root Element either odoo or openerp, supporting v9.0 and v10.0
+            # Condition: each xml file should have only one root element {<odoo>, <openerp> or —rarely— <data>};
             root_node = tree.getroot()
             root_node_noupdate = nodeattr2bool(root_node, 'noupdate', False)
-            if root_node.tag not in ('openerp', 'odoo'):
+            if root_node.tag not in ('openerp', 'odoo', 'data'):
                 raise Exception(
                     'Unexpected root Element: %s in file: %s' % (
                         tree.getroot(), xml_path


### PR DESCRIPTION
There exists rare cases where the root in xml files are the `<data>` tag.

Example: https://github.com/OCA/OpenUpgrade/blob/10.0/addons/account_accountant/data/account_accountant_tour.xml

Although it seems to me is an error of the developers due to a bad fast migration 😀