### PR TITLE
[9.0][ADD] account_invoice_reorder_lines

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
@@ -87,6 +87,7 @@ def cleanup_modules(cr):
             # from OCA/crm - included in core
             ('crm_lead_lost_reason', 'crm'),
             # from OCA/sale-workflow - included in core
+            ('account_invoice_reorder_lines', 'account'),
             ('sale_order_back2draft', 'sale'),
             ('partner_prepayment', 'sale_delivery_block'),
             ('sale_fiscal_position_update', 'sale'),

--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -23,7 +23,6 @@ renamed_modules = {
     # same here, whoever want this will also need bank-payment
     'account_payment': 'account_payment_order',
     # OCA/account-invoicing
-    'account_invoice_reorder_lines': 'account_invoice_line_sequence',
     'account_refund_original': 'account_invoice_refund_link',
     'invoice_fiscal_position_update': 'account_invoice_fiscal_position_update',
     # OCA/stock-logistics-workflow


### PR DESCRIPTION
The feature has been included now in core. The field sequence already existed in 8, but the _order was not set. Now that order has been set, and the field name is the same, so nothing more to do, except merging the module for avoiding a missing module message.
 
@Tecnativa