### PR TITLE
[9.0] Openupgrade: Rename module l10n_es_fiscal_year_closing to l10n_es_account_fiscal_year_closing

### DIFF
--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -53,6 +53,8 @@ renamed_modules = {
     # OCA/manufacture-reporting
     'mrp_bom_structure_xls': 'mrp_bom_structure_xlsx',
     'mrp_bom_structure_xls_level_1': 'mrp_bom_structure_xlsx_level_1',
+    # OCA/l10n-spain
+    'l10n_es_fiscal_year_closing': 'l10n_es_account_fiscal_year_closing',
 }
 
 renamed_models = {


### PR DESCRIPTION
cc @Tecnativa