### PR TITLE
[9.0][FIX] hr_expense: quantity is missing on migration

### DIFF
--- a/addons/hr_expense/migrations/9.0.2.0/pre-migration.py
+++ b/addons/hr_expense/migrations/9.0.2.0/pre-migration.py
@@ -17,6 +17,7 @@ field_renames = [
     ('product.template', 'product_template', 'hr_expense_ok',
      'can_be_expensed'),
     ('hr.expense', 'hr_expense', 'note', 'description'),
+    ('hr.expense.line', 'hr_expense_line', 'unit_quantity', 'quantity'),
 ]
 
 table_renames = [


### PR DESCRIPTION
Needed to save quantity on migration.

@Tecnativa