### PR TITLE
Port/11.0/coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,16 +1,17 @@
-# Config file .coveragerc
-# adapt the include for your project
+[run]
+data_file = .coverage_mqt  # to avoid being overridden by server tests
+omit =
+    *system_site_packages*
+    *site-packages*
+include =
+    odoo/addons/base/migrations/*/*.py
+    addons/*/migrations/*/*.py
 
 [report]
-include =
-    addons/*/migrations
-    odoo/addons/*/migrations
-
-omit =
-    addons/*/migrations/*/tests
-    odoo/addons/*/migrations/*/tests
-
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma
     pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:


### PR DESCRIPTION
Cherrypicked from https://github.com/OCA/OpenUpgrade/commit/a0c0cb98. It wasn't ported with the rest of the framework because it was not whitelisted in .gitignore. This was fixed in https://github.com/OCA/OpenUpgrade/pull/1296

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
