### PR TITLE
[9.0][IMP] *: Use new rename_fields method

### DIFF
--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -8,9 +8,6 @@
 from openupgradelib import openupgrade
 
 column_renames = {
-    'account_bank_statement': [
-        ('closing_date', 'date_done'),
-    ],
     'account_account_type': [
         ('close_method', None),
     ],
@@ -27,6 +24,67 @@ column_renames = {
         ('bank_statement_id', None),
     ]
 }
+
+field_renames = [
+    ('account.bank.statement', 'account_bank_statement', 'closing_date',
+     'date_done'),
+    # renamings with oldname attribute - They also need the rest of operations
+    ('account.account', 'account_account', 'user_type', 'user_type_id'),
+    ('account.account.template', 'account_account_template', 'user_type',
+     'user_type_id'),
+    ('account.chart.template', 'account_chart_template',
+     'property_account_expense', 'property_account_expense_id'),
+    ('account.chart.template', 'account_chart_template',
+     'property_account_expense_categ', 'property_account_expense_categ_id'),
+    ('account.chart.template', 'account_chart_template',
+     'property_account_income', 'property_account_income_id'),
+    ('account.chart.template', 'account_chart_template',
+     'property_account_income_categ', 'property_account_income_categ_id'),
+    ('account.chart.template', 'account_chart_template',
+     'property_account_payable', 'property_account_payable_id'),
+    ('account.chart.template', 'account_chart_template',
+     'property_account_receivable', 'property_account_receivable_id'),
+    ('account.invoice', 'account_invoice', 'fiscal_position',
+     'fiscal_position_id'),
+    ('account.invoice', 'account_invoice', 'invoice_line', 'invoice_line_ids'),
+    ('account.invoice', 'account_invoice', 'payment_term', 'payment_term_id'),
+    ('account.invoice', 'account_invoice', 'tax_line', 'tax_line_ids'),
+    ('account.invoice.line', 'account_invoice_line', 'invoice_line_tax_id',
+     'invoice_line_tax_ids'),
+    ('account.invoice.line', 'account_invoice_line', 'uos_id', 'uom_id'),
+    ('account.journal', 'account_journal', 'currency', 'currency_id'),
+    ('account.move.line', 'account_move_line', 'analytic_lines',
+     'analytic_line_ids'),
+    ('account.move.line', 'account_move_line', 'invoice', 'invoice_id'),
+    ('account.tax', 'account_tax', 'account_collected_id', 'account_id'),
+    ('account.tax', 'account_tax', 'account_paid_id', 'refund_account_id'),
+    ('account.tax', 'account_tax', 'type', 'amount_type'),
+    ('account.tax.template', 'account_tax_template', 'account_collected_id',
+     'account_id'),
+    ('account.tax.template', 'account_tax_template', 'account_paid_id',
+     'refund_account_id'),
+    ('product.category', 'product_category', 'property_account_expense_categ',
+     'property_account_expense_categ_id'),
+    ('product.category', 'product_category', 'property_account_income_categ',
+     'property_account_income_categ_id'),
+    ('product.template', 'product_template', 'property_account_expense',
+     'property_account_expense_id'),
+    ('product.template', 'product_template', 'property_account_income',
+     'property_account_income_id'),
+    ('res.partner', 'res_partner', 'last_reconciliation_date',
+     'last_time_entries_checked'),
+    ('res.partner', 'res_partner', 'property_account_payable',
+     'property_account_payable_id'),
+    ('res.partner', 'res_partner', 'property_account_position',
+     'property_account_position_id'),
+    ('res.partner', 'res_partner', 'property_account_receivable',
+     'property_account_receivable_id'),
+    ('res.partner', 'res_partner', 'property_payment_term',
+     'property_payment_term_id'),
+    ('res.partner', 'res_partner', 'property_supplier_payment_term',
+     'property_supplier_payment_term_id'),
+    ('res.partner', 'res_partner', 'ref_companies', 'ref_company_ids'),
+]
 
 column_copies = {
     'account_bank_statement': [
@@ -261,3 +319,4 @@ def migrate(env, version):
     remove_account_moves_from_special_periods(cr)
     blacklist_field_recomputation(env)
     merge_supplier_invoice_refs(env)
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/account_asset/migrations/9.0.1.0/pre-migration.py
+++ b/addons/account_asset/migrations/9.0.1.0/pre-migration.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('account.asset.asset', 'account_asset_asset', 'purchase_date', 'date'),
+    ('account.asset.asset', 'account_asset_asset', 'purchase_value', 'value'),
+    ('account.asset.category', 'account_asset_category',
+     'account_expense_depreciation_id', 'account_income_recognition_id'),
+]
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/account_voucher/migrations/9.0.1.0/pre-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/pre-migration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-# © 2016 Therp BV <http://therp.nl>
+# Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openupgradelib import openupgrade
 from openerp.addons.account_voucher.account_voucher import \
     account_voucher_line
@@ -14,6 +16,12 @@ column_copies = {
     ],
 }
 
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('account.voucher', 'account_voucher', 'type', 'voucher_type'),
+    ('account.voucher.line', 'account_voucher_line', 'amount', 'price_unit'),
+]
+
 
 def delete_payment_views(cr):
     """Delete account.voucher payment views that hinder upgrade."""
@@ -25,13 +33,14 @@ def delete_payment_views(cr):
     )
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     cr.execute('update account_voucher_line set amount=0 where amount is null')
     cr.execute("update account_voucher_line set name='/' where name is null")
     openupgrade.copy_columns(cr, column_copies)
+    openupgrade.rename_fields(env, field_renames)
     delete_payment_views(cr)
-
     cr.execute('SELECT count(*) FROM account_voucher WHERE tax_id IS NOT NULL')
     taxed_vouchers = cr.fetchone()[0]
     if not taxed_vouchers:

--- a/addons/crm/migrations/9.0.1.0/pre-migration.py
+++ b/addons/crm/migrations/9.0.1.0/pre-migration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2016 Therp BV <http://therp.nl>
+# Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
@@ -14,11 +15,7 @@ table_renames = [
 ]
 
 column_renames = {
-    'crm_case_categ': [
-        ('section_id', 'team_id'),
-    ],
     'crm_lead': [
-        ('section_id', 'team_id'),
         ('ref', None),
         ('ref2', None),
     ],
@@ -26,6 +23,12 @@ column_renames = {
         ('section_id', 'team_id'),
     ],
 }
+
+field_renames = [
+    ('crm.case.categ', 'crm_case_categ', 'section_id', 'team_id'),
+    # renamings with oldname attribute - They also need the rest of operations
+    ('crm.lead', 'crm_lead', 'section_id', 'team_id'),
+]
 
 column_copys = {
     'crm_lead': [
@@ -75,9 +78,11 @@ def migrate_tracking_source(cr):
         'from utm_source s where crm_tracking_source_id=source_id')
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)
     openupgrade.copy_columns(cr, column_copys)
     openupgrade.rename_tables(cr, table_renames)
     openupgrade.rename_models(cr, model_renames)

--- a/addons/crm_claim/migrations/9.0.1.0/pre-migration.py
+++ b/addons/crm_claim/migrations/9.0.1.0/pre-migration.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
-# © 2016 Therp BV <http://therp.nl>
+# Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('crm.claim', 'crm_claim', 'section_id', 'team_id'),
+]
 
 column_renames = {
     'crm_claim': [
@@ -17,7 +23,9 @@ table_renames = [
 ]
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
+    openupgrade.rename_fields(env, field_renames)
     openupgrade.rename_columns(cr, column_renames)
     openupgrade.rename_tables(cr, table_renames)

--- a/addons/delivery/migrations/9.0.1.0/pre-migration.py
+++ b/addons/delivery/migrations/9.0.1.0/pre-migration.py
@@ -7,8 +7,6 @@ from openupgradelib import openupgrade
 
 column_renames = {
     'delivery_grid_line': [
-        ('type', 'variable'),
-        ('grid_id', 'carrier_id'),
         ('price_type', None),
     ],
     'delivery_grid': [
@@ -21,6 +19,11 @@ column_renames = {
         ('grid_id', 'carrier_id'),
     ],
 }
+
+field_renames = [
+    ('delivery.grid.line', 'delivery_grid_line', 'type', 'variable'),
+    ('delivery.grid.line', 'delivery_grid_line', 'grid_id', 'carrier_id'),
+]
 
 column_copies = {
     'delivery_grid_line': [
@@ -80,10 +83,12 @@ def correct_rule_prices(cr):
     )
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     correct_object_references(cr)
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)
     correct_rule_prices(cr)
     openupgrade.rename_tables(cr, table_renames)
     # TODO: if the same product is used for multiple carriers, duplicate it

--- a/addons/event/migrations/9.0.0.1/pre-migration.py
+++ b/addons/event/migrations/9.0.0.1/pre-migration.py
@@ -1,8 +1,15 @@
 # -*- coding: utf-8 -*-
-# © 2016 Tecnativa - Vicent Cubells <vicent.cubells@tecnativa.com>
+# Copyright 2016 Tecnativa - Vicent Cubells <vicent.cubells@tecnativa.com>
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
 from openupgradelib import openupgrade
 
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('event.event', 'event_event', 'type', 'event_type_id'),
+]
 
 column_renames = {
     'event_event': [
@@ -19,6 +26,8 @@ column_renames = {
 }
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
+    openupgrade.rename_fields(env, field_renames)
     openupgrade.rename_columns(cr, column_renames)

--- a/addons/hr_expense/migrations/9.0.2.0/pre-migration.py
+++ b/addons/hr_expense/migrations/9.0.2.0/pre-migration.py
@@ -13,22 +13,20 @@ column_copies = {
     ],
 }
 
-column_renames = {
-    'product_template': [
-        ('hr_expense_ok', 'can_be_expensed'),
-    ],
-    'hr_expense': [
-        ('note', 'description'),
-    ],
-}
+field_renames = [
+    ('product.template', 'product_template', 'hr_expense_ok',
+     'can_be_expensed'),
+    ('hr.expense', 'hr_expense', 'note', 'description'),
+]
 
 table_renames = [
     ('hr_expense_expense', 'hr_expense'),
     ]
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.rename_tables(cr, table_renames)
-    openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)
     openupgrade.copy_columns(cr, column_copies)

--- a/addons/mail/migrations/9.0.1.0/pre-migration.py
+++ b/addons/mail/migrations/9.0.1.0/pre-migration.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
@@ -13,6 +14,11 @@ table_renames = [
     ('mail_group_res_group_rel', 'mail_channel_res_group_rel'),
 ]
 
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('mail.message', 'mail_message', 'type', 'message_type'),
+]
+
 column_renames = {
     'mail_channel_res_group_rel': [
         ('mail_group_id', 'mail_channel_id'),
@@ -24,6 +30,7 @@ column_renames = {
 def migrate(env, version):
     openupgrade.rename_models(env.cr, model_renames)
     openupgrade.rename_tables(env.cr, table_renames)
+    openupgrade.rename_fields(env, field_renames)
     openupgrade.rename_columns(env.cr, column_renames)
     # Remove noupdate ir.rule
     rule = env.ref('mail.mail_group_public_and_joined')

--- a/addons/product/migrations/9.0.1.2/pre-migration.py
+++ b/addons/product/migrations/9.0.1.2/pre-migration.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-# © 2014-2015 Microcom
-# © 2016 Serpent Consulting Services Pvt. Ltd.
-# © 2016 Eficent Business and IT Consulting Services S.L.
-# Copyright 2017 Tecnativa - Pedro M. Baeza <pedro.baeza@tecnativa.com>
+# Copyright 2014-2015 Microcom
+# Copyright 2016 Serpent Consulting Services Pvt. Ltd.
+# Copyright 2016 Eficent Business and IT Consulting Services S.L.
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
@@ -26,6 +26,12 @@ column_renames = {
     ],
 }
 
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('product.product', 'product_product', 'ean13', 'barcode'),
+    ('product.template', 'product_template', 'ean13', 'barcode'),
+]
+
 column_copies = {
     'product_template': [
         ('type', None, None),
@@ -45,8 +51,9 @@ def map_product_template_type(cr):
         table='product_template', write='sql')
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     # Remove NOT NULL constraint on these obsolete required fields
     openupgrade.logged_query(cr, """
         ALTER TABLE product_price_history
@@ -74,6 +81,7 @@ def migrate(cr, version):
         """)
 
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)
     openupgrade.copy_columns(cr, column_copies)
 
     # Add default value when it is null, as Product name / Package Logistic

--- a/addons/project/migrations/9.0.1.1/pre-migration.py
+++ b/addons/project/migrations/9.0.1.1/pre-migration.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-# @ 2014-Today: Odoo Community Association, Microcom
-# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Copyright 2014-Today: Odoo Community Association, Microcom
+# Copyright 2015 Eficent Business and IT Consulting Services S.L. -
 # Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
@@ -25,6 +26,11 @@ column_renames = {
         ('project_category_id', 'project_tags_id'),
     ],
 }
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('project.task', 'project_task', 'categ_ids', 'tag_ids'),
+]
 
 table_renames = [
     ('project_category', 'project_tags'),
@@ -75,11 +81,13 @@ def recreate_analytic_lines(cr):
     )
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.copy_columns(cr, column_copies)
     openupgrade.rename_tables(cr, table_renames)
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)
     openupgrade.rename_xmlids(cr, xmlid_renames)
     if not openupgrade.is_module_installed(cr, 'project_timesheet'):
         recreate_analytic_lines(cr)

--- a/addons/project_issue/migrations/9.0.1.0/pre-migration.py
+++ b/addons/project_issue/migrations/9.0.1.0/pre-migration.py
@@ -1,23 +1,7 @@
 # -*- coding: utf-8 -*-
-##############################################################################
-#
-#    OpenUpgrade module for Odoo
-#    @copyright 2014-Today: Odoo Community Association, Microcom
-#
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
-#
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
-#
-#    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-##############################################################################
+# Copyright 2014 Microcom
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
 
@@ -29,6 +13,11 @@ column_renames = {
         ('project_category_id', 'project_tags_id'),
     ],
 }
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('project.issue', 'project_issue', 'section_id', 'team_id'),
+]
 
 table_renames = [
     (
@@ -53,8 +42,10 @@ xmlid_renames = [
 ]
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.rename_xmlids(cr, xmlid_renames)
     openupgrade.rename_tables(cr, table_renames)
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Copyright 2015 Eficent Business and IT Consulting Services S.L. -
 # Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
@@ -11,6 +12,12 @@ column_copies = {
         ('state', None, None),
     ],
 }
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('purchase.order', 'purchase_order', 'fiscal_position',
+     'fiscal_position_id'),
+]
 
 
 def map_order_state(cr):
@@ -31,7 +38,9 @@ def map_order_state(cr):
         WHERE l.order_id = o.id""")
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.copy_columns(cr, column_copies)
+    openupgrade.rename_fields(env, field_renames)
     map_order_state(cr)

--- a/addons/purchase_requisition/migrations/9.0.0.1/pre-migration.py
+++ b/addons/purchase_requisition/migrations/9.0.0.1/pre-migration.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Copyright 2015 Eficent Business and IT Consulting Services S.L. -
 # Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
@@ -13,7 +14,15 @@ column_spec = {
     ],
 }
 
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('purchase.order.line', 'purchase_order_line', 'quantity_bid',
+     'quantity_tendered'),
+]
 
-@openupgrade.migrate()
-def migrate(cr, version):
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.copy_columns(cr, column_spec)
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/sale/migrations/9.0.1.0/pre-migration.py
+++ b/addons/sale/migrations/9.0.1.0/pre-migration.py
@@ -1,29 +1,32 @@
 # -*- coding: utf-8 -*-
-# © 2015 Microcom
-# © 2016 Eficent Business and IT Consulting Services S.L. -
+# Copyright 2015 Microcom
+# Copyright 2016 Eficent Business and IT Consulting Services S.L. -
 # Jordi Ballester Alomar
-# © 2016 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
-# © 2016 Opener B.V. - Stefan Rijnhart
+# Copyright 2016 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2016 Opener B.V. - Stefan Rijnhart
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
 
 column_renames = {
-    'sale_order': [
-        ('section_id', 'team_id'),
-    ],
-    'account_invoice': [
-        ('section_id', 'team_id'),
-    ],
     # 'invoice_id' in 8.0 already referred to invoice lines
     'sale_order_line_invoice_rel': [
         ('invoice_id', 'invoice_line_id'),
     ],
-    'sale_order_tax': [
-        ('order_line_id', 'sale_order_line_id'),
-        ('tax_id', 'account_tax_id'),
-    ],
 }
+
+field_renames = [
+    ('sale.order', 'sale_order', 'section_id', 'team_id'),
+    ('account.invoice', 'account_invoice', 'section_id', 'team_id'),
+    ('sale.order.tax', 'sale_order_tax', 'order_line_id',
+     'sale_order_line_id'),
+    ('sale.order.tax', 'sale_order_tax', 'tax_id', 'account_tax_id'),
+    # renamings with oldname attribute - They also need the rest of operations
+    ('sale.order', 'sale_order', 'fiscal_position', 'fiscal_position_id'),
+    ('sale.order', 'sale_order', 'payment_term', 'payment_term_id'),
+    ('sale.order.line', 'sale_order_line', 'delay', 'customer_lead'),
+]
 
 table_renames = [
     ('sale_order_tax', 'account_tax_sale_order_line_rel'),
@@ -56,9 +59,11 @@ def map_order_state(cr):
         WHERE sol.order_id = so.id""")
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)
     openupgrade.copy_columns(cr, column_copies)
     openupgrade.rename_tables(cr, table_renames)
     map_order_state(cr)

--- a/addons/sales_team/migrations/9.0.1.0/pre-migration.py
+++ b/addons/sales_team/migrations/9.0.1.0/pre-migration.py
@@ -1,19 +1,27 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Copyright 2015 Eficent Business and IT Consulting Services S.L. -
 # Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
-# © 2016 Opener B.V. - Stefan Rijnhart
+# Copyright 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# Copyright 2016 Opener B.V. - Stefan Rijnhart
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
 from openupgradelib import openupgrade
 
+field_renames = [
+    ('res.users', 'res_users', 'default_section_id', 'sale_team_id'),
+    # renamings with oldname attribute - They also need the rest of operations
+    ('res.partner', 'res_partner', 'section_id', 'team_id'),
+]
 
-@openupgrade.migrate()
-def migrate(cr, version):
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.rename_xmlids(cr, [
         ('sales_team.section_sales_department',
          'sales_team.team_sales_department'),
     ])
     openupgrade.rename_tables(cr, [('crm_case_section', 'crm_team')])
     openupgrade.rename_models(cr, [('crm.case.section', 'crm.team')])
-    openupgrade.rename_columns(cr, {
-        'res_users': [('default_section_id', 'sale_team_id')]})
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/stock/migrations/9.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/9.0.1.1/pre-migration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# @copyright 2014-Today: Odoo Community Association, Microcom, Therp BV
+# Copyright 2014 Microcom, Therp BV
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
@@ -21,8 +22,15 @@ column_renames = {
     ],
 }
 
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('stock.location', 'stock_location', 'loc_barcode', 'barcode'),
+]
 
-@openupgrade.migrate()
-def migrate(cr, version):
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.rename_xmlids(cr, xmlids)
     openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/stock_account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/stock_account/migrations/9.0.1.1/pre-migration.py
@@ -1,7 +1,19 @@
 # -*- coding: utf-8 -*-
-# © 2016 Therp BV <http://therp.nl>
+# Copyright 2016 Therp BV <http://therp.nl>
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openupgradelib import openupgrade
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('product.category', 'product_category',
+     'property_stock_account_input_categ',
+     'property_stock_account_input_categ_id'),
+    ('product.category', 'product_category',
+     'property_stock_account_output_categ',
+     'property_stock_account_output_categ_id'),
+]
 
 
 def rename_property(cr, model, old_name, new_name):
@@ -24,8 +36,9 @@ def rename_property(cr, model, old_name, new_name):
         (new_name, field_ids))
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     rename_property(
         cr, 'product.template', 'cost_method', 'property_cost_method')
     rename_property(
@@ -36,3 +49,4 @@ def migrate(cr, version):
     rename_property(
         cr, 'product.category', 'property_stock_account_output_categ',
         'property_stock_account_output_categ_id')
+    openupgrade.rename_fields(env, field_renames)

--- a/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
@@ -19,11 +19,11 @@ column_copies = {
     ]
 }
 
-column_renames = {
-    'res_partner_bank': [
-        ('bank', 'bank_id'),
-    ],
-}
+field_renames = [
+    ('res.partner.bank', 'res_partner_bank', 'bank', 'bank_id'),
+    # renamings with oldname attribute - They also need the rest of operations
+    ('res.partner', 'res_partner', 'ean13', 'barcode'),
+]
 
 
 OBSOLETE_RULES = (
@@ -118,13 +118,14 @@ def map_res_partner_type(cr):
         table='res_partner', write='sql')
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     openupgrade.update_module_names(
         cr, apriori.renamed_modules.iteritems()
     )
     openupgrade.copy_columns(cr, column_copies)
-    openupgrade.rename_columns(cr, column_renames)
+    openupgrade.rename_fields(env, field_renames, no_deep=True)
     remove_obsolete(cr)
     pre_create_columns(cr)
     cleanup_modules(cr)


### PR DESCRIPTION
Depends on 

- [x] OCA/openupgradelib#84

This is a huge change, but it's only the result of applying 2 techniques:

* Use `rename_fields` with the existing renamed columns that are actually fields.
* Use `rename_fields` with the fields that have been handled by Odoo with `oldname` attribute (thanks @StefanRijnhart for including that lines in the analysis!)

With this, we improve even more our migration, handling:

* Fields that have been renamed and are translatable. The translations were missing before, so it can be considered this even a bug.
* If the fields are included in an export profile (first level for now), they are automatically handled.
* If the fields are included in a filter as domain (first level for now) or a group by, they are automatically handled.

@Tecnativa