### PR TITLE
[IMP] Set invalid custom views to inactive

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/tests/custom_view.yml
+++ b/openerp/addons/base/migrations/9.0.1.3/tests/custom_view.yml
@@ -1,0 +1,12 @@
+-
+    !python {model: ir.ui.view }: |
+        inherit_id = self.pool.get('ir.model.data').get_object_reference(
+            cr, uid, 'base', 'view_currency_form')[1]
+        self.create(
+            cr, uid, {
+                'model': 'res.currency',
+                'type': 'form',
+                'arch': '<field name="base" position="replace"/>',
+                'inherit_id': inherit_id,
+                'name': 'Invalid custom view',
+            })

--- a/openerp/modules/loading.py
+++ b/openerp/modules/loading.py
@@ -453,24 +453,6 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
 
         cr.commit()
 
-        # OpenUpgrade: run deferred tests
-        tests_dir = os.path.join(
-            os.path.dirname(os.path.abspath(deferred_90.__file__)),
-            'tests_deferred')
-        if update_module and os.environ.get('OPENUPGRADE_TESTS') and os.path.exists(
-                tests_dir):
-            import unittest
-            threading.currentThread().testing = True
-            tests = unittest.defaultTestLoader.discover(tests_dir, top_level_dir=tests_dir)
-            report.record_result(
-                unittest.TextTestRunner(
-                    verbosity=2,
-                    stream=openerp.modules.module.TestStream('deferred'),
-                ).run(tests).wasSuccessful()
-            )
-            threading.currentThread().testing = False
-        # OpenUpgrade edit end
-
         # STEP 5: Uninstall modules to remove
         if update_module:
             # Remove records referenced from ir_model_data for modules to be
@@ -522,5 +504,24 @@ def load_modules(db, force_demo=False, status=None, update_module=False):
             for module_name in cr.fetchall():
                 report.record_result(openerp.modules.module.run_unit_tests(module_name[0], cr.dbname, position=runs_post_install))
             _logger.log(25, "All post-tested in %.2fs, %s queries", time.time() - t0, openerp.sql_db.sql_counter - t0_sql)
+
+        # OpenUpgrade: run deferred tests
+        tests_dir = os.path.join(
+            os.path.dirname(os.path.abspath(deferred_90.__file__)),
+            'tests_deferred')
+        if update_module and os.environ.get('OPENUPGRADE_TESTS') and os.path.exists(
+                tests_dir):
+            import unittest
+            threading.currentThread().testing = True
+            tests = unittest.defaultTestLoader.discover(tests_dir, top_level_dir=tests_dir)
+            report.record_result(
+                unittest.TextTestRunner(
+                    verbosity=2,
+                    stream=openerp.modules.module.TestStream('deferred'),
+                ).run(tests).wasSuccessful()
+            )
+            threading.currentThread().testing = False
+        # OpenUpgrade edit end
+
     finally:
         cr.close()

--- a/openerp/openupgrade/tests_deferred/tests_deferred.py
+++ b/openerp/openupgrade/tests_deferred/tests_deferred.py
@@ -23,6 +23,17 @@ class TestDeferred(common.TransactionCase):
             self.env.ref('hr_attendance.hr_attendace_group')
 
     def test_event_migration(self):
+        try:
+            self.env['event.event']
+        except KeyError:
+            return  # test does not apply
         self.assertEqual(
             len(self.env.ref('event.event_1').registration_ids), 15,
         )
+
+    def test_invalid_custom_view(self):
+        """ Check that an invalid custom view has been set to inactive """
+        view = self.env['ir.ui.view'].with_context(active_test=False).search([
+            ('name', '=', 'Invalid custom view')])
+        self.assertTrue(view)
+        self.assertFalse(view.active)


### PR DESCRIPTION
Fixes #1271

A lot happens in this innocuous little bugfix

* Set invalid custom views to inactive (that's the actual bug)
* Add an invalid custom view in YML data
* Add a deferred test
* Refactor OpenUpgrade changes to view validation: raise on context value so that we know which views to set inactive
* Make sure context value is always passed
* Validate custom views without XML ID (upstream PR https://github.com/odoo/odoo/pull/23626)
* Move deferred tests until after custom views are validated
* Make sure deferred test for event module does not run if it is not installed

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
