### PR TITLE
[9.0][FIX] account: Fill tax_id in account.invoice.tax

### DIFF
--- a/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
@@ -233,8 +233,7 @@ account      / account.invoice.tax      / tax_amount (float)            : DEL
 
 account      / account.invoice.tax      / tax_code_id (many2one)        : DEL relation: account.tax.code
 account      / account.invoice.tax      / tax_id (many2one)             : NEW relation: account.tax
-# TODO: A mapping function should provide the transition from tax_code_ids to tax_ids. 
-  Use this function to get the new tax_id from the old tax_code_id.
+# Done: Post-migration - A function tries to infer the mapping from tax codes to taxes
 
 
 #### FIELDS IN MODEL ACCOUNT.JOURNAL ####


### PR DESCRIPTION
Method followed
===============

* If both codes are present in only one tax, then we can safely fill tax_id with that tax.
* If there are more than one tax with that tax codes, try to match tax with the name of the tax line.
* If still no single match, try to match only with active taxes.
* Finally, if there is no match, see if there's any tax code manual mapping for starting again the matching.

@Tecnativa