### PR TITLE
[9.0] Improve migration of account.operation.template, field amount_type

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -1157,10 +1157,10 @@ def migrate(env, version):
     UPDATE account_journal SET bank_statements_source = 'manual'
     """)
 
-    # Value 'percentage_of_total' => 'percentage'
+    # Value 'percentage_of_total' and 'percentage_of_balance' => 'percentage'
     cr.execute("""
     UPDATE account_operation_template SET amount_type = 'percentage'
-    WHERE amount_type = 'percentage_of_total'
+    WHERE amount_type in ('percentage_of_total', 'percentage_of_balance')
     """)
 
     # Set up anglosaxon accounting


### PR DESCRIPTION
Field definition of amount_type on v8: https://github.com/odoo/odoo/blob/8.0/addons/account/account_bank_statement.py#L970
Field definition of amount_type on v9: https://github.com/odoo/odoo/blob/9.0/addons/account/models/account.py#L780

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
