### PR TITLE
[IMP] account_voucher: Use the voucher's number before comment.

### DIFF
--- a/addons/account_voucher/migrations/9.0.1.0/post-migration.py
+++ b/addons/account_voucher/migrations/9.0.1.0/post-migration.py
@@ -44,7 +44,7 @@ def create_payments_from_vouchers(env):
             END,
             av.journal_id, av.state, av.writeoff_acc_id, av.create_uid,
             av.write_date, av.write_uid,
-            COALESCE(av.name, av.comment),
+            COALESCE(av.name, av.number, av.comment),
             av.amount,
             CASE
                WHEN av.voucher_type = 'receipt' THEN 'inbound'


### PR DESCRIPTION
In a DB migration, I've found that most of the payments end-up being named 'Write-off' which is the default comment in Odoo 8.  This is because our clients use preferably the number instead of the name.  The comment is normally not changed because it's set when there are differences between credits and debits which is rare in our case.

Proposal: Use the number instead of the comment first.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
