### PR TITLE
[10.0][FIX] .travis.yml: Module list for previous version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,10 +62,11 @@ script:
     # on unreleased features in openupgradelib
     - pip install --ignore-installed git+https://github.com/OCA/openupgradelib.git@master
     # select modules and perform the upgrade
-    - MODULES=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules90-100.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
-    - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES | sed -e "s/,/','/g")')"
-    - echo Testing modules $MODULES
-    - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES --stop-after-init
+    - MODULES_OLD=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules90-100.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|del\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
+    - MODULES_NEW=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules90-100.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
+    - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES_OLD | sed -e "s/,/','/g")')"
+    - echo Testing modules $MODULES_NEW
+    - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init
     # try to build the documentation
     - pip install sphinx
     - sh scripts/build_openupgrade_docs


### PR DESCRIPTION
The list of modules for marking as installed in the DB should be the one from the previous version, so it should include those with the |del| mark.

Cherry-pick from https://github.com/OCA/OpenUpgrade/pull/1307.