### PR TITLE
[IMP][FIX] hr_timesheet: Pre-compute news fields for sub-tasks.

### DIFF
--- a/addons/hr_timesheet/migrations/10.0.1.0/openupgrade_analysis.txt
+++ b/addons/hr_timesheet/migrations/10.0.1.0/openupgrade_analysis.txt
@@ -8,6 +8,8 @@ hr_timesheet / project.project          / allow_timesheets (boolean)    : NEW
 hr_timesheet / project.project          / subtask_project_id (many2one) : NEW relation: project.project
 hr_timesheet / project.task             / parent_id (many2one)          : NEW relation: project.task
 hr_timesheet / project.task             / timesheet_ids (one2many)      : NEW relation: account.analytic.line
+hr_timesheet / project.task             / children_hours (float)        : NEW computed field
+hr_timesheet / project.task             / total_hours_spent (float)     : NEW computed field
 ---XML records in module 'hr_timesheet'---
 NEW ir.actions.act_window: hr_timesheet.act_hr_timesheet_line
 NEW ir.actions.act_window: hr_timesheet.act_hr_timesheet_line_by_project

--- a/addons/hr_timesheet/migrations/10.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/hr_timesheet/migrations/10.0.1.0/openupgrade_analysis_work.txt
@@ -22,6 +22,11 @@ hr_timesheet / project.task             / parent_id (many2one)          : NEW re
 hr_timesheet / project.task             / timesheet_ids (one2many)      : NEW relation: account.analytic.line
 # Nothing to do: One2many field
 
+hr_timesheet / project.task             / children_hours (float)        : NEW computed field
+hr_timesheet / project.task             / total_hours_spent (float)     : NEW computed field
+# Done: Added in SQL in the pre-migration script
+
+
 ---XML records in module 'hr_timesheet'---
 NEW ir.actions.act_window: hr_timesheet.act_hr_timesheet_line
 NEW ir.actions.act_window: hr_timesheet.act_hr_timesheet_line_by_project


### PR DESCRIPTION
Odoo 10 adds a tree of sub-tasks (`parent_id` and `child_ids`) and two new computed fields `children_hours` and `total_hours_spent` over that structure.

The first one is defined recursively over the child_ids.  At the leaves of the tree children_hours is 0.  Since all tasks in the migration process would end-up being leaves of this structure, children_hours would be 0.

The field `total_hours_spent` is simply defined by `effective_hours + children_hours`.

The other fields in this computed method are kept invariant.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
