### PR TITLE
[FIX] mass_mailing_sending_queue: Delete cron noupdate job

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/post-migration.py
@@ -77,6 +77,14 @@ def publish_attachments(env):
     )
 
 
+def cleanup_modules_post(env):
+    # Remove noupdate cron in OCA/social/mass_mailing_sending_queue
+    # It has been already moved to 'mass_mailing' module
+    cron = env.ref('mass_mailing.cronjob', False)
+    if cron:
+        cron.unlink()
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     for table_name in column_copies.keys():
@@ -93,3 +101,4 @@ def migrate(env, version):
     )
     assign_view_keys(env)
     publish_attachments(env)
+    cleanup_modules_post(env)


### PR DESCRIPTION
This module includes a noupdate record for a cronjob. If we don't remove it, then on migrated DB there will be a warning about an inexisting model, because these kind of records are not auto-removed on update.

cc @Tecnativa