### PR TITLE
[FIX] event: Take into account nb_register

### DIFF
--- a/addons/event/migrations/9.0.0.1/end-migration.py
+++ b/addons/event/migrations/9.0.0.1/end-migration.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def create_multiple_attendees_registration_records(env):
+    """On v8, we have one event.registration record = one or several attendees
+    according nb_register field.
+
+    But on v9 we have one event.registration record = one attended, so here
+    we duplicate the existing record for representing the same number of
+    records than attendees.
+
+    Done in end-migration for having all the possible fields in
+    event.registration already loaded.
+    """
+    # Pre-create a column for storing original reference
+    column_name = openupgrade.get_legacy_name('original_registration_id')
+    table = 'event_registration'
+    if not openupgrade.column_exists(env.cr, table, column_name):
+        openupgrade.logged_query(
+            env.cr, """
+            ALTER TABLE %s 
+            ADD COLUMN %s INTEGER""" % (table, column_name)
+        )
+    env.cr.execute(
+        'SELECT id, nb_register FROM %s WHERE nb_register > 1' % table
+    )
+    data = dict(env.cr.fetchall())
+    for registration in env['event.registration'].browse(data.keys()):
+        new_registrations = env['event.registration']
+        for i in range(data[registration.id] - 1):
+            new_registrations += registration.copy()
+        openupgrade.logged_query(
+            env.cr, """
+            UPDATE %s
+            SET %s = %%s
+            WHERE id IN %%s""" % (table, column_name),
+            (registration.id, tuple(new_registrations.ids))
+        )
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    create_multiple_attendees_registration_records(env)

--- a/addons/event/migrations/9.0.0.1/openupgrade_analysis_work.txt
+++ b/addons/event/migrations/9.0.0.1/openupgrade_analysis_work.txt
@@ -76,7 +76,7 @@ event        / event.registration       / message_follower_ids (many2many): type
 # Concerns module Mail (has to be done in another migration script specifically for that module) ---> Nothing to do
 
 event        / event.registration       / nb_register (integer)         : DEL required: required, req_default: 1
-# Nothing to do: new relation
+# Done: Copy (nb_register-1) times the event.registration record for having the same effect with new structure: 1 record = 1 attendee
 
 event        / event.registration       / user_id (many2one)            : DEL relation: res.users
 # Nothing to do: new relation

--- a/openerp/openupgrade/tests_deferred/tests_deferred.py
+++ b/openerp/openupgrade/tests_deferred/tests_deferred.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2017 Opener B.V. <https://opener.am>
+# Copyright 2017 Opener B.V. <https://opener.am>
+# Copyright 2017 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openerp.tests import common
 
@@ -20,3 +21,8 @@ class TestDeferred(common.TransactionCase):
         """
         with self.assertRaisesRegexp(ValueError, 'External ID not found'):
             self.env.ref('hr_attendance.hr_attendace_group')
+
+    def test_event_migration(self):
+        self.assertEqual(
+            len(self.env.ref('event.event_1').registration_ids), 15,
+        )


### PR DESCRIPTION
On v8, we have one event.registration record = one or several attendees according nb_register field.

But on v9 we have one event.registration record = one attended, so here we duplicate the existing record for representing the same number of records than attendees.

Done in end-migration for having all the possible fields in event.registration already loaded.

@Tecnativa