### PR TITLE
[FIX] mass_mailing: Create one utm.source per mass mailing

### DIFF
--- a/addons/mass_mailing/migrations/10.0.2.0/openupgrade_analysis_work.txt
+++ b/addons/mass_mailing/migrations/10.0.2.0/openupgrade_analysis_work.txt
@@ -3,7 +3,7 @@ mass_mailing / mail.mass_mailing        / _inherits (False)             : NEW
 # Nothing to do: The inheritance by delegation relies on campaign_id fields, which was present already
 
 mass_mailing / mail.mass_mailing        / source_id (many2one)          : now required
-# Done: Fill empty records with a wildcard pre-created source
+# Done: Create one source per mass mailing as Odoo now works
 
 mass_mailing / mail.mass_mailing.contact / website_message_ids (one2many): DEL relation: mail.message
 # Nothing to do: mail thing

--- a/addons/mass_mailing/migrations/10.0.2.0/tests/test_mass_mailing.py
+++ b/addons/mass_mailing/migrations/10.0.2.0/tests/test_mass_mailing.py
@@ -10,4 +10,4 @@ class TestMassMailing(TransactionCase):
     def test_mass_mailing_source_id(self):
         mm = self.env.ref('mass_mailing.mass_mail_1')
         self.assertTrue(mm.source_id)
-        self.assertEqual(mm.source_id.name, "OpenUpgrade wildcard source")
+        self.assertEqual(mm.source_id.name, u"First Newsletter")


### PR DESCRIPTION
Odoo now inherits by delegation from utm.source and create a different
record per mass mailing, using the name of the source as subject, so we
need to pre-create a source for each record.

WARNING: This replaces sources already set, but it's the only way to
preserve the subject on the mass mailing and this binding is a feature
hardly used on previous versions.