### PR TITLE
[ADD] website_sale_qty name change

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -8,6 +8,8 @@ renamed_modules = {
     # connector and queue_job. We need to do this to correct upgrade both
     # modules.
     'connector': 'queue_job',
+    # OCA/e-commerce
+    'website_sale_qty': 'website_sale_price_tier',
     # OCA/hr
     # The OCA extensions of the hr_holidays module are 'hr_holidays_something'
     'hr_holiday_notify_employee_manager': 'hr_holidays_notify_employee_manager'


### PR DESCRIPTION
* Add ``website_sale_qty`` to list of renamed modules to support name change to ``website_sale_price_tiers``

This PR depends on:
- [x] https://github.com/OCA/e-commerce/pull/153
