### PR TITLE
[10.0] compare_noupdate_xml_records: 3 fixes

### DIFF
--- a/scripts/compare_noupdate_xml_records.py
+++ b/scripts/compare_noupdate_xml_records.py
@@ -108,7 +108,10 @@ def get_records(addon_dir):
         for xml_file in manifest[key]:
             xml_path = xml_file.split('/')
             try:
-                tree = etree.parse(os.path.join(addon_dir, *xml_path))
+                # This is for a final correct pretty print
+                # Ref.: https://stackoverflow.com/a/7904066
+                parser = etree.XMLParser(remove_blank_text=True)
+                tree = etree.parse(os.path.join(addon_dir, *xml_path), parser)
             except etree.XMLSyntaxError:
                 continue
             # Support xml files with root Element either odoo or openerp, supporting v9.0 and v10.0

--- a/scripts/compare_noupdate_xml_records.py
+++ b/scripts/compare_noupdate_xml_records.py
@@ -132,7 +132,7 @@ def get_records(addon_dir):
 
 def main_analysis(old_update, old_noupdate, new_update, new_noupdate):
 
-    data = etree.Element("data")
+    odoo = etree.Element("odoo")
 
     for xml_id, record_new in new_noupdate.items():
         record_old = None
@@ -172,9 +172,8 @@ def main_analysis(old_update, old_noupdate, new_update, new_noupdate):
                 element.append(deepcopy(record_new_dict[key]))
 
         if len(element):
-            data.append(element)
+            odoo.append(element)
 
-    odoo = etree.Element("odoo")
     document = etree.ElementTree(odoo)
 
     print etree.tostring(

--- a/scripts/compare_noupdate_xml_records.py
+++ b/scripts/compare_noupdate_xml_records.py
@@ -110,7 +110,10 @@ def get_records(addon_dir):
             try:
                 # This is for a final correct pretty print
                 # Ref.: https://stackoverflow.com/a/7904066
-                parser = etree.XMLParser(remove_blank_text=True)
+                # Also don't strip CDATA tags as needed for HTML content
+                parser = etree.XMLParser(
+                    remove_blank_text=True, strip_cdata=False,
+                )
                 tree = etree.parse(os.path.join(addon_dir, *xml_path), parser)
             except etree.XMLSyntaxError:
                 continue


### PR DESCRIPTION
* Add elements to <odoo>, not <data>.
* Really pretty print.
* Don't strip CDATA tags.

cc @Tecnativa