### PR TITLE
[FIX+IMP] hr_expense: Fixes and improvements to current script

### DIFF
--- a/addons/hr_expense/migrations/10.0.2.0/post-migration.py
+++ b/addons/hr_expense/migrations/10.0.2.0/post-migration.py
@@ -23,11 +23,13 @@ def set_expense_responsible(env):
     openupgrade.logged_query(
         env.cr, """
         UPDATE hr_expense_sheet s
-        SET responsible_id = e.user_id
+        SET responsible_id = r.user_id
         FROM hr_department d,
-             hr_employee e
+             hr_employee e,
+             resource_resource r
         WHERE s.department_id = d.id
-            AND d.manager_id = e.id""",
+            AND d.manager_id = e.id
+            AND r.id = e.resource_id""",
     )
 
 

--- a/addons/hr_expense/migrations/10.0.2.0/pre-migration.py
+++ b/addons/hr_expense/migrations/10.0.2.0/pre-migration.py
@@ -4,9 +4,16 @@
 
 from openupgradelib import openupgrade
 
+column_copies = {
+    'hr_expense': [
+        ('state', None, None),
+    ]
+}
+
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
+    openupgrade.copy_columns(env.cr, column_copies)
     record = env.ref('hr_expense.action_client_expense_menu', False)
     if record:
         record.unlink()


### PR DESCRIPTION
* RFR: Extract methods with some migration operations.
* IMP: Use openupgrade.logged_query for seeing results in the log.
* IMP: Don't use subqueries in UPDATE where no needed
* FIX: set expense responsible was setting employee IDs, where it should be user IDs.
* IMP: Use openupgradelib `map_values` instead of several plain SQLs.
* FIX: Assign correctly product accounts using ORM and taking into account multi-company

There are still 2 operations without being checked, that are still in the main method.

@Tecnativa