### PR TITLE
[FIX] .travis.yml: Module list for previous version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,11 @@ script:
     # on unreleased features in openupgradelib
     - pip install --ignore-installed git+https://github.com/OCA/openupgradelib.git@master
     # select modules and perform the upgrade
-    - MODULES=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules100-110.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
-    - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES | sed -e "s/,/','/g")')"
-    - echo Testing modules $MODULES
-    - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES --stop-after-init
+    - MODULES_OLD=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules100-110.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|del\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
+    - MODULES_NEW=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules100-110.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
+    - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES_OLD | sed -e "s/,/','/g")')"
+    - echo Testing modules $MODULES_NEW
+    - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init
     # try to build the documentation
     - pip install sphinx
     - sh scripts/build_openupgrade_docs

--- a/addons/base_automation/migrations/11.0.1.0/pre-migration.py
+++ b/addons/base_automation/migrations/11.0.1.0/pre-migration.py
@@ -100,10 +100,16 @@ def create_ir_actions_server(env):
             """, (srv_act_id, act['id']),
         )
         # Write in the base.automation record the parent ir.actions.server ID
-        env.cr.execute(
-            "UPDATE base_automation SET action_server_id = %s WHERE id = %s",
-            (srv_act_id, act['id']),
-        )
+        # and possible filters
+        set_query = "action_server_id = %s"
+        params = [srv_act_id]
+        for field in ['filter_domain', 'filter_pre_domain']:
+            if vals.get(field):
+                set_query += ', %s = %%s' % field
+                params.append(vals[field])
+        params.append(act['id'])
+        query = 'UPDATE base_automation SET %s WHERE id = %%s' % set_query
+        openupgrade.logged_query(env.cr, query, tuple(params))
 
 
 @openupgrade.migrate(use_env=True)

--- a/addons/base_automation/migrations/11.0.1.0/tests/base_automation_test_data.yml
+++ b/addons/base_automation/migrations/11.0.1.0/tests/base_automation_test_data.yml
@@ -3,7 +3,7 @@
 -
     !record {model: ir.actions.server, id: base_action_rule.test_action_server_multi}:
       name: 'Test action server'
-      model_id: base_action_rule.model_base_action_rule_lead_test
+      model_id: base.model_res_partner
       condition: 'True'
       type: 'ir.actions.server'
       state: 'code'
@@ -15,10 +15,18 @@
     !record {model: base.action.rule, id: base_action_rule.test_rule_followers_multi}:
       name: 'Test rule followers multi'
       kind: 'on_create'
-      model_id: base_action_rule.model_base_action_rule_lead_test
+      model_id: base.model_res_partner
       act_followers:
         - base.partner_demo
         - base.partner_root
-      filter_id: base_action_rule.test_filter_draft
       server_action_ids:
         - base_action_rule.test_action_server_multi
+-
+    create a rule with only followers
+-
+    !record {model: base.action.rule, id: base_action_rule.test_rule_followers_only}:
+      name: 'Test rule followers only'
+      kind: 'on_create'
+      model_id: base.model_res_partner
+      act_followers:
+        - base.partner_demo

--- a/addons/base_automation/migrations/11.0.1.0/tests/test_base_automation.py
+++ b/addons/base_automation/migrations/11.0.1.0/tests/test_base_automation.py
@@ -13,8 +13,9 @@ class TestBaseAutomation(common.TransactionCase):
         self.assertEquals(record.trigger, "on_write")
         self.assertEquals(record.state, "object_write")
         self.assertTrue(record.fields_lines)
-        self.assertEquals(record.fields_lines.value,
-                          self.env.ref('base.user_demo'))
+        self.assertEquals(
+            int(record.fields_lines.value), self.env.ref('base.user_demo').id,
+        )
 
     def test_rule_followers_multi(self):
         record = self.env.ref('base_automation.test_rule_followers_multi')
@@ -26,6 +27,13 @@ class TestBaseAutomation(common.TransactionCase):
         self.assertEquals(len(rules), 2)
         new_record = rules - record
         self.assertEquals(new_record.state, "followers")
-        followers = new_record.partners
+        followers = new_record.partner_ids
         self.assertIn(self.env.ref('base.partner_root'), followers)
         self.assertIn(self.env.ref('base.partner_demo'), followers)
+
+    def test_rule_followers_only(self):
+        record = self.env.ref('base_automation.test_rule_followers_only')
+        self.assertTrue(record)
+        self.assertEquals(
+            self.env.ref('base.partner_demo'), record.partner_ids,
+        )

--- a/odoo/openupgrade/doc/source/modules100-110.rst
+++ b/odoo/openupgrade/doc/source/modules100-110.rst
@@ -481,9 +481,9 @@ missing in the new release are marked with |del|.
 +-----------------------------------+-------------------------------------------------+
 |stock_landed_costs                 |                                                 |
 +-----------------------------------+-------------------------------------------------+
-| |new| stock_picking_batch         | Done - Renamed from stock_picking_wave          |
+| |new| stock_picking_batch         | Blocked - Renamed from stock_picking_wave       |
 +-----------------------------------+-------------------------------------------------+
-| |del| stock_picking_wave          | Done - Renamed to stock_picking_batch           |
+| |del| stock_picking_wave          | Blocked - Renamed to stock_picking_batch        |
 +-----------------------------------+-------------------------------------------------+
 | |del| subscription                |                                                 |
 +-----------------------------------+-------------------------------------------------+


### PR DESCRIPTION
The list of modules for marking as installed in the DB should be the one from the previous version, so it should include those with the `|del|` mark.

Let's see if this one is the definitive.

@Tecnativa