### PR TITLE
[FIX] load noupdate data with mode init_no_create

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/post-migration.py
@@ -98,6 +98,7 @@ def migrate(env, version):
     set_filter_active(env.cr)
     openupgrade.load_data(
         env.cr, 'base', 'migrations/9.0.1.3/noupdate_changes.xml',
+        mode='init_no_create',
     )
     assign_view_keys(env)
     publish_attachments(env)


### PR DESCRIPTION
without this, migrations can break if some of the records are removed