### PR TITLE
[FIX][8.0] product_price_history initialization

### DIFF
--- a/addons/product/migrations/8.0.1.1/openupgrade_analysis_WORK.txt
+++ b/addons/product/migrations/8.0.1.1/openupgrade_analysis_WORK.txt
@@ -33,7 +33,10 @@ product      / product.price.history    / company_id (many2one)         : NEW re
 product      / product.price.history    / cost (float)                  : NEW 
 product      / product.price.history    / datetime (datetime)           : NEW 
 product      / product.price.history    / product_template_id (many2one): NEW relation: product.template, required: required
-# OK new fields -> nothing to do
+# OK. Create history for each template by ORM (write again standard_price)
+# 1. Set history to the template company (if defined)
+# Note : For global products (company_id = False), product.price.history has missing records. (As in Odoo Core)
+# 2. Set history date to 1970-01-01
 
 product      / product.template         / attribute_line_ids (one2many) : NEW relation: product.attribute.line
 product      / product.product          / attribute_value_ids (many2many): NEW relation: product.attribute.value

--- a/addons/product/migrations/8.0.1.1/post-migration.py
+++ b/addons/product/migrations/8.0.1.1/post-migration.py
@@ -85,22 +85,16 @@ def create_properties(cr, pool):
     # company of the SUPERUSER, during the migration
     cr.execute("""
         UPDATE product_price_history pph
-        SET company_id = template_company.company_id
-        FROM (
-            SELECT
-                pt.id template_id,
-                pt.company_id
-            FROM product_template pt
-            WHERE company_id is not null
-        ) template_company
-        WHERE pph.product_template_id = template_company.template_id
+        SET company_id = product_template.company_id
+        FROM product_template
+        WHERE pph.product_template_id = product_template.id
+        AND product_template.company_id IS NOT NULL
     """)
 
     # product.price.history entries have been generated with a value for
     # today, we want a value for the past as well, write a bogus date to
     # be sure that we have an historic value whenever we want
     cr.execute("UPDATE product_price_history SET "
-               # calling a field 'datetime' is not really a good idea
                "datetime = '1970-01-01 00:00:00+00'")
 
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

in a multicompany context, after a migration from 7.0 to 8.0, all items in product_price_history has the same company_id as the current company of the super user. That is due to this line.
https://github.com/OCA/OpenUpgrade/blob/8.0/addons/product/migrations/8.0.1.1/post-migration.py#L71

**Current behavior before PR:**
if a product doesn't belong to this company, the history will be bad.

**Desired behavior after PR is merged:**
the PR execute a extra SQL request to alter history and affect the company, according to the company of the template.

Note : It is a partial fix. I don't know how to manage products that doesn't have a company. (global product) because : 
* product_price_history.company_id > required = True
* product_template.company_id > required = False

regards.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
