### PR TITLE
[10.0][IMP] *: Use new rename_fields method

### DIFF
--- a/addons/account_asset/migrations/10.0.1.0/pre-migration.py
+++ b/addons/account_asset/migrations/10.0.1.0/pre-migration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - Vicent Cubells
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
@@ -11,7 +12,14 @@ column_renames = {
     ],
 }
 
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('account.asset.category', 'account_asset_category',
+     'account_income_recognition_id', 'account_depreciation_expense_id'),
+]
+
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     openupgrade.rename_columns(env.cr, column_renames)
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/calendar/migrations/10.0.1.0/pre-migration.py
+++ b/addons/calendar/migrations/10.0.1.0/pre-migration.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('calendar.event', 'calendar_event', 'class', 'privacy'),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/hr_attendance/migrations/10.0.2.0/pre-migration.py
+++ b/addons/hr_attendance/migrations/10.0.2.0/pre-migration.py
@@ -5,11 +5,9 @@
 
 from openupgradelib import openupgrade
 
-_column_renames = {
-    'hr_attendance': [
-        ('name', 'check_in'),
-    ],
-}
+_field_renames = [
+    ('hr.attendance', 'hr_attendance', 'name', 'check_in'),
+]
 
 
 @openupgrade.migrate()
@@ -28,6 +26,6 @@ def migrate(env, version):
         """DELETE FROM hr_attendance
         WHERE action != 'sign_in'"""
     )
-    openupgrade.rename_columns(env.cr, _column_renames)
+    openupgrade.rename_fields(env, _field_renames)
     env.ref('hr_attendance.property_rule_attendace_manager').unlink()
     env.ref('hr_attendance.property_rule_attendace_employee').unlink()

--- a/addons/marketing_campaign/migrations/10.0.1.1/pre-migration.py
+++ b/addons/marketing_campaign/migrations/10.0.1.1/pre-migration.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('marketing.campaign.activity', 'marketing_campaign_activity', 'type',
+     'action_type'),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_fields(env, field_renames)

--- a/addons/sale/migrations/10.0.1.0/pre-migration.py
+++ b/addons/sale/migrations/10.0.1.0/pre-migration.py
@@ -11,15 +11,18 @@ column_renames_sale_layout = {
     'sale_layout_category': [
         ('separator', None),
     ],
-    'account_invoice_line': [
-        ('sale_layout_cat_id', 'layout_category_id'),
-        ('categ_sequence', 'layout_category_sequence'),
-    ],
-    'sale_order_line': [
-        ('sale_layout_cat_id', 'layout_category_id'),
-        ('categ_sequence', 'layout_category_sequence'),
-    ],
 }
+
+field_renames_sale_layout = [
+    ('account.invoice.line', 'account_invoice_line', 'sale_layout_cat_id',
+     'layout_category_id'),
+    ('account.invoice.line', 'account_invoice_line', 'categ_sequence',
+     'layout_category_sequence'),
+    ('sale.order.line', 'sale_order_line', 'sale_layout_cat_id',
+     'layout_category_id'),
+    ('sale.order.line', 'sale_order_line', 'categ_sequence',
+     'layout_category_sequence'),
+]
 
 
 # rename_tables is not needed because "sale_layout.category" and
@@ -54,6 +57,7 @@ def migrate_sale_layout(env):
     )
     if openupgrade.is_module_installed(env.cr, 'sale_layout'):
         openupgrade.rename_columns(env.cr, column_renames_sale_layout)
+        openupgrade.rename_fields(env, field_renames_sale_layout)
         openupgrade.rename_models(env.cr, model_renames_sale_layout)
 
 
@@ -143,23 +147,21 @@ def sale_expense_update_module_names_partial(cr):
     openupgrade.logged_query(cr, query, (old_name, field_ids))
 
 
-def migrate_account_invoice_shipping_address(cr):
+def migrate_account_invoice_shipping_address(env):
     """The feature of this module is now on core, so we merge and change data
     accordingly.
     """
+    cr = env.cr
     module_name = 'account_invoice_shipping_address'
     if not openupgrade.is_module_installed(cr, module_name):
         return
     openupgrade.update_module_names(
         cr, [(module_name, 'sale')], merge_modules=True,
     )
-    openupgrade.rename_columns(
-        cr, {
-            'account_invoice': [
-                ('address_shipping_id', 'partner_shipping_id'),
-            ]
-        },
-    )
+    openupgrade.rename_fields(env, [
+        ('account.invoice', 'account_invoice', 'address_shipping_id',
+         'partner_shipping_id')
+    ])
 
 
 @openupgrade.migrate(use_env=True)
@@ -169,4 +171,4 @@ def migrate(env, version):
     cleanup_modules(env.cr)
     warning_update_module_names_partial(env.cr)
     sale_expense_update_module_names_partial(env.cr)
-    migrate_account_invoice_shipping_address(env.cr)
+    migrate_account_invoice_shipping_address(env)

--- a/addons/stock/migrations/10.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/10.0.1.1/pre-migration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Trescloud <http://trescloud.com>
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
@@ -12,6 +13,12 @@ column_copies = {
         ('route_sequence', None, None),
     ],
 }
+
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('stock.pack.operation', 'stock_pack_operation', 'processed_boolean',
+     'is_done'),
+]
 
 xmlid_renames = [
     ('stock.group_locations', 'stock.group_stock_multi_locations'),
@@ -64,4 +71,5 @@ def migrate(env, version):
     openupgrade.float_to_integer(cr, 'procurement_rule', 'route_sequence')
     openupgrade.float_to_integer(cr, 'stock_location_path', 'route_sequence')
     openupgrade.rename_xmlids(env.cr, xmlid_renames)
+    openupgrade.rename_fields(env, field_renames)
     warning_update_module_names_partial(cr)

--- a/addons/website_sale/migrations/10.0.1.0/pre-migration.py
+++ b/addons/website_sale/migrations/10.0.1.0/pre-migration.py
@@ -1,12 +1,21 @@
 # -*- coding: utf-8 -*-
-# © 2017 Therp BV
+# Copyright 2017 Therp BV
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
 
-@openupgrade.migrate(use_env=False)
-def migrate(cr, version):
+field_renames = [
+    # renamings with oldname attribute - They also need the rest of operations
+    ('product.attribute.value', 'product_attribute_value', 'color',
+     'html_color'),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
     # keeping info in website pricelist table that would be dropped
     sql = """create table website_pricelist_openupgrade_10 as select * from
         website_pricelist"""
-    cr.execute(sql)
+    env.cr.execute(sql)
+    openupgrade.rename_fields(env, field_renames)

--- a/odoo/openupgrade/doc/source/modules90-100.rst
+++ b/odoo/openupgrade/doc/source/modules90-100.rst
@@ -319,7 +319,7 @@ missing in the new release are marked with |del|.
 +-----------------------------------+-----------------------------------+
 | |del| marketing                   | Done -Merged in marketing_campaign|
 +-----------------------------------+-----------------------------------+
-|marketing_campaign                 | Nothing to do                     |
+|marketing_campaign                 | Done                              |
 +-----------------------------------+-----------------------------------+
 |marketing_campaign_crm_demo        | Nothing to do                     |
 +-----------------------------------+-----------------------------------+


### PR DESCRIPTION
Depends on 

- [x] OCA/openupgradelib#84

This is a huge change, but it's only the result of applying 2 techniques:

* Use `rename_fields` with the existing renamed columns that are actually fields.
* Use `rename_fields` with the fields that have been handled by Odoo with `oldname` attribute.

With this, we improve even more our migration, handling:

* Fields that have been renamed and are translatable. The translations were missing before, so it can be considered this even a bug.
* If the fields are included in an export profile (first level for now), they are automatically handled.
* If the fields are included in a filter as domain (first level for now) or a group by, they are automatically handled.

@Tecnativa