### PR TITLE
[FIX] Build docs with virtualenv sphinx, not with standalone sphinx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
             - python-simplejson
             - python-serial
             - python-yaml
-            - python-sphinx
             - python-passlib
             - python-psycopg2
             - python-werkzeug
@@ -66,6 +65,7 @@ script:
     - echo Testing modules $MODULES
     - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES --stop-after-init
     # try to build the documentation
+    - pip install sphinx
     - sh scripts/build_openupgrade_docs
 
 after_success:


### PR DESCRIPTION
Fix recent travis builds. System-wide sphinx does not use virtualenv-python so it does not have access to all the imports.

Builds break while building the documentation, as
 
File "/home/travis/build/OCA/OpenUpgrade/odoo/tools/cache.py", line 7, in <module>
    from decorator import decorator
ImportError: No module named decorator

See https://travis-ci.org/OCA/OpenUpgrade/builds/289903471?utm_source=github_status&utm_medium=notification

This change is already present in the 11.0 branch


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
