### PR TITLE
[IMP] [FIX] hr_timesheet: Precompute department_id in analytic lines.

### DIFF
--- a/addons/hr_timesheet/migrations/10.0.1.0/openupgrade_analysis.txt
+++ b/addons/hr_timesheet/migrations/10.0.1.0/openupgrade_analysis.txt
@@ -1,9 +1,10 @@
 ---Fields in module 'hr_timesheet'---
-hr_timesheet / account.analytic.account / use_timesheets (boolean)      : DEL 
-hr_timesheet / account.analytic.line    / is_timesheet (boolean)        : DEL 
+hr_timesheet / account.analytic.account / use_timesheets (boolean)      : DEL
+hr_timesheet / account.analytic.line    / is_timesheet (boolean)        : DEL
+hr_timesheet / account.analytic.line    / department_id (many2one)      : NEW relation: hr.project
 hr_timesheet / account.analytic.line    / project_id (many2one)         : NEW relation: project.project
 hr_timesheet / account.analytic.line    / task_id (many2one)            : previously in module project_timesheet
-hr_timesheet / project.project          / allow_timesheets (boolean)    : NEW 
+hr_timesheet / project.project          / allow_timesheets (boolean)    : NEW
 hr_timesheet / project.project          / subtask_project_id (many2one) : NEW relation: project.project
 hr_timesheet / project.task             / parent_id (many2one)          : NEW relation: project.task
 hr_timesheet / project.task             / timesheet_ids (one2many)      : NEW relation: account.analytic.line

--- a/addons/hr_timesheet/migrations/10.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/hr_timesheet/migrations/10.0.1.0/openupgrade_analysis_work.txt
@@ -6,6 +6,9 @@ hr_timesheet / project.project          / allow_timesheets (boolean)    : NEW
 hr_timesheet / account.analytic.line    / is_timesheet (boolean)        : DEL
 # Nothing to do
 
+hr_timesheet / account.analytic.line    / department_id (many2one)      : NEW relation: hr.project
+# Done: Fill it with any of the user's employees department
+
 hr_timesheet / account.analytic.line    / project_id (many2one)         : NEW relation: project.project
 # Done: Fill this field with the associated project if there's a task or an issue linked to the line
 

--- a/addons/hr_timesheet/migrations/10.0.1.0/pre-migration.py
+++ b/addons/hr_timesheet/migrations/10.0.1.0/pre-migration.py
@@ -11,6 +11,25 @@ COLUMN_RENAMES = {
 }
 
 
+def create_and_populate_department(cr):
+    cr.execute('''
+       ALTER TABLE account_analytic_line ADD COLUMN department_id INT;
+       ALTER TABLE account_analytic_line
+          ADD CONSTRAINT account_analytic_line_department_id_fkey
+          FOREIGN KEY (department_id) REFERENCES hr_department (id);
+
+       WITH departments AS (
+          SELECT r.user_id AS user_id, MAX(e.department_id) AS dpt_id
+             FROM hr_employee e JOIN resource_resource r
+                                ON e.resource_id = r.id
+          GROUP BY user_id
+       )
+       UPDATE account_analytic_line aal SET department_id=departments.dpt_id
+       FROM departments WHERE aal.user_id = departments.user_id;
+    ''')
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_columns(env.cr, COLUMN_RENAMES)
+    create_and_populate_department(env.cr)


### PR DESCRIPTION
The analytic lines have a new (related) reference to the user's department.  Which for many analytic lines (I have a DB with more than 270k) may take a very long time doing in it via the ORM.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
