### PR TITLE
[FIX] base: Renamed modules in apriori.py

### DIFF
--- a/odoo/addons/base/migrations/10.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/10.0.1.3/pre-migration.py
@@ -2,6 +2,7 @@
 # © 2017 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+from odoo.addons.openupgrade_records.lib import apriori
 
 _column_renames = {
     'res_partner': [
@@ -12,6 +13,9 @@ _column_renames = {
 
 @openupgrade.migrate(use_env=False)
 def migrate(cr, version):
+    openupgrade.update_module_names(
+        cr, apriori.renamed_modules.iteritems()
+    )
     openupgrade.rename_columns(cr, _column_renames)
     cr.execute(
         # we rely on the ORM to write this value


### PR DESCRIPTION
It was not done previously.

cc @Tecnativa