### PR TITLE
[ADD] Migration of purchase order line invoice lines

### DIFF
--- a/addons/purchase/migrations/9.0.1.2/openupgrade_analysis_work.txt
+++ b/addons/purchase/migrations/9.0.1.2/openupgrade_analysis_work.txt
@@ -51,7 +51,7 @@ purchase     / purchase.order.line      / date_planned (date)           : type i
 #Nothing To Do : will get datetime automatically.
 
 purchase     / purchase.order.line      / invoice_lines (many2many)     : type is now 'one2many' ('many2many')
-#Nothing To Do : As there is already m2o (purchase_line_id) for purchase.order.line in account.invoice.line.
+#Done: migrated Many2many table to Many2one field on the invoice line (purchase_line_id)
 
 purchase     / purchase.order.line      / invoiced (boolean)            : DEL 
 #Nothing To Do : Functionality removed now no longer needed.

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -38,9 +38,24 @@ def map_order_state(cr):
         WHERE l.order_id = o.id""")
 
 
+def purchase_invoice_lines(cr):
+    """ odoo 8.0 introduced account.invoice.line's Many2one 'purchase_line_id'
+    but was not used until 9.0. Here, the 'invoice_lines' counterpart on the
+    purchase order line is migrated to a One2many field. The field already
+    exists, so it is easy to do in the pre-script so that the computation of
+    the invoiced quantities will be correct. """
+    openupgrade.logged_query(
+        cr,
+        """ UPDATE account_invoice_line ail
+        SET purchase_line_id = rel.order_line_id
+        FROM purchase_order_line_invoice_rel rel
+        WHERE rel.invoice_id = ail.id """)
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
     openupgrade.copy_columns(cr, column_copies)
     openupgrade.rename_fields(env, field_renames)
     map_order_state(cr)
+    purchase_invoice_lines(cr)


### PR DESCRIPTION
Odoo 8.0 introduced account.invoice.line's Many2one 'purchase_line_id but was not used until 9.0. Here, the 'invoice_lines' counterpart on the purchase order line is migrated to a One2many field. The field already exists, so it is easy to do in the pre-script so that the computation of the invoiced quantities will be correct.