### PR TITLE
[9.0][IMP]reassign carried_id

### DIFF
--- a/addons/delivery/migrations/9.0.1.0/post-migration.py
+++ b/addons/delivery/migrations/9.0.1.0/post-migration.py
@@ -28,9 +28,10 @@ def rename_property(cr, model, old_name, new_name):
 
 def reassign_carrier_id(cr):
     cr.execute("""
-        select id, openupgrade_legacy_9_0_carrier_id from delivery_carrier
-        where id != openupgrade_legacy_9_0_carrier_id;
-    """)
+        select id, %s from delivery_carrier
+        where id != %s;
+    """ % (openupgrade.get_legacy_name('carrier_id'),
+           openupgrade.get_legacy_name('carrier_id')),)
     for new_id, old_id in cr.fetchall():
         if openupgrade.table_exists(cr, 'sale_order') and \
                 openupgrade.column_exists(cr, 'sale_order', 'carrier_id'):

--- a/addons/delivery/migrations/9.0.1.0/post-migration.py
+++ b/addons/delivery/migrations/9.0.1.0/post-migration.py
@@ -28,20 +28,20 @@ def rename_property(cr, model, old_name, new_name):
 
 def reassign_carrier_id(cr):
     cr.execute("""
-        select id, openupgrade_legacy_9_0_carrier_id from delivery_carrier 
-        where id != openupgrade_legacy_9_0_carrier_id; 
+        select id, openupgrade_legacy_9_0_carrier_id from delivery_carrier
+        where id != openupgrade_legacy_9_0_carrier_id;
     """)
     for new_id, old_id in cr.fetchall():
         if openupgrade.table_exists(cr, 'sale_order') and \
                 openupgrade.column_exists(cr, 'sale_order', 'carrier_id'):
             cr.execute("""
-                UPDATE sale_order set carrier_id = %s 
+                UPDATE sale_order set carrier_id = %s
                 where carrier_id = %s
             """ % (new_id, old_id))
         if openupgrade.table_exists(cr, 'stock_picking') and \
                 openupgrade.column_exists(cr, 'stock_picking', 'carrier_id'):
             cr.execute("""
-                UPDATE stock_picking set carrier_id = %s 
+                UPDATE stock_picking set carrier_id = %s
                 where carrier_id = %s
             """ % (new_id, old_id))
 

--- a/addons/delivery/migrations/9.0.1.0/post-migration.py
+++ b/addons/delivery/migrations/9.0.1.0/post-migration.py
@@ -26,6 +26,26 @@ def rename_property(cr, model, old_name, new_name):
         (new_name, field_ids))
 
 
+def reassign_carrier_id(cr):
+    cr.execute("""
+        select id, openupgrade_legacy_9_0_carrier_id from delivery_carrier 
+        where id != openupgrade_legacy_9_0_carrier_id; 
+    """)
+    for new_id, old_id in cr.fetchall():
+        if openupgrade.table_exists(cr, 'sale_order') and \
+                openupgrade.column_exists(cr, 'sale_order', 'carrier_id'):
+            cr.execute("""
+                UPDATE sale_order set carrier_id = %s 
+                where carrier_id = %s
+            """ % (new_id, old_id))
+        if openupgrade.table_exists(cr, 'stock_picking') and \
+                openupgrade.column_exists(cr, 'stock_picking', 'carrier_id'):
+            cr.execute("""
+                UPDATE stock_picking set carrier_id = %s 
+                where carrier_id = %s
+            """ % (new_id, old_id))
+
+
 @openupgrade.migrate()
 def migrate(cr, version):
     cr.execute(
@@ -46,3 +66,4 @@ def migrate(cr, version):
         cr, 'res.partner', 'property_delivery_carrier',
         'property_delivery_carrier_id',
     )
+    reassign_carrier_id(cr)


### PR DESCRIPTION
This solves this issue: https://github.com/OCA/OpenUpgrade/issues/1212

When migrating, the ids for table delivery_carrier may change. There are references in sale_order and in stock_picking to delivery_carrier that need to be updated.