### PR TITLE
[IMP] migrate pricelist items with computed fixed price to fixed

### DIFF
--- a/addons/product/migrations/9.0.1.2/post-migration.py
+++ b/addons/product/migrations/9.0.1.2/post-migration.py
@@ -105,6 +105,16 @@ def update_product_pricelist_item(cr):
         UPDATE product_pricelist_item
         SET compute_price = 'formula'""")
 
+    # but ones that arguably are meant to be fixed prices should be fixed
+    openupgrade.logged_query(
+        cr,
+        "update product_pricelist_item "
+        "set compute_price='fixed', fixed_price=price_surcharge "
+        "where compute_price='formula' and price_discount=100 and "
+        "price_surcharge > 0 and coalesce(price_min_margin, 0)=0 and "
+        "coalesce(price_max_margin, 0)=0"
+    )
+
 
 def update_product_template(cr):
 


### PR DESCRIPTION
this tries to detect fixed prices that were hacked into the formula by 100% discount and the real price as surcharge. As I don't want to repeat the appropriate calculations in SQL, I only do this if there's no min/max margin.