### PR TITLE
[FIX+IMP] sale_stock: Recompute delivered qty + mgiration from v8

### DIFF
--- a/addons/sale_stock/migrations/10.0.1.0/post-migration.py
+++ b/addons/sale_stock/migrations/10.0.1.0/post-migration.py
@@ -1,17 +1,35 @@
 # -*- coding: utf-8 -*-
-# © 2017 bloopark systems (<http://bloopark.de>)
+# Copyright 2017 bloopark systems (<http://bloopark.de>)
+# Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
 from openupgradelib import openupgrade
 
 
-def update_to_refund_so(cr):
+def update_to_refund_so(env):
+    cr = env.cr
+    where_clause = "WHERE origin_returned_move_id IS NOT NULL"
+    # If there's a migration from v8, use the field to say if return is
+    # refundable or not
+    column_name = 'openupgrade_legacy_9_0_invoice_state'
+    if openupgrade.column_exists(cr, 'stock_move', column_name):
+        where_clause += " AND %s != 'none'" % column_name
+    query = "SELECT id FROM stock_move %s" % where_clause
+    cr.execute(query)
+    move_ids = [x[0] for x in cr.fetchall()]
+    if not move_ids:
+        return
     openupgrade.logged_query(
-        cr, """UPDATE stock_move SET to_refund_so=True
-               WHERE origin_returned_move_id IS NOT NULL"""
+        cr, "UPDATE stock_move SET to_refund_so=True WHERE id IN %s",
+        (tuple(move_ids), ),
     )
+    # Recompute delivered quantities
+    moves = env['stock.move'].browse(move_ids)
+    sale_order_lines = moves.mapped('procurement_id.sale_line_id')
+    for line in sale_order_lines:
+        line.qty_delivered = line._get_delivered_qty()
 
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    cr = env.cr
-    update_to_refund_so(cr)
+    update_to_refund_so(env)


### PR DESCRIPTION
* After setting `to_refund_so` field, we need to recompute the delivered qty, as it's not a computed field.
* If you come from a v8 migration, take into account the `invoice_status` field that excludes some returns from being invoiceable.

@Tecnativa