### PR TITLE
[REN] rename mail_log_messages_to_process to mail_log_message_to_process

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -16,6 +16,8 @@ renamed_modules = {
         'hr_holidays_notify_employee_manager',
     # OCA/manufacture-reporting:
     'report_mrp_bom_matrix': 'mrp_bom_matrix_report',
+    # OCA/server-tools:
+    'mail_log_messages_to_process': 'mail_log_message_to_process',
 }
 
 renamed_models = {


### PR DESCRIPTION
Module renamed on migration from v9 to v10

* [ ] Depends on https://github.com/OCA/server-tools/pull/1214