### PR TITLE
[11.0][FIX] base_automation: Fix migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ script:
     # on unreleased features in openupgradelib
     - pip install --ignore-installed git+https://github.com/OCA/openupgradelib.git@master
     # select modules and perform the upgrade
-    - MODULES=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules100-110.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -n '/^|/ s/^|\([0-9a-z_]*\) *|.*$/\1/g p' | paste -d, -s)
+    - MODULES=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules100-110.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
     - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES | sed -e "s/,/','/g")')"
     - echo Testing modules $MODULES
     - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES --stop-after-init

--- a/addons/base_automation/migrations/11.0.1.0/end-migration.py
+++ b/addons/base_automation/migrations/11.0.1.0/end-migration.py
@@ -1,0 +1,16 @@
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def deactivate_invalid_model_rules(env):
+    """Deactivate rules with invalid models."""
+    for rule in env['base.automation'].search([]):
+        if not env.get(rule.model_name):
+            rule.active = False
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    deactivate_invalid_model_rules(env)

--- a/addons/base_automation/migrations/11.0.1.0/post-migration.py
+++ b/addons/base_automation/migrations/11.0.1.0/post-migration.py
@@ -1,0 +1,78 @@
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def migrate_act_user_id(env):
+    """Migrate action rules that have field act_user_id filled for assigning
+    a responsible, creating/updating the rule and adding the field
+    """
+    BaseAutomation = env['base.automation']
+    IrModelFields = env['ir.model.fields']
+    env.cr.execute(
+        "SELECT id, act_user_id "
+        "FROM base_automation "
+        "WHERE act_user_id IS NOT NULL"
+    )
+    for row in env.cr.fetchall():
+        rule = BaseAutomation.browse(row[0])
+        field = IrModelFields.search([
+            ('name', '=', 'user_id'),
+            ('model_id', '=', rule.model_id.id),
+        ])
+        if not field:
+            continue
+        if rule.child_ids:
+            # If the rule has server actions to run, duplicate it
+            new_rule = rule.copy({'child_ids': False})
+        else:
+            new_rule = rule
+        new_rule.write({
+            'state': 'object_write',
+            'fields_lines': [
+                (0, 0, {
+                    'col1': field.id,
+                    'type': 'value',
+                    'value': row[1],
+                }),
+            ]
+        })
+
+
+def migrate_act_followers(env):
+    """Migrate action rules that have field act_followers filled for adding
+    followers, creating/updating the rule and setting the new m2m.
+    """
+    BaseAutomation = env['base.automation']
+    env.cr.execute(
+        """SELECT DISTINCT(ba.id)
+        FROM base_automation ba,
+            base_action_rule_res_partner_rel rel
+        WHERE rel.base_action_rule_id = ba.id"""
+    )
+    for row in env.cr.fetchall():
+        rule = BaseAutomation.browse(row[0])
+        if rule.child_ids or rule.state != 'multi':
+            # If the rule has server actions to run or has been used already
+            # assigning a responsible, duplicate it
+            new_rule = rule.copy({'child_ids': False})
+        else:
+            new_rule = rule
+        env.cr.execute(
+            """SELECT res_partner_id
+            FROM base_action_rule_res_partner_rel
+            WHERE base_action_rule_id = %s"""
+        )
+        new_rule.write({
+            'state': 'followers',
+            'partner_ids': [
+                (6, 0, [x[0] for x in env.cr.fetchall()]),
+            ]
+        })
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    migrate_act_user_id(env)
+    migrate_act_followers(env)

--- a/addons/base_automation/migrations/11.0.1.0/tests/base_automation_test_data.yml
+++ b/addons/base_automation/migrations/11.0.1.0/tests/base_automation_test_data.yml
@@ -1,0 +1,24 @@
+-
+    create a server action for the rule
+-
+    !record {model: ir.actions.server, id: base_action_rule.test_action_server_multi}:
+      name: 'Test action server'
+      model_id: base_action_rule.model_base_action_rule_lead_test
+      condition: 'True'
+      type: 'ir.actions.server'
+      state: 'code'
+      code: 'True'
+
+-
+    create a rule with followers and server actions to run
+-
+    !record {model: base.action.rule, id: base_action_rule.test_rule_followers_multi}:
+      name: 'Test rule followers multi'
+      kind: 'on_create'
+      model_id: base_action_rule.model_base_action_rule_lead_test
+      act_followers:
+        - base.partner_demo
+        - base.partner_root
+      filter_id: base_action_rule.test_filter_draft
+      server_action_ids:
+        - base_action_rule.test_action_server_multi

--- a/addons/base_automation/migrations/11.0.1.0/tests/test_base_automation.py
+++ b/addons/base_automation/migrations/11.0.1.0/tests/test_base_automation.py
@@ -5,11 +5,27 @@ from odoo.tests import common
 
 
 class TestBaseAutomation(common.TransactionCase):
-    def test_rule_on_create(self):
-        record = self.env['base.automation'].search([
-            ('name', '=', 'Test rule on write'),
-        ])
+    def test_rule_on_write(self):
+        record = self.env.ref('base_automation.test_rule_on_write')
         self.assertTrue(record)
         self.assertEquals(record.filter_domain, "[('state', '=', 'done')]")
         self.assertEquals(record.filter_pre_domain, "[('state', '=', 'open')]")
         self.assertEquals(record.trigger, "on_write")
+        self.assertEquals(record.state, "object_write")
+        self.assertTrue(record.fields_lines)
+        self.assertEquals(record.fields_lines.value,
+                          self.env.ref('base.user_demo'))
+
+    def test_rule_followers_multi(self):
+        record = self.env.ref('base_automation.test_rule_followers_multi')
+        self.assertTrue(record)
+        self.assertTrue(record.child_ids)
+        rules = self.env['base.automation'].search([
+            ('name', '=', 'Test rule followers multi'),
+        ])
+        self.assertEquals(len(rules), 2)
+        new_record = rules - record
+        self.assertEquals(new_record.state, "followers")
+        followers = new_record.partners
+        self.assertIn(self.env.ref('base.partner_root'), followers)
+        self.assertIn(self.env.ref('base.partner_demo'), followers)


### PR DESCRIPTION
Depends on:

- [X] `add_fields` method in https://github.com/OCA/openupgradelib/pull/100

It turns out that migration was not correct all:

* Checking if module "base_action_rule" is installed will return always False, as the module has been renamed. Any way, we don't need to check it, as if the script is being executed is because the module was installed.
* Query for inserting ir_action_server record was not correct.
* The column for referencing the delegate field was not created.
* By default, queries don't return dictionaries with column names.
* Associated server actions to run weren't linked.

In addition, I have added:

* More tests
* If the fields for assigning a responsible or for adding followers are set, this is taken into account and translated to new system, so we can consider this now as a "pixel perfect" conversion.

@Tecnativa