### PR TITLE
[FIX 11.0] sale: typo in version and security group renamed

### DIFF
--- a/addons/sale/migrations/11.0.1.1/pre-migration.py
+++ b/addons/sale/migrations/11.0.1.1/pre-migration.py
@@ -1,16 +1,14 @@
 # -*- coding: utf-8 -*-
-# © 2017 bloopark systems (<http://bloopark.de>)
+# Copyright 2018 - Nicolas JEUDY
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openupgradelib import openupgrade
 
 _xmlid_renames = [
-    ('sale.group_display_incoterm', 'sale_stock.group_display_incoterm'),
+    ('account.group_proforma_invoices', 'sale.group_proforma_sales'),
 ]
 
 
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_xmlids(env.cr, _xmlid_renames)
-    openupgrade.load_data(
-        env.cr, 'sale', 'migrations/11.0.1.1/noupdate_changes.xml',
-    )


### PR DESCRIPTION
Sale module:

- Rename account.group_proforma_invoices security group
- Fix typo

Needed by #1196 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
