### PR TITLE
[FIX] mass_mailing: Fill empty source_id in mass mailings

### DIFF
--- a/addons/mass_mailing/migrations/10.0.2.0/openupgrade_analysis_work.txt
+++ b/addons/mass_mailing/migrations/10.0.2.0/openupgrade_analysis_work.txt
@@ -3,7 +3,7 @@ mass_mailing / mail.mass_mailing        / _inherits (False)             : NEW
 # Nothing to do: The inheritance by delegation relies on campaign_id fields, which was present already
 
 mass_mailing / mail.mass_mailing        / source_id (many2one)          : now required
-# Nothing to do: Seeing source, this is not correct. It's not required
+# Done: Fill empty records with a wildcard pre-created source
 
 mass_mailing / mail.mass_mailing.contact / website_message_ids (one2many): DEL relation: mail.message
 # Nothing to do: mail thing

--- a/addons/mass_mailing/migrations/10.0.2.0/pre-migration.py
+++ b/addons/mass_mailing/migrations/10.0.2.0/pre-migration.py
@@ -10,6 +10,25 @@ XMLID_RENAMES = [
 ]
 
 
+def fill_missing_sources(env):
+    env.cr.execute(
+        "SELECT COUNT(*) FROM mail_mass_mailing WHERE source_id IS NULL"
+    )
+    if env.cr.fetchone()[0] == 0:
+        return
+    source = env['utm.source'].create({
+        'name': "OpenUpgrade wildcard source",
+    })
+    openupgrade.logged_query(
+        env.cr,
+        """UPDATE mail_mass_mailing
+        SET source_id = %s
+        WHERE source_id IS NULL""",
+        (source.id, )
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_xmlids(env.cr, XMLID_RENAMES)
+    fill_missing_sources(env)

--- a/addons/mass_mailing/migrations/10.0.2.0/tests/test_mass_mailing.py
+++ b/addons/mass_mailing/migrations/10.0.2.0/tests/test_mass_mailing.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests.common import TransactionCase
+
+
+class TestMassMailing(TransactionCase):
+
+    def test_mass_mailing_source_id(self):
+        mm = self.env.ref('mass_mailing.mass_mail_1')
+        self.assertTrue(mm.source_id)
+        self.assertEqual(mm.source_id.name, "OpenUpgrade wildcard source")


### PR DESCRIPTION
It seems that the analysis file is not incorrect at the end :wink: 

cc @Tecnativa