### PR TITLE
[ADD] Migration of field name translations

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/tests/base_data80.yml
+++ b/openerp/addons/base/migrations/9.0.1.3/tests/base_data80.yml
@@ -1,0 +1,8 @@
+-
+  Set a custom field name translation to verify its correct migration.
+  Take advantage of the fact that the French translation is already loaded in a
+  database with demo data installed.
+-
+  !python {model: ir.translation}: |
+    trans_ids = self.search(cr, uid, [('lang', '=', 'fr_FR'), ('name', '=', 'ir.module.module,summary'), ('type', '=', 'field')])
+    self.write(cr, uid, trans_ids, {'value': 'Custom translation'})

--- a/openerp/addons/base/migrations/9.0.1.3/tests/test_base.py
+++ b/openerp/addons/base/migrations/9.0.1.3/tests/test_base.py
@@ -20,3 +20,10 @@ class TestBase(common.TransactionCase):
         self.assertIn(
             self.env.ref('base.user_root'),
             self.env.ref('base.group_no_one').users)
+
+    def test_translation(self):
+        """ Existing field name translations are migrated correctly """
+        self.assertEqual(
+            self.env.ref('base.field_ir_module_module_summary').with_context(
+                lang='fr_FR')['field_description'],
+            'Custom translation')


### PR DESCRIPTION
Translations of field names are encoded differently in Odoo 9.0:
```
     version |           name                    | res_id |  type
    ---------+-----------------------------------+--------+-------
     8.0     | ir.module.module,summary          |      0 | field
     9.0     | ir.model.fields,field_description |    759 | model
```
This change migrates existing entries.