### PR TITLE
[9.0][FIX] Switch property rename from post migration to pre migration script

### DIFF
--- a/addons/delivery/migrations/9.0.1.0/post-migration.py
+++ b/addons/delivery/migrations/9.0.1.0/post-migration.py
@@ -6,26 +6,6 @@
 from openupgradelib import openupgrade
 
 
-def rename_property(cr, model, old_name, new_name):
-    """Rename property old_name to new_name. This should happen in a
-    pre-migration script."""
-    # TODO: propose this to openupgradelib
-    cr.execute(
-        "update ir_model_fields f set name=%s "
-        "from ir_model m "
-        "where m.id=f.model_id and m.model=%s and f.name=%s "
-        "returning f.id",
-        (new_name, model, old_name))
-    field_ids = tuple(i for i, in cr.fetchall())
-    cr.execute(
-        "update ir_model_data set name=%s where model='ir.model.fields' and "
-        "res_id in %s",
-        ('%s,%s' % (model, new_name), field_ids))
-    cr.execute(
-        "update ir_property set name=%s where fields_id in %s",
-        (new_name, field_ids))
-
-
 @openupgrade.migrate()
 def migrate(cr, version):
     cr.execute(
@@ -41,8 +21,4 @@ def migrate(cr, version):
             openupgrade.get_legacy_name('delivery_carrier'),
             openupgrade.get_legacy_name('carrier_id'),
         )
-    )
-    rename_property(
-        cr, 'res.partner', 'property_delivery_carrier',
-        'property_delivery_carrier_id',
     )

--- a/addons/delivery/migrations/9.0.1.0/pre-migration.py
+++ b/addons/delivery/migrations/9.0.1.0/pre-migration.py
@@ -136,3 +136,6 @@ def migrate(env, version):
     openupgrade.rename_fields(env, field_renames)
     correct_rule_prices(cr)
     openupgrade.rename_tables(cr, table_renames)
+    openupgrade.rename_property(
+        cr,'res.partner', 'property_delivery_carrier',
+        'property_delivery_carrier_id')


### PR DESCRIPTION
Pull Request to fix the problem described here : https://github.com/OCA/OpenUpgrade/issues/1308

I dug into the problem to understand why I had this bug when nobody else seemed to have it...
And here is the reason. It is a migration from 7 to 9 and the module base_custom_attributes add a sql constraint on the name column of ir_model_fields : https://github.com/OCA/product-attribute/blob/7.0/base_custom_attributes/ir_model.py#L37

That is why Openupgrade failed for my database.
For other, the constraint does not exist, so OpenUpgrade allow to have a duplicate ir_model_fields.

I juste made a verification on a recenttly migrated database of a colleague, and the database contains 2 records of ir.model.fields with name `property_delivery_carrier_id` (and `model` `res.partner`).
Which is only possible because Openupgrade by pass the orm.

@pedrobaeza @StefanRijnhart 



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
