### PR TITLE
[FIX] Purchase requisition setting on products

### DIFF
--- a/addons/purchase_requisition/migrations/9.0.0.1/post-migration.py
+++ b/addons/purchase_requisition/migrations/9.0.0.1/post-migration.py
@@ -3,14 +3,17 @@
 # Jordi Ballester Alomar
 # © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
-
+from psycopg2.extensions import AsIs
 from openupgradelib import openupgrade
 
 
 @openupgrade.migrate()
 def migrate(cr, version):
     # Mapping new values for purchase_requisition
-    openupgrade.map_values(
-        cr, openupgrade.get_legacy_name('purchase_requisition'),
-        'purchase_requisition', [(True, 'tenders'), (False, 'rfq')],
-        table='product_template')
+    column = openupgrade.get_legacy_name('purchase_requisition')
+    openupgrade.logged_query(
+        cr, """UPDATE product_template SET purchase_requisition = 'rfq'
+        WHERE %s IS NOT TRUE""", (AsIs(column),))
+    openupgrade.logged_query(
+        cr, """UPDATE product_template SET purchase_requisition = 'tenders'
+        WHERE %s""",  (AsIs(column),))

--- a/addons/purchase_requisition/migrations/9.0.0.1/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/migrations/9.0.0.1/tests/test_purchase_requisition.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+# Copyright 2018 Opener B.V. <https://opener.amsterdam>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openerp.tests.common import TransactionCase
+
+
+class TestPurchaseRequisition(TransactionCase):
+    def test_purchase_requisition(self):
+        """ Product setting was migrated properly """
+        self.assertEqual(
+            self.env.ref('product.product_product_13').purchase_requisition,
+            'tenders')
+        self.assertEqual(
+            self.env.ref('product.product_product_48').purchase_requisition,
+            'rfq')


### PR DESCRIPTION
[FIX] Purchase requisition setting on products
The previously used method openupgrade.map_values currently does not support
mapping away from boolean values as these are mapped to 'is (not) set'.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
