### PR TITLE
[FIX+IMP] base: Add server action on cron + warnings + tests

### DIFF
--- a/odoo/addons/base/migrations/11.0.1.3/noupdate_changes.xml
+++ b/odoo/addons/base/migrations/11.0.1.3/noupdate_changes.xml
@@ -416,9 +416,6 @@
     <field name="currency_subunit_label">Centime</field>
     <field name="currency_unit_label">Franc</field>
   </record>
-  <record model="res.company" id="main_company">
-    <field name="rml_header1"/>
-  </record>
   <record model="res.partner" id="main_partner">
     <field name="image" type="base64" file="base/static/img/main_partner-image.png"/>
   </record>

--- a/odoo/addons/base/migrations/11.0.1.3/openupgrade_analysis_work.txt
+++ b/odoo/addons/base/migrations/11.0.1.3/openupgrade_analysis_work.txt
@@ -85,13 +85,11 @@ base         / ir.config_parameter      / group_ids (many2many)         : DEL re
 # NOTHING TO DO
 
 base         / ir.cron                  / _inherits (False)             : NEW 
-# Strange quirk from analysis
-
-base         / ir.cron                  / args (text)                   : DEL 
+base         / ir.cron                  / args (text)                   : DEL
 base         / ir.cron                  / function (char)               : DEL 
 base         / ir.cron                  / model (char)                  : DEL 
 base         / ir.cron                  / ir_actions_server_id (many2one): NEW relation: ir.actions.server, required: required
-# NOTHING TO DO, manually check needed for action server relations after migration
+# Done: pre-migration. Create manually ir.actions.server record
 
 base         / ir.cron                  / interval_type (selection)     : selection_keys is now '['days', 'hours', 'minutes', 'months', 'weeks']' ('['days', 'hours', 'minutes', 'months', 'weeks', 'work_days']')
 # DONE map value 'work_days' to 'days'

--- a/odoo/addons/base/migrations/11.0.1.3/tests/ir_cron_v10.yml
+++ b/odoo/addons/base/migrations/11.0.1.3/tests/ir_cron_v10.yml
@@ -1,0 +1,12 @@
+-
+    create a ir.cron record
+-
+    !record {model: ir.cron, id: base.cron_test_migration}:
+      name: 'Test cron for migration'
+      model: 'res.partner'
+      function: '_commercial_sync_from_company'
+      args: '()'
+      numbercall: 1
+      doall: False
+      interval_number: 1
+      interval_type: 'months'

--- a/odoo/addons/base/migrations/11.0.1.3/tests/test_ir_cron.py
+++ b/odoo/addons/base/migrations/11.0.1.3/tests/test_ir_cron.py
@@ -1,0 +1,16 @@
+# coding: utf-8
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests.common import TransactionCase
+
+
+class TestIrCron(TransactionCase):
+    def test_ir_cron(self):
+        cron = self.env.ref('base.cron_test_migration')
+        self.assertTrue(cron)
+        self.assertTrue(cron.ir_actions_server_id)
+        self.assertEquals(
+            cron.ir_actions_server_id.code,
+            'records._commercial_sync_from_company()',
+        )


### PR DESCRIPTION
I continue refining existing scripts. For base, ir.cron records shouldn't be let in an inconsistent state without proper server action, as they won't update properly. There's a warning about a missing field in noupdate XML data removed, and I have added tests for the ir.cron thing.

@Tecnativa