### PR TITLE
[9.0] Add subscription to mail channel and keep posted messages

### DIFF
--- a/addons/mail/migrations/9.0.1.0/post-migration.py
+++ b/addons/mail/migrations/9.0.1.0/post-migration.py
@@ -54,6 +54,18 @@ def migrate(cr, version):
             and (sub.res_model = 'mail.channel' or sub.res_model is NULL)
         """
     )
+    # retrieve messages on channels
+    cr.execute(
+        """
+        INSERT INTO mail_message_mail_channel_rel (
+            mail_message_id, mail_channel_id
+        )
+        SELECT mm.id, mm.res_id
+        FROM mail_message mm
+        INNER JOIN mail_channel cc on cc.id = mm.res_id
+        WHERE mm.model = 'mail.channel'
+        """
+    )
     openupgrade.load_data(
         cr, 'mail', 'migrations/9.0.1.0/noupdate_changes.xml',
     )

--- a/addons/mail/migrations/9.0.1.0/post-migration.py
+++ b/addons/mail/migrations/9.0.1.0/post-migration.py
@@ -27,6 +27,33 @@ def migrate(cr, version):
         '(mail_message_id, res_partner_id) '
         'select distinct message_id, partner_id from mail_notification '
         'where starred')
+    # make channel listen itself: posting on a channel notifies the channel
+    cr.execute(
+        """
+        INSERT INTO mail_followers (
+            res_id, channel_id, res_model
+        )
+        SELECT
+            id, id, 'mail.channel'
+        FROM mail_channel
+        WHERE channel_type = 'channel'
+        """
+    )
+    # subscribe the channels to the defaults message subtypes(Discussions)
+    cr.execute(
+        """
+        INSERT INTO mail_followers_mail_message_subtype_rel(
+            mail_followers_id, mail_message_subtype_id
+        )
+        SELECT mf.id,sub.id
+        FROM mail_followers mf, mail_message_subtype sub
+        WHERE
+            mf.res_model='mail.channel'
+            and mf.partner_id is null
+            and sub.default = TRUE
+            and (sub.res_model = 'mail.channel' or sub.res_model is NULL)
+        """
+    )
     openupgrade.load_data(
         cr, 'mail', 'migrations/9.0.1.0/noupdate_changes.xml',
     )


### PR DESCRIPTION
After migrating a 'mail.group' to 'mail.channel' it must subscribe to itself, otherwise you won't see any message of migrated channel.

Fixes #1264.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
