### PR TITLE
[FIX] Cleanup openerp directory with .pyc files after switching from …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,8 @@ script:
     - if [ -s ../test_data90.yml ]; then ./openerp-server --database=$DB --test-file=`readlink -f ../test_data90.yml` --test-commit --stop-after-init; fi
     # Line below may fail quite often due to Travis bug:
     - git reset -q --hard $TRAVIS_COMMIT
+    # Remove obsolete directories with .pyc files to prevent them from being imported (such as 'openerp')
+    - git clean -xfdq
     # Install Python requirements of target release
     - pip install -q -r requirements.txt
     # don't use pypi's openupgradelib, but the one from source to avoid choking


### PR DESCRIPTION
…9.0 to 10.0

fixes sphinx documentation build step in Travis:

WARNING: /home/travis/build/OCA/OpenUpgrade/odoo/openupgrade/doc/source/API.rst:41: (WARNING/2) autodoc: failed to import module u'openupgradelib.openupgrade_80'; the following exception was raised:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/sphinx/ext/autodoc.py", line 658, in import_object
    __import__(self.modname)
  File "/home/travis/build/OCA/OpenUpgrade/odoo/openupgrade/doc/openupgradelib/openupgradelib/openupgrade_80.py", line 30, in <module>
    from openerp import SUPERUSER_ID
  File "/home/travis/build/OCA/OpenUpgrade/openerp/__init__.py", line 64, in <module>
  File "/home/travis/build/OCA/OpenUpgrade/openerp/modules/__init__.py", line 8, in <module>
  File "/home/travis/build/OCA/OpenUpgrade/openerp/modules/loading.py", line 20, in <module>
AttributeError: 'module' object has no attribute 'tools'