### PR TITLE
[9.0][FIX] sale_stock: Compute delivered quantities in some conditions

### DIFF
--- a/addons/sale_mrp/migrations/9.0.1.0/post-migrate.py
+++ b/addons/sale_mrp/migrations/9.0.1.0/post-migrate.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV (<http://acsone.eu>)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+# TODO: Set delivered_qty in sale order lines with bom
+# See https://github.com/OCA/OpenUpgrade/pull/1410

--- a/addons/sale_stock/migrations/9.0.1.0/post-migrate.py
+++ b/addons/sale_stock/migrations/9.0.1.0/post-migrate.py
@@ -83,6 +83,9 @@ def set_sale_order_qty_delivered(env):
                 AND sm.location_dest_id in %s
             GROUP by sol.id) a
          WHERE sol.id = line_id""", (loc_ids,))
+    # Take only records that have the same products on both move and
+    # sale order lines as unit categories could be different if
+    # bom (phantom) are used.
     env.cr.execute("""\
         SELECT sol.id, sm.id
         FROM sale_order_line sol
@@ -90,6 +93,7 @@ def set_sale_order_qty_delivered(env):
             JOIN stock_move sm ON sm.procurement_id = po.id
         WHERE sm.state = 'done'
             AND sm.product_uom != sol.product_uom
+            AND sm.product_id = sol.product_id
             AND sm.location_dest_id in %s""", (loc_ids,))
     so_qty_map = {}
     uom_obj = env['product.uom']


### PR DESCRIPTION
If the product delivered is different from the ordered one, don't call compute_qty_obj
as the unit categories could be different.
This is typically the use case with mrp.bom.

That avoid crash
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
