### PR TITLE
[10.0][IMP] purchase: Speed up copying of 'state' field in purchase lines.

### DIFF
--- a/addons/purchase/migrations/10.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/10.0.1.2/pre-migration.py
@@ -6,15 +6,10 @@ from openupgradelib import openupgrade
 
 
 def copy_state_to_purchase_lines(cr):
+    cr.execute('ALTER TABLE purchase_order_line ADD COLUMN state VARCHAR;')
     openupgrade.logged_query(cr, '''
-       ALTER TABLE purchase_order_line ADD COLUMN state VARCHAR;
-
-       WITH purchases AS (
-          SELECT id, state FROM purchase_order
-       )
        UPDATE purchase_order_line line SET state=po.state
-       FROM purchases po WHERE line.order_id=po.id;
-
+       FROM purchase_order po WHERE line.order_id=po.id;
     ''')
 
 

--- a/addons/purchase/migrations/10.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/10.0.1.2/pre-migration.py
@@ -6,7 +6,7 @@ from openupgradelib import openupgrade
 
 
 def copy_state_to_purchase_lines(cr):
-    cr.execute('''
+    openupgrade.logged_query(cr, '''
        ALTER TABLE purchase_order_line ADD COLUMN state VARCHAR;
 
        WITH purchases AS (

--- a/addons/purchase/migrations/10.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/10.0.1.2/pre-migration.py
@@ -1,7 +1,3 @@
-from __future__ import (division as _py3_division,
-                        print_function as _py3_print,
-                        absolute_import as _py3_abs_import)
-
 from openupgradelib import openupgrade
 
 

--- a/addons/purchase/migrations/10.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/10.0.1.2/pre-migration.py
@@ -1,0 +1,23 @@
+from __future__ import (division as _py3_division,
+                        print_function as _py3_print,
+                        absolute_import as _py3_abs_import)
+
+from openupgradelib import openupgrade
+
+
+def copy_state_to_purchase_lines(cr):
+    cr.execute('''
+       ALTER TABLE purchase_order_line ADD COLUMN state VARCHAR;
+
+       WITH purchases AS (
+          SELECT id, state FROM purchase_order
+       )
+       UPDATE purchase_order_line line SET state=po.state
+       FROM purchases po WHERE line.order_id=po.id;
+
+    ''')
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    copy_state_to_purchase_lines(env.cr)


### PR DESCRIPTION
This is just a speed improvement.  For me it also avoids an error, because we added another possible choice in the 'state' field in an addon.  Without this I get a `ValueError: Wrong value for purchase.order.line.state: 'paid'`.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
