### PR TITLE
[9.0][FIX] account: Set default inbound and outbound payment methods

### DIFF
--- a/addons/account/migrations/9.0.1.1/end-migration.py
+++ b/addons/account/migrations/9.0.1.1/end-migration.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Sergio Teruel
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def update_journal_payment_methods(env):
+    """Update default payment methods in journals when type is 'bank' or
+    'cash'.
+    """
+    payment_methods = env['account.payment.method'].search([])
+    journals = env['account.journal'].search([
+        '|', ('type', '=', 'bank'), ('type', '=', 'cash'),
+    ])
+    in_methods = payment_methods.filtered(
+        lambda x: x.payment_type == 'inbound')
+    out_methods = payment_methods - in_methods
+    journals.write({
+        'inbound_payment_method_ids': [(6, 0, in_methods.ids)],
+        'outbound_payment_method_ids': [(6, 0, out_methods.ids)],
+    })
+
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    update_journal_payment_methods(env)


### PR DESCRIPTION
cc @Tecnativa
The account_payment_mode module from bank-payment repo updates the default payment mode for this fields so i need update these module too to set all payment_methods.

default methods in account module:
https://github.com/OCA/OCB/blob/9.0/addons/account/models/account.py#L203

default methods in account_payment_mode:
https://github.com/OCA/bank-payment/blob/10.0/account_payment_mode/models/account_journal.py#L11

Please @pedrobaeza @carlosdauden Can you review?

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
