### PR TITLE
[FIX] Unset noupdate of regular view

### DIFF
--- a/addons/hr_attendance/migrations/9.0.1.1/openupgrade_analysis.txt
+++ b/addons/hr_attendance/migrations/9.0.1.1/openupgrade_analysis.txt
@@ -11,7 +11,11 @@ DEL ir.ui.menu: hr_attendance.menu_hr_attendance_graph
 DEL ir.ui.menu: hr_attendance.menu_open_view_attendance_reason
 NEW ir.ui.view: hr_attendance.hr_department_view_kanban
 NEW ir.ui.view: hr_attendance.view_hr_attendance_pivot
+
 DEL ir.ui.view: hr_attendance.hr_attendace_group
+# Done, set view to noupdate = false so that it is removed and does not block
+# the removal of the views that it inherits from
+
 DEL ir.ui.view: hr_attendance.hr_attendance_employee
 NEW res.groups: base.group_hr_manager
 DEL res.groups: base.group_hr_attendance

--- a/addons/hr_attendance/migrations/9.0.1.1/pre-migration.py
+++ b/addons/hr_attendance/migrations/9.0.1.1/pre-migration.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Opener B.V. <https://opener.amsterdam>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    env.cr.execute(
+        """ UPDATE ir_model_data SET noupdate = false
+        WHERE module = 'hr_attendance' AND name = 'hr_attendace_group' """)

--- a/openerp/openupgrade/tests_deferred/tests_deferred.py
+++ b/openerp/openupgrade/tests_deferred/tests_deferred.py
@@ -14,3 +14,9 @@ class TestDeferred(common.TransactionCase):
                 ('res_field', '=', 'image'),
                 ('res_name', '=', 'Axelor...'),
             ]).datas)
+
+    def test_hr_attendance_view_removed(self):
+        """ This view, which had the noupdate flag, is now successfully removed
+        """
+        with self.assertRaisesRegexp(ValueError, 'External ID not found'):
+            self.env.ref('hr_attendance.hr_attendace_group')


### PR DESCRIPTION
https://github.com/odoo/odoo/blob/8.0/addons/hr_attendance/res_config_view.xml#L3

This view is not removed because it was set to noupdate. As a result, the view that it depends on is not removed either.
