### PR TITLE
Py3 compat, openupgrade records and travis data loading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,11 @@ script:
     # Loading and committing test data without triggering post tests needs https://github.com/odoo/odoo/pull/13146. This is now included in OpenUpgrade.
     - git fetch --depth 2 origin 10.0
     - git reset --hard `git ls-remote |grep refs/heads/10.0 |awk '{print $1}'`
+    - source ~/virtualenv/python2.7/bin/activate
     - pip install -q -r requirements.txt
     # this crashes if there is no test data
     - if [ -s ../test_data100.yml ]; then ./openerp-server --database=$DB --test-file=`readlink -f ../test_data100.yml` --test-commit --stop-after-init; fi
+    - source ~/virtualenv/python3.5/bin/activate
     # Line below may fail quite often due to Travis bug:
     - git reset -q --hard $TRAVIS_COMMIT
     # Install Python requirements of target release

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
             - python-simplejson
             - python-serial
             - python-yaml
-            - python-sphinx
             - python-passlib
             - python-psycopg2
             - python-werkzeug
@@ -68,6 +67,7 @@ script:
     - echo Testing modules $MODULES
     - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES --stop-after-init
     # try to build the documentation
+    - pip install sphinx
     - sh scripts/build_openupgrade_docs
 
 after_success:

--- a/odoo/addons/openupgrade_records/__manifest__.py
+++ b/odoo/addons/openupgrade_records/__manifest__.py
@@ -18,6 +18,6 @@
     ],
     'installable': True,
     'external_dependencies': {
-        'python': ['openerplib', 'openupgradelib'],
+        'python': ['odoorpc', 'openupgradelib'],
     },
 }

--- a/odoo/addons/openupgrade_records/models/analysis_wizard.py
+++ b/odoo/addons/openupgrade_records/models/analysis_wizard.py
@@ -55,7 +55,7 @@ class AnalysisWizard(models.TransientModel):
 
         self.ensure_one()
         connection = self.server_config.get_connection()
-        remote_record_obj = connection.get_model('openupgrade.record')
+        remote_record_obj = connection.env['openupgrade.record']
         local_record_obj = self.env['openupgrade.record']
 
         # Retrieve field representations and compare
@@ -95,12 +95,12 @@ class AnalysisWizard(models.TransientModel):
             contents = "---Fields in module '%s'---\n" % key
             if key in res:
                 contents += '\n'.join(
-                    [unicode(line) for line in sorted(res[key])])
+                    [str(line) for line in sorted(res[key])])
                 if res[key]:
                     contents += '\n'
             contents += "---XML records in module '%s'---\n" % key
             if key in res_xml:
-                contents += '\n'.join([unicode(line) for line in res_xml[key]])
+                contents += '\n'.join([str(line) for line in res_xml[key]])
                 if res_xml[key]:
                     contents += '\n'
             if key not in res and key not in res_xml:

--- a/odoo/openupgrade/doc/source/conf.py
+++ b/odoo/openupgrade/doc/source/conf.py
@@ -154,6 +154,8 @@ htmlhelp_basename = 'OpenUpgradedoc'
 # Options for LaTeX output
 # ------------------------
 
+latex_elements = {'papersize': 'a4paper'}
+
 # The paper size ('letter' or 'a4').
 # latex_paper_size = 'letter'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ openupgradelib>=1.3.0
 passlib==1.6.5
 Pillow==3.4.1
 psutil==4.3.1
-openerp-client-lib==1.1.2
+odoorpc==0.6.0
 psycogreen==1.0
 psycopg2==2.7.1
 pydot==1.2.3

--- a/scripts/build_openupgrade_docs
+++ b/scripts/build_openupgrade_docs
@@ -22,4 +22,4 @@ else
 fi
 export PYTHONPATH=$PYTHONPATH:$OPENUPGRADE_PYTHON_PATH:$DOC_BUILD_DIR/openupgradelib
 mkdir -p $DOC_BUILD_DIR/source/.static
-sphinx-build -q -d $DOC_BUILD_DIR/.doctrees -D latex_paper_size=a4 $DOC_BUILD_DIR/source $OUTPUT_DIR
+sphinx-build -q -d $DOC_BUILD_DIR/.doctrees $DOC_BUILD_DIR/source $OUTPUT_DIR

--- a/scripts/compare_noupdate_xml_records.py
+++ b/scripts/compare_noupdate_xml_records.py
@@ -185,8 +185,8 @@ def main_analysis(old_update, old_noupdate, new_update, new_noupdate):
 
     document = etree.ElementTree(odoo)
 
-    print etree.tostring(
-        document, pretty_print=True, xml_declaration=True, encoding='utf-8')
+    print(etree.tostring(
+        document, pretty_print=True, xml_declaration=True, encoding='utf-8'))
 
 
 def main(argv=None):
@@ -220,10 +220,10 @@ def main(argv=None):
     parser.add_argument(
         '--mode', metavar='module/repository', default='module')
     arguments = parser.parse_args(argv)
-    print "\n"
+    print("\n")
 
     if arguments.mode == "module":
-        print arguments.olddir.split('/')[-1] + ":\n"
+        print(arguments.olddir.split('/')[-1] + ":\n")
         old_update, old_noupdate = get_records(arguments.olddir)
         new_update, new_noupdate = get_records(arguments.newdir)
         main_analysis(old_update, old_noupdate, new_update, new_noupdate)
@@ -240,7 +240,7 @@ def main(argv=None):
                     opj(arguments.newdir, m, mname)),
                 os.listdir(arguments.newdir))
         for module_name in set(old_module_list).intersection(new_module_list):
-            print module_name + ":\n"
+            print(module_name + ":\n")
             old_update, old_noupdate = get_records(
                 opj(arguments.olddir, module_name))
             new_update, new_noupdate = get_records(


### PR DESCRIPTION
* Implemented Python version switching in Travis to load yml data
* Finish conversion to Python3 of OpenUpgrade code
* Move from openerplib to odoorpc for openupgrade_records communication because of Python3 compatibility
* Switch to pip installed sphinx because sphinx3-python did not seem to use the active virtualenv
* Move deprecated sphinx-build command line option to new option in config file
