### PR TITLE
[FIX] im_odoo_support view breaks web client (internal server error)

### DIFF
--- a/odoo/addons/base/migrations/10.0.1.3/post-migration.py
+++ b/odoo/addons/base/migrations/10.0.1.3/post-migration.py
@@ -1,11 +1,25 @@
 # coding: utf-8
-# © 2017 Opener BV <http://therp.nl>
+# © 2017-2018 Opener BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
 
+def handle_im_odoo_support_views(env):
+    """ im_odoo_support is a deprecated module, merged into im_livechat.
+    If this module is installed, a broken version of
+    im_odoo_support.assets_backend is left in the database which breaks the
+    web client after the migration. """
+    module = env['ir.module.module'].search([('name', '=', 'im_livechat')])
+    if module and module.state not in ('to upgrade', 'installed'):
+        view = env.ref('im_livechat.assets_backend', False)
+        if view and not env['ir.ui.view'].search([
+                ('inherit_id', '=', view.id)]):
+            view.unlink()
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
+    handle_im_odoo_support_views(env)
     openupgrade.load_data(
         env.cr, 'base', 'migrations/10.0.1.3/noupdate_changes.xml'
     )


### PR DESCRIPTION
im_odoo_support is a deprecated module, merged into im_livechat in OpenUpgrade 10.0
If the latter module is not installed on the 9.0 database, a broken version of im_odoo_support.assets_backend is left in the database which breaks the web client after the migration.

Note that im_odoo_support is installed by default on Odoo but not on OCB so none of the usual OpenUpgrade contributors noticed...

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
