### PR TITLE
[FIX] sales_team: noupdate records changes + XML-ID rename

### DIFF
--- a/addons/sales_team/migrations/10.0.1.0/noupdate_changes.xml
+++ b/addons/sales_team/migrations/10.0.1.0/noupdate_changes.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+  <record id="team_sales_department" model="crm.team">
+    <field name="company_id" eval="False"/>
+  </record>
+  <!-- This one has been added manually as the record has been renamed but
+       it's a noupdate record and this field has changed -->
+  <record id="salesteam_website_sales" model="crm.team">
+    <field name="company_id" eval="False"/>
+  </record>
+</odoo>

--- a/addons/sales_team/migrations/10.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/sales_team/migrations/10.0.1.0/openupgrade_analysis_work.txt
@@ -4,6 +4,8 @@ sales_team   / crm.team                 / working_hours (float)         : DEL
 # Store columns for preserving data
 ---XML records in module 'sales_team'---
 NEW crm.team: sales_team.salesteam_website_sales
+Done: Rename if exists from 'website.salesteam_website_sales'
+
 NEW ir.actions.act_window: sales_team.action_sale_config
 NEW ir.rule: sales_team.crm_rule_all_salesteam
 NEW ir.rule: sales_team.crm_rule_own_salesteam

--- a/addons/sales_team/migrations/10.0.1.0/post-migration.py
+++ b/addons/sales_team/migrations/10.0.1.0/post-migration.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, 'sales_team', 'migrations/10.0.1.0/noupdate_changes.xml',
+    )

--- a/addons/sales_team/migrations/10.0.1.0/pre-migration.py
+++ b/addons/sales_team/migrations/10.0.1.0/pre-migration.py
@@ -16,6 +16,7 @@ _xmlid_renames = [
     ('base.group_sale_salesman', 'sales_team.group_sale_salesman'),
     ('base.group_sale_salesman_all_leads',
      'sales_team.group_sale_salesman_all_leads'),
+    ('website.salesteam_website_sales', 'sales_team.salesteam_website_sales'),
 ]
 
 

--- a/addons/website_crm/migrations/10.0.2.0/openupgrade_analysis_work.txt
+++ b/addons/website_crm/migrations/10.0.2.0/openupgrade_analysis_work.txt
@@ -2,5 +2,7 @@
 ---XML records in module 'website_crm'---
 NEW crm.team: sales_team.salesteam_website_sales
 DEL crm.team: website.salesteam_website_sales
+# Done: Renamed in sales_team module
+
 NEW ir.ui.view: website_crm.assets_backend
 # NOTHING TO DO

--- a/addons/website_sale/migrations/10.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/website_sale/migrations/10.0.1.0/openupgrade_analysis_work.txt
@@ -30,6 +30,8 @@ website_sale / website                  / website_pricelist_ids (one2many): DEL 
 ---XML records in module 'website_sale'---
 NEW crm.team: sales_team.salesteam_website_sales
 DEL crm.team: website.salesteam_website_sales
+# Done: Renamed in sales_team module
+
 NEW ir.actions.act_window: website_sale.action_abandonned_orders_ecommerce
 NEW ir.actions.act_window: website_sale.action_invoices_ecommerce
 NEW ir.actions.act_window: website_sale.action_orders_ecommerce


### PR DESCRIPTION
* Website Sales team has been moved from module XML_ID and this way is kept
* We continue paying #1045 bug, so here there are other noupdate records load

cc @Tecnativa