### PR TITLE
[FIX] Computation of residual currency amount when reconciling moves …

### DIFF
--- a/addons/account_full_reconcile/migrations/9.0.1.1/post-migration.py
+++ b/addons/account_full_reconcile/migrations/9.0.1.1/post-migration.py
@@ -92,10 +92,15 @@ def migrate_reconcile(cr):
         currency_id = False
         rate = 1.0
         amount_currency = 0.0
-        if debit_record.line_currency_id and debit_record.amount_currency:
+        if debit_record.line_currency_id:
             currency_id = debit_record.line_currency_id
-            rate = abs(debit_record.balance / debit_record.amount_currency)
-            amount_currency = amount / rate
+            if debit_record.line_currency_id == credit_record.line_currency_id:
+                amount_currency = min(
+                    abs(debit_record.amount_residual_currency),
+                    abs(credit_record.amount_residual_currency))
+            elif debit_record.amount_currency:
+                rate = abs(debit_record.balance / debit_record.amount_currency)
+                amount_currency = amount / rate
         elif credit_record.line_currency_id and credit_record.amount_currency:
             currency_id = credit_record.line_currency_id
             rate = abs(credit_record.balance / credit_record.amount_currency)


### PR DESCRIPTION
…in the same currency

Don't apply the rate computation between outstanding amount and currency amount when
the currencies of both reconciled lines are the same, but derive the residual currency
amount directly from the two currency amounts of both lines. Analogous to
https://github.com/odoo/odoo/blob/9.0/addons/account/models/account_move.py#L857-L861

Fixes #1262
