### PR TITLE
[11.0][FIX] remove unwanted migrations directory (2.0, 9.0.1.1)

### DIFF
--- a/addons/l10n_fr/migrations/2.0/post-migrate_tags_on_taxes.py
+++ b/addons/l10n_fr/migrations/2.0/post-migrate_tags_on_taxes.py
@@ -1,7 +1,0 @@
-from openerp.modules.registry import RegistryManager
-
-
-def migrate(cr, version):
-    registry = RegistryManager.get(cr.dbname)
-    from openerp.addons.account.models.chart_template import migrate_tags_on_taxes
-    migrate_tags_on_taxes(cr, registry)

--- a/addons/l10n_fr/migrations/9.0.1.1/post-migrate_tags_on_taxes.py
+++ b/addons/l10n_fr/migrations/9.0.1.1/post-migrate_tags_on_taxes.py
@@ -1,7 +1,0 @@
-from openerp.modules.registry import RegistryManager
-
-def migrate(cr, version):
-    registry = RegistryManager.get(cr.dbname)
-    from openerp.addons.account.models.chart_template import migrate_tags_on_taxes
-    migrate_tags_on_taxes(cr, registry)
-

--- a/addons/l10n_fr/migrations/9.0.1.1/pre-set_tags_and_taxes_updatable.py
+++ b/addons/l10n_fr/migrations/9.0.1.1/pre-set_tags_and_taxes_updatable.py
@@ -1,7 +1,0 @@
-from openerp.modules.registry import RegistryManager
-
-def migrate(cr, version):
-    registry = RegistryManager.get(cr.dbname)
-    from openerp.addons.account.models.chart_template import migrate_set_tags_and_taxes_updatable
-    migrate_set_tags_and_taxes_updatable(cr, registry, 'l10n_fr')
-


### PR DESCRIPTION
Some directory prevent from running openupgrade 11.0 script in french 10.0 databases :)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
