### PR TITLE
[10.0][MIG] Rename of hr_holiday_notify_employee_manager

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -8,6 +8,9 @@ renamed_modules = {
     # connector and queue_job. We need to do this to correct upgrade both
     # modules.
     'connector': 'queue_job',
+    # OCA/hr
+    # The OCA extensions of the hr_holidays module are 'hr_holidays_something'
+    'hr_holiday_notify_employee_manager': 'hr_holidays_notify_employee_manager'
 }
 
 renamed_models = {


### PR DESCRIPTION
In the migration of hr_holiday_notify_employee_manager (https://github.com/OCA/hr/pull/362), it has been renamed to follow conventions.