### PR TITLE
[MIG] l10n_be: tax tags from tax codes

### DIFF
--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -13,11 +13,6 @@ _logger = logging.getLogger(__name__)
 
 
 MIG_TAX_LINE_PREFIX = "[8 to 9 tax migration] "
-
-# Set this to True if you want to attempt to reuse existing taxes
-# on move lines. If False, a new inactive tax is created for each
-# tax code used on move lines.
-MIG_TAX_REUSE = False
 MIG_TAX_PREFIX = "Mig Code "
 
 
@@ -30,16 +25,18 @@ def _load_code2tag(env):
         code_code_index = header.index('account.tax.code:code')
         tag_xmlid_index = header.index('account.account.tag:xmlid')
         ttype_index = header.index('ttype')
+        dc_index = header.index('sign')
         for row in reader:
             code_code = row[code_code_index]
             tag_xmlid = row[tag_xmlid_index]
             ttype = row[ttype_index]
+            dc = row[dc_index]
             if not code_code:
                 continue
             if tag_xmlid:
-                res[code_code] = (env.ref(tag_xmlid), ttype)
+                res[code_code] = (env.ref(tag_xmlid), ttype, dc)
             else:
-                res[code_code] = (None, None)
+                res[code_code] = (None, None, None)
     return res
 
 
@@ -53,46 +50,11 @@ def _load_codeid2code(env):
     return res
 
 
-def set_tax_tags_from_tax_codes(env, company_id, codeid2tag):
-    _logger.info(
-        "Setting tax tags from tax codes from company %s",
-        company_id,
-    )
-    taxes = env['account.tax'].search([
-        ('company_id', '=', company_id),
-    ])
-    for tax in taxes:
-        tags = []
-        env.cr.execute("""
-            SELECT
-              base_code_id, tax_code_id,
-              ref_base_code_id, ref_tax_code_id
-            FROM account_tax
-            WHERE id = %s
-        """, (tax.id, ))
-        for code_id in env.cr.fetchone():
-            if not code_id:
-                continue
-            tag, _ = codeid2tag.get(code_id)
-            if tag:
-                tags.append(tag)
-            else:
-                _logger.error(
-                    "Tax %s [%s] references tax code %s which does "
-                    "not map to a tax tag. You need to resolve this "
-                    "manually.",
-                    tax.name, tax.id, code_id,
-                )
-        tax.write({
-            'tag_ids': [(6, 0, [t.id for t in tags])],
-        })
-
-
 def _create_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag):
     """ Create an inactive tax that is linked to a single tax tag
     correponding to the provided tax_code_id.
     """
-    tax_tag, _ = codeid2tag.get(tax_code_id)
+    tax_tag, _, _ = codeid2tag.get(tax_code_id)
     if not tax_tag:
         _logger.error(
             "Tax code with id [%s] does "
@@ -122,387 +84,124 @@ def _create_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag):
     return tax
 
 
-def _get_tax_from_tax_code(env, company_id, tax_code_id, inv_type,
-                           codeid2tag, tc2t):
+def _get_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag, tc2t):
     """ Obtain a tax corresponding to the provided tax_code_id
-    and invoice type. Try to determine if this tax code is
-    used as base or tax.
 
-    Return tax_id, tax type ('base' or 'tax' or None)
+    Return tax_id, tax type ('base' or 'tax' or None), 'deb' or 'crd'
     """
-    if (tax_code_id, inv_type) in tc2t:
-        return tc2t[(tax_code_id, inv_type)]
-    #
-    # 1. find out ttype (base or tax)
-    #
-    _, ttype = codeid2tag.get(tax_code_id)
-    base_where = []
-    tax_where = []
-    if inv_type == 'in_invoice':
-        base_where.append(
-            "base_code_id=%(tax_code_id)s AND "
-            "type_tax_use='purchase'"
-        )
-        tax_where.append(
-            "tax_code_id=%(tax_code_id)s AND "
-            "type_tax_use='purchase'"
-        )
-    elif inv_type == 'out_invoice':
-        base_where.append(
-            "base_code_id=%(tax_code_id)s AND "
-            "type_tax_use='sale'"
-        )
-        tax_where.append(
-            "tax_code_id=%(tax_code_id)s AND "
-            "type_tax_use='sale'"
-        )
-    elif inv_type == 'in_refund':
-        base_where.append(
-            "ref_base_code_id=%(tax_code_id)s AND "
-            "type_tax_use='purchase'"
-        )
-        tax_where.append(
-            "ref_tax_code_id=%(tax_code_id)s AND "
-            "type_tax_use='purchase'"
-        )
-    elif inv_type == 'out_refund':
-        base_where.append(
-            "ref_base_code_id=%(tax_code_id)s AND "
-            "type_tax_use='sale'"
-        )
-        tax_where.append(
-            "ref_tax_code_id=%(tax_code_id)s AND "
-            "type_tax_use='sale'"
-        )
-    else:
-        base_where.append(
-            "base_code_id=%(tax_code_id)s OR "
-            "ref_base_code_id=%(tax_code_id)s"
-        )
-        tax_where.append(
-            "tax_code_id=%(tax_code_id)s OR "
-            "ref_tax_code_id=%(tax_code_id)s"
-        )
-    base_where = base_where[0]
-    env.cr.execute(
-        "SELECT id FROM account_tax WHERE " + base_where,
-        {'tax_code_id': tax_code_id},
+    if tax_code_id in tc2t:
+        return tc2t[tax_code_id]
+
+    _, ttype, dc = codeid2tag.get(tax_code_id)
+
+    tax = _create_tax_from_tax_code(
+        env, company_id, tax_code_id, codeid2tag,
     )
-    base_tax_ids = env.cr.fetchall()
-    tax_where = tax_where[0]
-    env.cr.execute(
-        "SELECT id FROM account_tax WHERE " + tax_where,
-        {'tax_code_id': tax_code_id},
-    )
-    tax_tax_ids = env.cr.fetchall()
-    if not ttype:
-        if base_tax_ids and not tax_tax_ids:
-            ttype = 'base'
-        elif tax_tax_ids and not base_tax_ids:
-            ttype = 'tax'
-    #
-    # 2. find out tax or create a new one
-    #
-    tax_ids = base_tax_ids + tax_tax_ids
-    if MIG_TAX_REUSE and len(tax_ids) == 1:
-        tax_id = tax_ids[0]
-    else:
-        if MIG_TAX_REUSE and not tax_ids:
-            _logger.warning(
-                "No tax found using tax_code_id [%s] and invoice "
-                "type '%s', creating one.",
-                tax_code_id, inv_type,
-            )
-        # several taxes use this code, create one
-        # and cache those we have created
-        if (tax_code_id, 'mig') in tc2t:
-            tax_id = tc2t[(tax_code_id, 'mig')]
-        else:
-            tax = _create_tax_from_tax_code(
-                env, company_id, tax_code_id, codeid2tag,
-            )
-            tax_id = tax.id if tax else None
-            tc2t[(tax_code_id, 'mig')] = tax_id
-    tc2t[(tax_code_id, inv_type)] = (tax_id, ttype)
-    return tax_id, ttype
+    tax_id = tax.id if tax else None
+    tc2t[tax_code_id] = (tax_id, ttype, dc)
+
+    return tax_id, ttype, dc
 
 
 def set_aml_taxes(env, company_id, codeid2tag):
     tc2t = {}
-    ambiguous_tax_codes = []
-    #
-    # Step 1.
-    #
-    # Handle the normal case: debit or credit != 0 and tax amount != 0
-    #
-    # * If the tax code can be unambiguously linked to a tax for use
-    #   as tax amount, use it for tax_line_id.
-    # * If the tax code can be unambiguously linked to a tax for use
-    #   as base amount, us it for tax_ids
-    #
-    # If the tax code may be used for base or tax, keep it
-    # a list of ambiguous tax code that we'll attempt to diambiguate
-    # in step 2.
-    #
-    _logger.info("set_aml_taxes step 1 for company %s", company_id)
+    _logger.info("set_aml_taxes step for company %s", company_id)
     env.cr.execute(
-        """SELECT DISTINCT tax_code_id, inv.type
+        """SELECT aml.*
         FROM account_move_line aml
-        LEFT JOIN account_invoice inv on inv.id = aml.invoice_id
         WHERE aml.company_id=%s
           AND aml.tax_code_id IS NOT NULL
-          AND (aml.debit != 0 or aml.credit != 0) AND aml.tax_amount != 0
-        """, (company_id, )
-    )
-    for tax_code_id, inv_type, in env.cr.fetchall():
-        _logger.info("tax code [%s] '%s'", tax_code_id, inv_type)
-        tax_id, ttype = _get_tax_from_tax_code(
-            env, company_id, tax_code_id, inv_type, codeid2tag, tc2t,
-        )
-        if not tax_id:
-            # the error has been logged before
-            continue
-        if ttype == 'tax':
-            if not inv_type:
-                openupgrade.logged_query(
-                    env.cr,
-                    """UPDATE account_move_line
-                    SET tax_line_id=%s
-                    WHERE tax_code_id=%s
-                      AND (debit != 0 or credit != 0) AND tax_amount != 0
-                      AND invoice_id IS NULL
-                    """, (tax_id, tax_code_id)
-                )
-            else:
-                openupgrade.logged_query(
-                    env.cr,
-                    """UPDATE account_move_line
-                    SET tax_line_id=%s
-                    WHERE tax_code_id=%s
-                      AND (debit != 0 or credit != 0) AND tax_amount != 0
-                      AND invoice_id IN
-                          (SELECT id FROM account_invoice
-                           WHERE type=%s AND company_id=%s)
-                    """, (tax_id, tax_code_id, inv_type, company_id)
-                )
-        elif ttype == 'base':
-            if not inv_type:
-                openupgrade.logged_query(
-                    env.cr,
-                    """INSERT INTO account_move_line_account_tax_rel
-                    (account_move_line_id, account_tax_id)
-                    SELECT aml.id, %s
-                    FROM account_move_line aml
-                    WHERE aml.tax_code_id=%s
-                      AND invoice_id IS NULL
-                      AND (debit != 0 or credit != 0) AND tax_amount != 0
-                    """,
-                    (tax_id, tax_code_id)
-                )
-            else:
-                openupgrade.logged_query(
-                    env.cr,
-                    """INSERT INTO account_move_line_account_tax_rel
-                    (account_move_line_id, account_tax_id)
-                    SELECT aml.id, %s
-                    FROM account_move_line aml
-                    LEFT JOIN account_invoice inv ON inv.id = aml.invoice_id
-                    WHERE aml.tax_code_id=%s
-                      AND inv.type=%s
-                      AND (debit != 0 or credit != 0) AND tax_amount != 0
-                    """,
-                    (tax_id, tax_code_id, inv_type)
-                )
-        else:
-            if not inv_type:
-                _logger.error(
-                    "account.tax.group %s may correspond to both base and "
-                    "taxes. You need to manually fix move lines that have "
-                    "this tax_code_id and are not related to an invoice "
-                    "by finding a way to determine if it's a base or tax "
-                    "and set tax_ids or tax_line_id to %s.",
-                    tax_code_id, tax_id,
-                )
-            else:
-                ambiguous_tax_codes.append((tax_code_id, inv_type))
-    #
-    # Step 2.
-    #
-    # Handle ambiguous tax codes by looking at the invoice linked
-    # to the move line and examine the account_invoice_tax table
-    # to determine if the tax code is for base or tax.
-    # If this fails, log an error (this should be very rare).
-    #
-    _logger.info("set_aml_taxes step 2 for company %s", company_id)
-    for tax_code_id, inv_type in ambiguous_tax_codes:
-        _logger.info(
-            "Trying to disambiguate tax code [%s] '%s'.",
-            tax_code_id, inv_type,
-        )
-        env.cr.execute(
-            """SELECT aml.id, aml.date, aml.name, aml.move_id,
-                      aml.account_id, aml.tax_code_id, aml.tax_amount,
-                      invoice_id, inv.type
-            FROM account_move_line aml
-            LEFT JOIN account_invoice inv ON inv.id = aml.invoice_id
-            WHERE tax_code_id=%s AND inv.type=%s
-            """, (tax_code_id, inv_type)
-        )
-        for ml_id, date, name, move_id, \
-                account_id, tax_code_id, tax_amount, \
-                invoice_id, inv_type \
-                in env.cr.fetchall():
-            if not invoice_id:
-                _logger.error(
-                    "Could not determine if tax code [%s] is base or tax for "
-                    "move line %s [%s] because it is not linked to an invoice. "
-                    "You need to fix this manually.",
-                    tax_code_id, name, ml_id, invoice_id,
-                )
-                continue
-            env.cr.execute(
-                """SELECT base_amount, base_code_id, tax_amount, tax_code_id
-                FROM account_invoice_tax
-                WHERE invoice_id=%s
-                """ % (invoice_id, )
-            )
-            invoice_taxes = env.cr.fetchall()
-            ttype = None
-            in_bases = any(x == tax_code_id for _, x, _, _ in invoice_taxes)
-            in_taxes = any(x == tax_code_id for _, _, _, x in invoice_taxes)
-            if in_bases and not in_taxes:
-                ttype = 'base'
-            elif in_taxes and not in_bases:
-                ttype = 'tax'
-            else:
-                for inv_base_amount, inv_base_code_id, \
-                        inv_tax_amount, inv_tax_code_id \
-                        in invoice_taxes:
-                    if inv_base_amount == tax_amount and \
-                            inv_base_code_id == tax_code_id:
-                        ttype = 'base'
-                        break
-                    elif inv_tax_amount == tax_amount and \
-                            inv_tax_code_id == tax_code_id:
-                        ttype = 'tax'
-                        break
-            tax_id, _ = _get_tax_from_tax_code(
-                env, company_id, tax_code_id, inv_type, codeid2tag, tc2t,
-            )
-            if not tax_id:
-                # the error has been logged before
-                continue
-            if ttype == 'tax':
-                _logger.warning(
-                    "Found a move line [%s] with a tax code that could be "
-                    "base or tax, and which is actually a tax, "
-                    "This will be handled correctly but we log it "
-                    "as it should be a rare occurence.",
-                    ml_id,
-                )
-                openupgrade.logged_query(
-                    env.cr,
-                    """UPDATE account_move_line
-                    SET tax_line_id=%s
-                    WHERE id=%s
-                    """, (tax_id, ml_id)
-                )
-            elif ttype == 'base':
-                openupgrade.logged_query(
-                    env.cr,
-                    """INSERT INTO account_move_line_account_tax_rel
-                    (account_move_line_id, account_tax_id)
-                    VALUES (%s, %s)
-                    """,
-                    (ml_id, tax_id)
-                )
-            else:
-                _logger.error(
-                    "Could not determine if tax code [%s] is base or tax for "
-                    "move line %s [%s] of invoice [%s]. "
-                    "You need to fix this manually.",
-                    tax_code_id, name, ml_id, invoice_id,
-                )
-    #
-    # Step 3.
-    #
-    # Handle tax lines with debit=credit=0 by creating debit/credit transaction
-    #
-    # If it's a base we try to find the base line in the same move with
-    # same amount and add the tax to it. If we don't find it, or if it's a tax,
-    # we create new move lines.
-    #
-    _logger.info("set_aml_taxes step 3 for company %s", company_id)
-    env.cr.execute(
-        """SELECT aml.*, inv.type AS inv_type
-        FROM account_move_line aml
-        LEFT JOIN account_invoice inv ON inv.id = aml.invoice_id
-        WHERE aml.company_id=%s
-          AND aml.tax_code_id IS NOT NULL
-          AND aml.debit = 0 AND aml.credit = 0 AND aml.tax_amount != 0
         """, (company_id, )
     )
     for row in env.cr.dictfetchall():
-        tax_id, ttype = _get_tax_from_tax_code(
-            env, company_id, row['tax_code_id'], row['inv_type'],
-            codeid2tag, tc2t,
+        tax_id, ttype, dc = _get_tax_from_tax_code(
+            env, company_id, row['tax_code_id'], codeid2tag, tc2t,
         )
         if not tax_id:
             # the error has been logged before
-            continue
-        if not ttype:
-            _logger.error(
-                "account.tax.code %s may correspond to both base and taxes "
-                "for move line %s [%s] with invoice type '%s'. "
-                "You need to fix move lines with this tax_code_id manually "
-                "by finding a way to determine if it's a base or tax "
-                "and set tax_ids or tax_line_id to %s.",
-                row['tax_code_id'], row['name'], row['id'], row['inv_type'],
-                tax_id,
-            )
-            continue
-        elif ttype == 'tax':
-            _logger.warning(
-                "Found a move line [%s] with a tax code that could be "
-                "base or tax, and which is actually a tax, "
-                "This will be handled correctly but we log it "
-                "as it should be a rare occurence.",
-                row['id'],
-            )
-        if row['tax_amount'] < 0:
-            debit = -row['tax_amount']
-            credit = 0
+            _logger.error("tax code %s not found", row['tax_code_id'])
+        assert ttype
+        if dc == 'deb':
+            if row['tax_amount'] > 0:
+                wanted_debit = row['tax_amount']
+                wanted_credit = 0
+            else:
+                wanted_debit = 0
+                wanted_credit = -row['tax_amount']
+        elif dc == 'crd':
+            if row['tax_amount'] > 0:
+                wanted_debit = 0
+                wanted_credit = row['tax_amount']
+            else:
+                wanted_debit = -row['tax_amount']
+                wanted_credit = 0
         else:
-            debit = 0
-            credit = row['tax_amount']
-        _logger.debug("updating move %s for 0/0/tax", row['move_id'])
+            _logger.error("error: unknown dc %s for tax code %s", dc, row['tax_code_id'])
+            continue
         if ttype == 'base':
-            # it's a base, add the tax to another move line
-            # with the same amount
-            env.cr.execute(
-                """SELECT id
-                FROM account_move_line
-                WHERE move_id=%s
-                  AND debit=%s AND credit=%s
-                  AND tax_code_id != %s
-                  AND tax_line_id IS NULL
-                """, (row['move_id'], debit, credit, row['tax_code_id'])
-            )
-            base_ml = env.cr.fetchall()
+            if row['debit'] == wanted_debit and row['credit'] == wanted_credit:
+                base_ml = row
+            else:
+                # it's a base, add the tax to another move line
+                # with the same amount
+                env.cr.execute(
+                    """SELECT id
+                    FROM account_move_line
+                    WHERE move_id=%s
+                      AND debit=%s AND credit=%s
+                      AND tax_code_id IS NOT NULL
+                      AND tax_line_id IS NULL
+                    """, (row['move_id'], wanted_debit, wanted_credit)
+                )
+                base_ml = env.cr.dictfetchall()
+                if base_ml:
+                    base_ml = base_ml[0]
             if base_ml:
                 openupgrade.logged_query(
                     env.cr,
                     """INSERT INTO account_move_line_account_tax_rel
                     (account_move_line_id, account_tax_id)
-                    VALUES (%s, %s)
-                    """, (base_ml[0], tax_id)
+                    SELECT %s, %s
+                    WHERE NOT EXISTS (
+                        SELECT * FROM account_move_line_account_tax_rel
+                        WHERE account_move_line_id=%s AND account_tax_id=%s
+                    )
+                    RETURNING account_move_line_id
+                    """, (base_ml['id'], tax_id, base_ml['id'], tax_id)
+                )
+                if env.cr.fetchone():
+                    # if we could insert, it's ok, continue the loop
+                    # if not, it means we have several similar line and
+                    # we must create dummy debit/credit lines to hold the tax
+                    continue
+            else:
+                # we'll add a dummy line to hold the tax with the correct debit/credit
+                pass
+        elif ttype == 'tax':
+            if row['debit'] == wanted_debit and row['credit'] == wanted_credit:
+                tax_ml = row
+            else:
+                tax_ml = None
+            if tax_ml:
+                openupgrade.logged_query(
+                    env.cr,
+                    """UPDATE account_move_line
+                    SET tax_line_id = %s
+                    WHERE id=%s
+                    """, (tax_id, tax_ml['id'])
                 )
                 continue
+            else:
+                # we'll add a dummy line to hold the tax with the correct debit/credit
+                pass
+
         # we did not find a move line with same debit/credit/tax_code_id
-        # create new debit/credit lines
-        for d, c, t in ((debit, credit, tax_id), (credit, debit, None)):
+        # create new debit/credit lines to hold the tax information
+        for d, c, t in (
+                (wanted_debit, wanted_credit, tax_id),
+                (wanted_credit, wanted_debit, None),
+        ):
             rec = row.copy()
-            rec.pop('inv_type')
             rec.pop('id')
             rec.pop('create_date')
             rec.pop('create_uid')
@@ -513,7 +212,8 @@ def set_aml_taxes(env, company_id, codeid2tag):
             rec['create_uid'] = SUPERUSER_ID
             rec['debit'] = d
             rec['credit'] = c
-            rec['tax_line_id'] = t if ttype == 'tax' else None,
+            rec['balance'] = d - c 
+            rec['tax_line_id'] = t if (t and ttype == 'tax') else None
             rec['name'] = MIG_TAX_LINE_PREFIX + rec['name']
             columns = list(rec.keys())
             values = ["%({})s".format(c) for c in columns]
@@ -528,7 +228,7 @@ def set_aml_taxes(env, company_id, codeid2tag):
                 ),
                 rec,
             )
-            if ttype == 'base':
+            if t and ttype == 'base':
                 new_ml_id = env.cr.fetchone()[0]
                 openupgrade.logged_query(
                     env.cr,
@@ -588,7 +288,6 @@ def _migrate(env):
     for company in env['res.company'].search([]):
         if company.partner_id.country_id.code != 'BE':
             continue
-        set_tax_tags_from_tax_codes(env, company.id, codeid2tag)
         reset_aml_taxes(env, company.id)
         set_aml_taxes(env, company.id, codeid2tag)
 

--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 ACSONE SA/NV - Stéphane Bidoul
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from __future__ import print_function
+import csv
+import logging
+import os
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+def _load_code2tag(env):
+    res = {}
+    here = os.path.dirname(__file__)
+    with open(os.path.join(here, 'tax_code2tag.csv')) as csvfile:
+        reader = csv.reader(csvfile, delimiter=',')
+        next(reader)
+        for code_code, code_name, tag_name, tag_xmlid in reader:
+            if not code_code:
+                continue
+            if tag_xmlid:
+                res[code_code] = env.ref(tag_xmlid)
+            else:
+                res[code_code] = None
+    return res
+
+
+def _load_codeid2code(env):
+    res = {}
+    env.cr.execute("""
+       SELECT id, code FROM account_tax_group
+    """)
+    for code_id, code_code in env.cr.fetchall():
+        res[code_id] = code_code
+    return res
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
+    code2tag = _load_code2tag(env)
+    codeid2code = _load_codeid2code(env)
+    for company in env['res.company'].search([]):
+        if company.partner_id.country_id.code != 'BE':
+            continue
+        taxes = env['account.tax'].search([
+            ('company_id', '=', company.id),
+        ])
+        for tax in taxes:
+            tags = []
+            cr.execute("""
+                SELECT
+                  base_code_id, tax_code_id,
+                  ref_base_code_id, ref_tax_code_id
+                FROM account_tax
+                WHERE id = %s
+            """, (tax.id, ))
+            for code_id in cr.fetchone():
+                if not code_id:
+                    continue
+                code_code = codeid2code[code_id]
+                if code2tag.get(code_code):
+                    tags.append(code2tag[code_code])
+                else:
+                    _logger.error(
+                        "Tax %s [%s] references tax code %s which does "
+                        "not map to a tax tag. You need to resolve this "
+                        "manually.",
+                        tax.name, tax.id, code_code,
+                    )
+            tax.write({
+                'tag_ids': [(6, 0, [tag.id for tag in tags])],
+            })

--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -2,7 +2,6 @@
 # Copyright 2018 ACSONE SA/NV - Stéphane Bidoul
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
-from __future__ import print_function
 import csv
 import logging
 import os
@@ -10,6 +9,9 @@ import os
 from openupgradelib import openupgrade
 
 _logger = logging.getLogger(__name__)
+
+
+MIG_TAX_PREFIX = "Mig Code "
 
 
 def _load_code2tag(env):
@@ -42,39 +44,210 @@ def _load_codeid2code(env):
     return res
 
 
-@openupgrade.migrate(use_env=True)
-def migrate(env, version):
-    cr = env.cr
+def set_tax_tags_from_tax_codes(env, company_id, codeid2tag):
+    taxes = env['account.tax'].search([
+        ('company_id', '=', company_id),
+    ])
+    for tax in taxes:
+        tags = []
+        env.cr.execute("""
+            SELECT
+              base_code_id, tax_code_id,
+              ref_base_code_id, ref_tax_code_id
+            FROM account_tax
+            WHERE id = %s
+        """, (tax.id, ))
+        for code_id in env.cr.fetchone():
+            if not code_id:
+                continue
+            tag = codeid2tag.get(code_id)
+            if tag:
+                tags.append(tag)
+            else:
+                _logger.error(
+                    "Tax %s [%s] references tax code %s which does "
+                    "not map to a tax tag. You need to resolve this "
+                    "manually.",
+                    tax.name, tax.id, code_id,
+                )
+        tax.write({
+            'tag_ids': [(6, 0, [t.id for t in tags])],
+        })
+
+
+def _create_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag):
+    tax_tag = codeid2tag.get(tax_code_id)
+    if not tax_tag:
+        _logger.error(
+            "Tax code with id [%s] does "
+            "not map to a tax tag. You need to resolve this "
+            "manually.",
+            tax_code_id,
+        )
+        return None
+    env.cr.execute(
+        """SELECT code FROM account_tax_group WHERE id=%s""",
+        (tax_code_id, )
+    )
+    tax_code_code = env.cr.fetchone()[0]
+    tax = env['account.tax'].create({
+        'name': MIG_TAX_PREFIX + tax_code_code,
+        'company_id': company_id,
+        'tag_ids': [(6, 0, [tax_tag.id])],
+        'active': False,
+        'amount': 0,
+    })
+    _logger.info(
+        "Created tax '%s' with tag '%s'",
+        tax.name, tax_tag.name,
+    )
+    return tax
+
+
+def _get_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag, tc2t):
+    if tax_code_id in tc2t:
+        return tc2t[tax_code_id]
+    env.cr.execute(
+        """SELECT id FROM account_tax
+        WHERE base_code_id=%(tax_code_id)s
+        OR ref_base_code_id=%(tax_code_id)s""",
+        {'tax_code_id': tax_code_id},
+    )
+    base_tax_ids = env.cr.fetchall()
+    env.cr.execute(
+        """SELECT id FROM account_tax
+        WHERE tax_code_id=%(tax_code_id)s
+        OR ref_tax_code_id=%(tax_code_id)s""",
+        {'tax_code_id': tax_code_id},
+    )
+    tax_tax_ids = env.cr.fetchall()
+    if base_tax_ids and not tax_tax_ids:
+        ttype = 'base'
+    elif tax_tax_ids and not base_tax_ids:
+        ttype = 'tax'
+    else:
+        ttype = None
+    tax_ids = base_tax_ids + tax_tax_ids
+    if len(tax_ids) == 1:
+        tax_id = tax_ids[0]
+    else:
+        tax = _create_tax_from_tax_code(
+            env, company_id, tax_code_id, codeid2tag,
+        )
+        tax_id = tax.id if tax else None
+    tc2t[tax_code_id] = (tax_id, ttype)
+    return tax_id, ttype
+
+
+def set_aml_taxes(env, company_id, codeid2tag):
+    env.cr.execute(
+        """SELECT DISTINCT tax_code_id
+        FROM account_move_line
+        WHERE company_id=%s 
+          AND tax_code_id IS NOT NULL
+          AND (debit != 0 or credit != 0) AND tax_amount != 0
+        """, (company_id, )
+    )
+    tc2t = {}
+    for tax_code_id, in env.cr.fetchall():
+        tax_id, ttype = _get_tax_from_tax_code(
+            env, company_id, tax_code_id, codeid2tag, tc2t,
+        )
+        if not tax_id:
+            continue
+        if ttype == 'tax':
+            env.cr.execute(
+                """UPDATE account_move_line
+                SET tax_line_id=%s
+                WHERE tax_code_id=%s
+                  AND (debit != 0 or credit != 0) AND tax_amount != 0
+                """, (tax_id, tax_code_id)
+            )
+        elif ttype == 'base':
+            env.cr.execute(
+                """INSERT INTO account_move_line_account_tax_rel
+                (account_move_line_id, account_tax_id)
+                SELECT id, %s
+                FROM account_move_line
+                WHERE tax_code_id=%s
+                  AND (debit != 0 or credit != 0) AND tax_amount != 0
+                """,
+                (tax_id, tax_code_id)
+            )
+        else:
+            _logger.error(
+                "account.tax.code %s may correspond to both base and taxes. "
+                "You need to fix move lines with this tax_code_id manually "
+                "by finding a way to determine if it's a base or tax "
+                "and set tax_ids or tax_line_id to %s.",
+                tax_code_id, tax_id,
+            )
+    env.cr.execute(
+        """SELECT id, name, move_id, account_id, tax_code_id, tax_amount
+        FROM account_move_line
+        WHERE company_id=%s
+          AND tax_code_id IS NOT NULL
+          AND debit = 0 AND credit = 0 AND tax_amount != 0
+        """, (company_id, )
+    )
+    for ml_id, name, move_id, account_id, tax_code_id, tax_amount \
+            in env.cr.fetchall():
+        tax_id, ttype = _get_tax_from_tax_code(
+            env, company_id, tax_code_id, codeid2tag, tc2t,
+        )
+        if not tax_id:
+            continue
+        move = env['account.move'].browse(move_id)
+        _logger.info("fixing %s %s %s %s", ml_id, name, tax_code_id, move.name)
+        for move_line in move.line_ids:
+            if move_line.account_id.id == account_id and \
+                    (move_line.debit == abs(tax_amount) or
+                     move_line.credit == abs(tax_amount)):
+                move_line.write({
+                    'tax_ids': [(4, tax_id, 0)],
+                })
+                break
+        else:
+            _logger.error("fixing %s %s %s in %s", ml_id, name, tax_code_id, move.name)
+
+
+def reset_aml_taxes(env, company_id):
+    env.cr.execute("""
+        UPDATE account_move_line
+        SET tax_line_id = NULL
+        WHERE tax_line_id IS NOT NULL
+          AND company_id = %s
+    """, (company_id, ))
+    env.cr.execute("""
+        DELETE FROM account_move_line_account_tax_rel
+        WHERE account_move_line_id IN
+          (SELECT id FROM account_move_line
+           WHERE company_id=%s)
+    """, (company_id, ))
+    env.cr.execute(
+        """DELETE FROM account_tax
+        WHERE NAME like '{}%'
+        """.format(MIG_TAX_PREFIX),
+    )
+
+
+def _migrate(env):
     code2tag = _load_code2tag(env)
     codeid2code = _load_codeid2code(env)
+    codeid2tag = {}
+    for codeid, code in codeid2code.items():
+        codeid2tag[codeid] = code2tag.get(code)
     for company in env['res.company'].search([]):
         if company.partner_id.country_id.code != 'BE':
             continue
-        taxes = env['account.tax'].search([
-            ('company_id', '=', company.id),
-        ])
-        for tax in taxes:
-            tags = []
-            cr.execute("""
-                SELECT
-                  base_code_id, tax_code_id,
-                  ref_base_code_id, ref_tax_code_id
-                FROM account_tax
-                WHERE id = %s
-            """, (tax.id, ))
-            for code_id in cr.fetchone():
-                if not code_id:
-                    continue
-                code_code = codeid2code[code_id]
-                if code2tag.get(code_code):
-                    tags.append(code2tag[code_code])
-                else:
-                    _logger.error(
-                        "Tax %s [%s] references tax code %s which does "
-                        "not map to a tax tag. You need to resolve this "
-                        "manually.",
-                        tax.name, tax.id, code_code,
-                    )
-            tax.write({
-                'tag_ids': [(6, 0, [tag.id for tag in tags])],
-            })
+        set_tax_tags_from_tax_codes(env, company.id, codeid2tag)
+        reset_aml_taxes(env, company.id)
+        set_aml_taxes(env, company.id, codeid2tag)
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    _migrate(env)
+
+
+_migrate(env)

--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -12,7 +12,7 @@ _logger = logging.getLogger(__name__)
 
 
 MIG_TAX_PREFIX = "Mig Code "
-MIG_TAX_LINE_PREFIX = "[9 to 9 tax migration] "
+MIG_TAX_LINE_PREFIX = "[8 to 9 tax migration] "
 
 
 def _load_code2tag(env):
@@ -76,7 +76,7 @@ def set_tax_tags_from_tax_codes(env, company_id, codeid2tag):
         })
 
 
-def _create_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag):
+def _create_tax_from_tax_code(env, company_id, tax_code_id, inv_type, codeid2tag):
     tax_tag = codeid2tag.get(tax_code_id)
     if not tax_tag:
         _logger.error(
@@ -92,7 +92,7 @@ def _create_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag):
     )
     tax_code_code = env.cr.fetchone()[0]
     tax = env['account.tax'].create({
-        'name': MIG_TAX_PREFIX + tax_code_code,
+        'name': MIG_TAX_PREFIX + tax_code_code + ' (' + (inv_type or '') + ')',
         'company_id': company_id,
         'tag_ids': [(6, 0, [tax_tag.id])],
         'active': False,
@@ -105,20 +105,66 @@ def _create_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag):
     return tax
 
 
-def _get_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag, tc2t):
-    if tax_code_id in tc2t:
-        return tc2t[tax_code_id]
+def _get_tax_from_tax_code(env, company_id, tax_code_id, inv_type,
+                           codeid2tag, tc2t):
+    if (tax_code_id, inv_type) in tc2t:
+        return tc2t[(tax_code_id, inv_type)]
+    base_where = []
+    tax_where = []
+    if inv_type == 'in_invoice':
+        base_where.append(
+            "base_code_id=%(tax_code_id)s AND "
+            "type_tax_use='purchase'"
+        )
+        tax_where.append(
+            "tax_code_id=%(tax_code_id)s AND "
+            "type_tax_use='purchase'"
+        )
+    elif inv_type == 'out_invoice':
+        base_where.append(
+            "base_code_id=%(tax_code_id)s AND "
+            "type_tax_use='sale'"
+        )
+        tax_where.append(
+            "tax_code_id=%(tax_code_id)s AND "
+            "type_tax_use='sale'"
+        )
+    elif inv_type == 'in_refund':
+        base_where.append(
+            "ref_base_code_id=%(tax_code_id)s AND "
+            "type_tax_use='purchase'"
+        )
+        tax_where.append(
+            "ref_tax_code_id=%(tax_code_id)s AND "
+            "type_tax_use='purchase'"
+        )
+    elif inv_type == 'out_refund':
+        base_where.append(
+            "ref_base_code_id=%(tax_code_id)s AND "
+            "type_tax_use='sale'"
+        )
+        tax_where.append(
+            "ref_tax_code_id=%(tax_code_id)s AND "
+            "type_tax_use='sale'"
+        )
+    else:
+        base_where.append(
+            "base_code_id=%(tax_code_id)s OR "
+            "ref_base_code_id=%(tax_code_id)s"
+        )
+        tax_where.append(
+            "tax_code_id=%(tax_code_id)s OR "
+            "ref_tax_code_id=%(tax_code_id)s"
+        )
+    base_where = base_where[0]
     env.cr.execute(
-        """SELECT id FROM account_tax
-        WHERE base_code_id=%(tax_code_id)s
-        OR ref_base_code_id=%(tax_code_id)s""",
+        "SELECT id FROM account_tax WHERE " + base_where,
         {'tax_code_id': tax_code_id},
     )
     base_tax_ids = env.cr.fetchall()
+    tax_where = tax_where[0]
     env.cr.execute(
-        """SELECT id FROM account_tax
-        WHERE tax_code_id=%(tax_code_id)s
-        OR ref_tax_code_id=%(tax_code_id)s""",
+        "SELECT id FROM account_tax WHERE " + tax_where,
         {'tax_code_id': tax_code_id},
     )
     tax_tax_ids = env.cr.fetchall()
@@ -127,32 +173,43 @@ def _get_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag, tc2t):
     elif tax_tax_ids and not base_tax_ids:
         ttype = 'tax'
     else:
+        # this code can be used as base or tax
         ttype = None
     tax_ids = base_tax_ids + tax_tax_ids
     if len(tax_ids) == 1:
         tax_id = tax_ids[0]
     else:
+        # several taxes use this code, use one
         tax = _create_tax_from_tax_code(
-            env, company_id, tax_code_id, codeid2tag,
+            env, company_id, tax_code_id, inv_type, codeid2tag,
         )
         tax_id = tax.id if tax else None
-    tc2t[tax_code_id] = (tax_id, ttype)
+    tc2t[(tax_code_id, inv_type)] = (tax_id, ttype)
     return tax_id, ttype
 
 
 def set_aml_taxes(env, company_id, codeid2tag):
+    tc2t = {}
+    ambiguous_tax_codes = []
+    # Handle the normal case: debit or credit != 0 and tax amount != 0
+    #
+    # * If the tax code can be unambiguously linked to a tax for use
+    #   as tax amount, use it for tax_line_id.
+    # * If the tax code can be unambiguously linked to a tax for use
+    #   as base amount, us it for tax_ids
     env.cr.execute(
-        """SELECT DISTINCT tax_code_id
-        FROM account_move_line
-        WHERE company_id=%s 
-          AND tax_code_id IS NOT NULL
-          AND (debit != 0 or credit != 0) AND tax_amount != 0
+        """SELECT DISTINCT tax_code_id, inv.type
+        FROM account_move_line aml
+        LEFT JOIN account_invoice inv on inv.id = aml.invoice_id
+        WHERE aml.company_id=%s
+          AND aml.tax_code_id IS NOT NULL
+          AND (aml.debit != 0 or aml.credit != 0) AND aml.tax_amount != 0
         """, (company_id, )
     )
-    tc2t = {}
-    for tax_code_id, in env.cr.fetchall():
+    for tax_code_id, inv_type, in env.cr.fetchall():
+        _logger.info("tax code [%s] '%s'", tax_code_id, inv_type)
         tax_id, ttype = _get_tax_from_tax_code(
-            env, company_id, tax_code_id, codeid2tag, tc2t,
+            env, company_id, tax_code_id, inv_type, codeid2tag, tc2t,
         )
         if not tax_id:
             continue
@@ -176,6 +233,126 @@ def set_aml_taxes(env, company_id, codeid2tag):
                 (tax_id, tax_code_id)
             )
         else:
+            if not inv_type:
+                _logger.error(
+                    "account.tax.group %s may correspond to both base and "
+                    "taxes. You need to manually fix move lines that have "
+                    "this tax_code_id and are not related to an invoice "
+                    "by finding a way to determine if it's a base or tax "
+                    "and set tax_ids or tax_line_id to %s.",
+                    tax_code_id, tax_id,
+                )
+            else:
+                ambiguous_tax_codes.append((tax_code_id, inv_type))
+    # Handle ambiguous tax codes
+    for tax_code_id, inv_type in ambiguous_tax_codes:
+        _logger.info(
+            "Trying to disambiguate tax code [%s] '%s'.",
+            tax_code_id, inv_type,
+        )
+        env.cr.execute(
+            """SELECT aml.id, aml.date, aml.name, aml.move_id,
+                      aml.account_id, aml.tax_code_id, aml.tax_amount,
+                      invoice_id, inv.type
+            FROM account_move_line aml
+            LEFT JOIN account_invoice inv ON inv.id = aml.invoice_id
+            WHERE tax_code_id=%s AND inv.type=%s
+            """, (tax_code_id, inv_type)
+        )
+        for ml_id, date, name, move_id, \
+                account_id, tax_code_id, tax_amount, \
+                invoice_id, inv_type \
+                in env.cr.fetchall():
+            env.cr.execute(
+                """SELECT base_amount, base_code_id, tax_amount, tax_code_id
+                FROM account_invoice_tax
+                WHERE invoice_id=%s
+                """ % (invoice_id, )
+            )
+            invoice_taxes = env.cr.fetchall()
+            ttype = None
+            in_bases = any(x == tax_code_id for _, x, _, _ in invoice_taxes)
+            in_taxes = any(x == tax_code_id for _, _, _, x in invoice_taxes)
+            if in_bases and not in_taxes:
+                ttype = 'base'
+            elif in_taxes and not in_bases:
+                ttype = 'tax'
+            else:
+                for inv_base_amount, inv_base_code_id, \
+                        inv_tax_amount, inv_tax_code_id \
+                        in invoice_taxes:
+                    if inv_base_amount == tax_amount and \
+                            inv_base_code_id == tax_code_id:
+                        ttype = 'base'
+                        break
+                    elif inv_tax_amount == tax_amount and \
+                            inv_tax_code_id == tax_code_id:
+                        ttype = 'tax'
+                        break
+            tax_id, _ = _get_tax_from_tax_code(
+                env, company_id, tax_code_id, inv_type, codeid2tag, tc2t,
+            )
+            if not tax_id:
+                continue
+            if ttype == 'tax':
+                env.cr.execute(
+                    """UPDATE account_move_line
+                    SET tax_line_id=%s
+                    WHERE id=%s
+                    """, (tax_id, ml_id)
+                )
+            elif ttype == 'base':
+                env.cr.execute(
+                    """INSERT INTO account_move_line_account_tax_rel
+                    (account_move_line_id, account_tax_id)
+                    VALUES (%s, %s)
+                    """,
+                    (ml_id, tax_id)
+                )
+            else:
+                _logger.error(
+                    "Could not determine if tax code [%s] is base or tax for "
+                    "move line %s [%s] of invoice [%s]. "
+                    "You need to fix this manually.",
+                    tax_code_id, name, ml_id, invoice_id,
+                )
+    # Handle tax lines with debit=credit=0 by creating debit/credit transaction
+    env.cr.execute(
+        """SELECT aml.id, aml.date, aml.name, aml.move_id,
+                  aml.account_id, aml.tax_code_id, aml.tax_amount,
+                  inv.type
+        FROM account_move_line aml
+        LEFT JOIN account_invoice inv ON inv.id = aml.invoice_id
+        WHERE aml.company_id=%s
+          AND aml.tax_code_id IS NOT NULL
+          AND aml.debit = 0 AND aml.credit = 0 AND aml.tax_amount != 0
+        """, (company_id, )
+    )
+    for ml_id, date, name, move_id, \
+            account_id, tax_code_id, tax_amount, \
+            inv_type \
+            in env.cr.fetchall():
+        tax_id, ttype = _get_tax_from_tax_code(
+            env, company_id, tax_code_id, inv_type, codeid2tag, tc2t,
+        )
+        if not tax_id:
+            continue
+        if not ttype:
+            _logger.error(
+                "account.tax.code %s may correspond to both base and taxes "
+                "for move line %s [%s] with invoice type '%s'. "
+                "You need to fix move lines with this tax_code_id manually "
+                "by finding a way to determine if it's a base or tax "
+                "and set tax_ids or tax_line_id to %s.",
+                tax_code_id, name, ml_id, inv_type, tax_id,
+            )
+        if tax_amount < 0:
+            debit = -tax_amount
+            credit = 0
+        else:
+            debit = 0
+            credit = tax_amount
+        if ttype == 'none':
             _logger.error(
                 "account.tax.code %s may correspond to both base and taxes. "
                 "You need to fix move lines with this tax_code_id manually "
@@ -183,28 +360,20 @@ def set_aml_taxes(env, company_id, codeid2tag):
                 "and set tax_ids or tax_line_id to %s.",
                 tax_code_id, tax_id,
             )
-    env.cr.execute(
-        """SELECT id, date, name, move_id, account_id, tax_code_id, tax_amount
-        FROM account_move_line
-        WHERE company_id=%s
-          AND tax_code_id IS NOT NULL
-          AND debit = 0 AND credit = 0 AND tax_amount != 0
-        """, (company_id, )
-    )
-    for ml_id, date, name, move_id, account_id, tax_code_id, tax_amount \
-            in env.cr.fetchall():
-        tax_id, ttype = _get_tax_from_tax_code(
-            env, company_id, tax_code_id, codeid2tag, tc2t,
-        )
-        if not tax_id:
             continue
-        if tax_amount < 0:
-            debit = -tax_amount
-            credit = 0
-        else:
-            debit = 0
-            credit = tax_amount
+        vals = []
         for d, c, t in ((debit, credit, tax_id), (credit, debit, None)):
+            vals.append((0, 0, dict(
+                date=date,
+                date_maturity=date,
+                name=MIG_TAX_LINE_PREFIX + name,
+                account_id=account_id,
+                debit=d,
+                credit=c,
+                tax_line_id=t if t and ttype == 'tax' else False,
+                tax_ids=[(6, 0, [tax_id] if t and ttype == 'base' else [])],
+            )))
+            continue
             env.cr.execute(
                 """INSERT INTO account_move_line
                 (move_id, date, date_maturity, name,
@@ -212,34 +381,57 @@ def set_aml_taxes(env, company_id, codeid2tag):
                 VALUES
                 (%s, %s, %s, %s,
                  %s, %s, %s, %s)
+                RETURNING id
                 """, (move_id, date, date, MIG_TAX_LINE_PREFIX + name,
-                      account_id, d, c, t)
+                      account_id, d, c, t if ttype == 'tax' else None)
             )
+            if t and ttype == 'base':
+                new_ml_id = env.cr.fetchone()[0]
+                env.cr.execute(
+                    """INSERT INTO account_move_line_account_tax_rel
+                    (account_move_line_id, account_tax_rel)
+                    VALUES
+                    (%s, %s)
+                    """, (new_ml_id, t)
+                )
+        _logger.info("updating move %s for 0/0/tax", move_id)
+        env['account.move'].browse(move_id).write(dict(line_ids=vals))
 
 
 def reset_aml_taxes(env, company_id):
-    env.cr.execute("""
-        UPDATE account_move_line
+    _logger.info("clearing aml.tax_line_id")
+    env.cr.execute(
+        """UPDATE account_move_line
         SET tax_line_id = NULL
         WHERE tax_line_id IS NOT NULL
           AND company_id = %s
-    """, (company_id, ))
-    env.cr.execute("""
-        DELETE FROM account_move_line_account_tax_rel
+        """, (company_id, )
+    )
+    _logger.info("clearing aml.tax_ids")
+    env.cr.execute(
+        """DELETE FROM account_move_line_account_tax_rel
         WHERE account_move_line_id IN
           (SELECT id FROM account_move_line
            WHERE company_id=%s)
-    """, (company_id, ))
+        """, (company_id, )
+    )
+    _logger.info("deleting %s taxes", MIG_TAX_PREFIX)
     env.cr.execute(
         """DELETE FROM account_tax
-        WHERE name LIKE '{}%'
+        WHERE name LIKE '{}%%'
+          AND company_id = %s
         """.format(MIG_TAX_PREFIX),
+        (company_id, )
     )
+    _logger.info("deleting %s aml", MIG_TAX_LINE_PREFIX)
     env.cr.execute(
         """DELETE FROM account_move_line
-        WHERE name LIKE %s || '%'
-        """, (MIG_TAX_LINE_PREFIX, )
+        WHERE name LIKE '{}%%'
+          AND company_id = %s
+        """.format(MIG_TAX_LINE_PREFIX),
+        (company_id, )
     )
+    env.cr.commit()
 
 
 def _migrate(env):
@@ -252,7 +444,7 @@ def _migrate(env):
         if company.partner_id.country_id.code != 'BE':
             continue
         set_tax_tags_from_tax_codes(env, company.id, codeid2tag)
-        # reset_aml_taxes(env, company.id)
+        reset_aml_taxes(env, company.id)
         set_aml_taxes(env, company.id, codeid2tag)
 
 

--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -106,6 +106,8 @@ def _create_tax_from_tax_code(env, company_id, tax_code_id, codeid2tag):
         'company_id': company_id,
         'tag_ids': [(6, 0, [tax_tag.id])],
         'active': False,
+        'type_tax_use': 'none',
+        'amount_type': 'group',
         'amount': 0,
     })
     _logger.info(

--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -53,6 +53,10 @@ def _load_codeid2code(env):
 
 
 def set_tax_tags_from_tax_codes(env, company_id, codeid2tag):
+    _logger.info(
+        "Setting tax tags from tax codes from company %s",
+        company_id,
+    )
     taxes = env['account.tax'].search([
         ('company_id', '=', company_id),
     ])
@@ -239,6 +243,7 @@ def set_aml_taxes(env, company_id, codeid2tag):
     # a list of ambiguous tax code that we'll attempt to diambiguate
     # in step 2.
     #
+    _logger.info("set_aml_taxes step 1 for company %s", company_id)
     env.cr.execute(
         """SELECT DISTINCT tax_code_id, inv.type
         FROM account_move_line aml
@@ -327,6 +332,7 @@ def set_aml_taxes(env, company_id, codeid2tag):
     # to determine if the tax code is for base or tax.
     # If this fails, log an error (this should be very rare).
     #
+    _logger.info("set_aml_taxes step 2 for company %s", company_id)
     for tax_code_id, inv_type in ambiguous_tax_codes:
         _logger.info(
             "Trying to disambiguate tax code [%s] '%s'.",
@@ -425,6 +431,7 @@ def set_aml_taxes(env, company_id, codeid2tag):
     # same amount and add the tax to it. If we don't find it, or if it's a tax,
     # we create new move lines.
     #
+    _logger.info("set_aml_taxes step 3 for company %s", company_id)
     env.cr.execute(
         """SELECT aml.id, aml.date, aml.name, aml.move_id,
                   aml.account_id, aml.tax_code_id, aml.tax_amount,
@@ -565,6 +572,6 @@ def _migrate(env):
         set_aml_taxes(env, company.id, codeid2tag)
 
 
-@openupgrade.migrate(use_env=True)
+@openupgrade.migrate(use_env=True, no_version=True)
 def migrate(env, version):
     _migrate(env)

--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -557,6 +557,3 @@ def _migrate(env):
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     _migrate(env)
-
-
-_migrate(env)

--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -6,7 +6,7 @@ import csv
 import logging
 import os
 
-from odoo import SUPERUSER_ID
+from openerp import SUPERUSER_ID
 from openupgradelib import openupgrade
 
 _logger = logging.getLogger(__name__)

--- a/addons/l10n_be/migrations/9.0.1.1/post-migration.py
+++ b/addons/l10n_be/migrations/9.0.1.1/post-migration.py
@@ -17,8 +17,12 @@ def _load_code2tag(env):
     here = os.path.dirname(__file__)
     with open(os.path.join(here, 'tax_code2tag.csv')) as csvfile:
         reader = csv.reader(csvfile, delimiter=',')
-        next(reader)
-        for code_code, code_name, tag_name, tag_xmlid in reader:
+        header = next(reader)
+        code_code_index = header.index('account.tax.code:code')
+        tag_xmlid_index = header.index('account.account.tag:xmlid')
+        for row in reader:
+            code_code = row[code_code_index]
+            tag_xmlid = row[tag_xmlid_index]
             if not code_code:
                 continue
             if tag_xmlid:

--- a/addons/l10n_be/migrations/9.0.1.1/tax_code2tag.csv
+++ b/addons/l10n_be/migrations/9.0.1.1/tax_code2tag.csv
@@ -1,37 +1,37 @@
-account.tax.code:code,account.tax.code:name,account.account.tag:name,account.account.tag:xmlid,ttype
-00,Opérations soumises à un régime particulier,Belgium VAT Form: grid 0,l10n_be.tax_tag_00,base
-01,Opérations avec TVA à 6%,Belgium VAT Form: grid 01,l10n_be.tax_tag_01,base
-02,Opérations avec TVA à 12%,Belgium VAT Form: grid 02,l10n_be.tax_tag_02,base
-03,Opérations avec TVA à 21%,Belgium VAT Form: grid 03,l10n_be.tax_tag_03,base
-44,Services intra-communautaires,Belgium VAT Form: grid 44,l10n_be.tax_tag_44,base
-45,Opérations avec TVA due par le cocontractant,Belgium VAT Form: grid 45,l10n_be.tax_tag_45,base
-46,Livraisons intra-communautaire exemptées,,,base
-46L,Livraisons biens intra-communautaire exemptées,Belgium VAT Form: grid 46L,l10n_be.tax_tag_46L,base
-46T,ABC intra-communautaires,Belgium VAT Form: grid 46T,l10n_be.tax_tag_46T,base
-47,Autres operations exemptées,Belgium VAT Form: grid 47,l10n_be.tax_tag_47,base
-48,Notes de crédit aux opérations grilles [44] et [46],,,base
-48s44,Notes de crédit aux opérations grille [44],Belgium VAT Form: grid 48s44,l10n_be.tax_tag_48s44,base
-48s46L,Notes de crédit aux opérations grille [46L],Belgium VAT Form: grid 48s46L,l10n_be.tax_tag_48s46L,base
-48s46T,Notes de crédit aux opérations grille [46T],Belgium VAT Form: grid 48s46T,l10n_be.tax_tag_48s46T,base
-49,Notes de crédit aux opérations du point II,Belgium VAT Form: grid 49,l10n_be.tax_tag_49,base
-54,"TVA sur opérations des grilles [01], [02], [03]",Belgium VAT Form: grid 54,l10n_be.tax_tag_54,tax
-55,TVA sur opérations des grilles [86] et [88],Belgium VAT Form: grid 55,l10n_be.tax_tag_55,tax
-56,TVA sur opérations de la grille [87],Belgium VAT Form: grid 56,l10n_be.tax_tag_56,tax
-57,TVA relatives aux importations,Belgium VAT Form: grid 57,l10n_be.tax_tag_57,tax
-59,TVA déductible,Belgium VAT Form: grid 59,l10n_be.tax_tag_59,tax
-61,Diverses régularisations en faveur de l'Etat,Belgium VAT Form: grid 61,l10n_be.tax_tag_61,
-62,Régularisations TVA en faveur du déclarant,Belgium VAT Form: grid 62,l10n_be.tax_tag_62,
-63,TVA à reverser sur notes de crédit reçues,Belgium VAT Form: grid 63,l10n_be.tax_tag_63,
-64,TVA à recuperer sur notes de crédit delivrées,Belgium VAT Form: grid 64,l10n_be.tax_tag_64,
-81,"Marchandises, matières premières et auxiliaires",Belgium VAT Form: grid 81,l10n_be.tax_tag_81,base
-82,Services et biens divers,Belgium VAT Form: grid 82,l10n_be.tax_tag_82,base
-83,Biens d'investissement,Belgium VAT Form: grid 83,l10n_be.tax_tag_83,base
-84,Notes de crédits sur opérations case [86] et [88],Belgium VAT Form: grid 84,l10n_be.tax_tag_84,base
-85,Notes de crédits autres opérations,Belgium VAT Form: grid 85,l10n_be.tax_tag_85,base
-86,Acquisition intra-communautaires et ventes ABC,Belgium VAT Form: grid 86,l10n_be.tax_tag_86,base
-88,Acquisition services intra-communautaires,Belgium VAT Form: grid 88,l10n_be.tax_tag_88,base
-87,Autres opérations à l'entrée,Belgium VAT Form: base in 87,l10n_be.tax_tag_87,base
-,,Belgium VAT Form: Tax not deductible (grid 81),l10n_be.tax_tag_81_not_deductible,
-,,Belgium VAT Form: Tax not deductible (grid 82),l10n_be.tax_tag_82_not_deductible,
-,,Belgium VAT Form: Tax not deductible (grid 83),l10n_be.tax_tag_83_not_deductible,
-,,Belgium VAT Form: Tax not deductible (grid 85),l10n_be.tax_tag_85_not_deductible,
+account.tax.code:code,account.tax.code:name,account.account.tag:name,account.account.tag:xmlid,ttype,sign
+00,Opérations soumises à un régime particulier,Belgium VAT Form: grid 0,l10n_be.tax_tag_00,base,crd
+01,Opérations avec TVA à 6%,Belgium VAT Form: grid 01,l10n_be.tax_tag_01,base,crd
+02,Opérations avec TVA à 12%,Belgium VAT Form: grid 02,l10n_be.tax_tag_02,base,crd
+03,Opérations avec TVA à 21%,Belgium VAT Form: grid 03,l10n_be.tax_tag_03,base,crd
+44,Services intra-communautaires,Belgium VAT Form: grid 44,l10n_be.tax_tag_44,base,crd
+45,Opérations avec TVA due par le cocontractant,Belgium VAT Form: grid 45,l10n_be.tax_tag_45,base,crd
+46,Livraisons intra-communautaire exemptées,,,base,XXX
+46L,Livraisons biens intra-communautaire exemptées,Belgium VAT Form: grid 46L,l10n_be.tax_tag_46L,base,XXX
+46T,ABC intra-communautaires,Belgium VAT Form: grid 46T,l10n_be.tax_tag_46T,base,XXX
+47,Autres operations exemptées,Belgium VAT Form: grid 47,l10n_be.tax_tag_47,base,crd
+48,Notes de crédit aux opérations grilles [44] et [46],,,base,deb
+48s44,Notes de crédit aux opérations grille [44],Belgium VAT Form: grid 48s44,l10n_be.tax_tag_48s44,base,deb
+48s46L,Notes de crédit aux opérations grille [46L],Belgium VAT Form: grid 48s46L,l10n_be.tax_tag_48s46L,base,deb
+48s46T,Notes de crédit aux opérations grille [46T],Belgium VAT Form: grid 48s46T,l10n_be.tax_tag_48s46T,base,deb
+49,Notes de crédit aux opérations du point II,Belgium VAT Form: grid 49,l10n_be.tax_tag_49,base,deb
+54,"TVA sur opérations des grilles [01], [02], [03]",Belgium VAT Form: grid 54,l10n_be.tax_tag_54,tax,crd
+55,TVA sur opérations des grilles [86] et [88],Belgium VAT Form: grid 55,l10n_be.tax_tag_55,tax,deb
+56,TVA sur opérations de la grille [87],Belgium VAT Form: grid 56,l10n_be.tax_tag_56,tax,deb
+57,TVA relatives aux importations,Belgium VAT Form: grid 57,l10n_be.tax_tag_57,tax,crd
+59,TVA déductible,Belgium VAT Form: grid 59,l10n_be.tax_tag_59,tax,deb
+61,Diverses régularisations en faveur de l'Etat,Belgium VAT Form: grid 61,l10n_be.tax_tag_61,tax,crd
+62,Régularisations TVA en faveur du déclarant,Belgium VAT Form: grid 62,l10n_be.tax_tag_62,tax,deb
+63,TVA à reverser sur notes de crédit reçues,Belgium VAT Form: grid 63,l10n_be.tax_tag_63,tax,crd
+64,TVA à recuperer sur notes de crédit delivrées,Belgium VAT Form: grid 64,l10n_be.tax_tag_64,tax,deb
+81,"Marchandises, matières premières et auxiliaires",Belgium VAT Form: grid 81,l10n_be.tax_tag_81,base,deb
+82,Services et biens divers,Belgium VAT Form: grid 82,l10n_be.tax_tag_82,base,deb
+83,Biens d'investissement,Belgium VAT Form: grid 83,l10n_be.tax_tag_83,base,deb
+84,Notes de crédits sur opérations case [86] et [88],Belgium VAT Form: grid 84,l10n_be.tax_tag_84,base,crd
+85,Notes de crédits autres opérations,Belgium VAT Form: grid 85,l10n_be.tax_tag_85,base,crd
+86,Acquisition intra-communautaires et ventes ABC,Belgium VAT Form: grid 86,l10n_be.tax_tag_86,base,deb
+88,Acquisition services intra-communautaires,Belgium VAT Form: grid 88,l10n_be.tax_tag_88,base,deb
+87,Autres opérations à l'entrée,Belgium VAT Form: base in 87,l10n_be.tax_tag_87,base,deb
+,,Belgium VAT Form: Tax not deductible (grid 81),l10n_be.tax_tag_81_not_deductible,,
+,,Belgium VAT Form: Tax not deductible (grid 82),l10n_be.tax_tag_82_not_deductible,,
+,,Belgium VAT Form: Tax not deductible (grid 83),l10n_be.tax_tag_83_not_deductible,,
+,,Belgium VAT Form: Tax not deductible (grid 85),l10n_be.tax_tag_85_not_deductible,,

--- a/addons/l10n_be/migrations/9.0.1.1/tax_code2tag.csv
+++ b/addons/l10n_be/migrations/9.0.1.1/tax_code2tag.csv
@@ -1,4 +1,4 @@
-code,name,account.account.tag name,account.account.tag xmlid
+account.tax.code:code,account.tax.code:name,account.account.tag:name,account.account.tag:xmlid
 00,Opérations soumises à un régime particulier,Belgium VAT Form: grid 0,l10n_be.tax_tag_00
 01,Opérations avec TVA à 6%,Belgium VAT Form: grid 01,l10n_be.tax_tag_01
 02,Opérations avec TVA à 12%,Belgium VAT Form: grid 02,l10n_be.tax_tag_02

--- a/addons/l10n_be/migrations/9.0.1.1/tax_code2tag.csv
+++ b/addons/l10n_be/migrations/9.0.1.1/tax_code2tag.csv
@@ -1,0 +1,37 @@
+code,name,account.account.tag name,account.account.tag xmlid
+00,Opérations soumises à un régime particulier,Belgium VAT Form: grid 0,l10n_be.tax_tag_00
+01,Opérations avec TVA à 6%,Belgium VAT Form: grid 01,l10n_be.tax_tag_01
+02,Opérations avec TVA à 12%,Belgium VAT Form: grid 02,l10n_be.tax_tag_02
+03,Opérations avec TVA à 21%,Belgium VAT Form: grid 03,l10n_be.tax_tag_03
+44,Services intra-communautaires,Belgium VAT Form: grid 44,l10n_be.tax_tag_44
+45,Opérations avec TVA due par le cocontractant,Belgium VAT Form: grid 45,l10n_be.tax_tag_45
+46,Livraisons intra-communautaire exemptées,,
+46L,Livraisons biens intra-communautaire exemptées,Belgium VAT Form: grid 46L,l10n_be.tax_tag_46L
+46T,ABC intra-communautaires,Belgium VAT Form: grid 46T,l10n_be.tax_tag_46T
+47,Autres operations exemptées,Belgium VAT Form: grid 47,l10n_be.tax_tag_47
+48,Notes de crédit aux opérations grilles [44] et [46],,
+48s44,Notes de crédit aux opérations grille [44],Belgium VAT Form: grid 48s44,l10n_be.tax_tag_48s44
+48s46L,Notes de crédit aux opérations grille [46L],Belgium VAT Form: grid 48s46L,l10n_be.tax_tag_48s46L
+48s46T,Notes de crédit aux opérations grille [46T],Belgium VAT Form: grid 48s46T,l10n_be.tax_tag_48s46T
+49,Notes de crédit aux opérations du point II,Belgium VAT Form: grid 49,l10n_be.tax_tag_49
+54,"TVA sur opérations des grilles [01], [02], [03]",Belgium VAT Form: grid 54,l10n_be.tax_tag_54
+55,TVA sur opérations des grilles [86] et [88],Belgium VAT Form: grid 55,l10n_be.tax_tag_55
+56,TVA sur opérations de la grille [87],Belgium VAT Form: grid 56,l10n_be.tax_tag_56
+57,TVA relatives aux importations,Belgium VAT Form: grid 57,l10n_be.tax_tag_57
+59,TVA déductible,Belgium VAT Form: grid 59,l10n_be.tax_tag_59
+61,Diverses régularisations en faveur de l'Etat,Belgium VAT Form: grid 61,l10n_be.tax_tag_61
+62,Régularisations TVA en faveur du déclarant,Belgium VAT Form: grid 62,l10n_be.tax_tag_62
+63,TVA à reverser sur notes de crédit reçues,Belgium VAT Form: grid 63,l10n_be.tax_tag_63
+64,TVA à recuperer sur notes de crédit delivrées,Belgium VAT Form: grid 64,l10n_be.tax_tag_64
+81,"Marchandises, matières premières et auxiliaires",Belgium VAT Form: grid 81,l10n_be.tax_tag_81
+82,Services et biens divers,Belgium VAT Form: grid 82,l10n_be.tax_tag_82
+83,Biens d'investissement,Belgium VAT Form: grid 83,l10n_be.tax_tag_83
+84,Notes de crédits sur opérations case [86] et [88],Belgium VAT Form: grid 84,l10n_be.tax_tag_84
+85,Notes de crédits autres opérations,Belgium VAT Form: grid 85,l10n_be.tax_tag_85
+86,Acquisition intra-communautaires et ventes ABC,Belgium VAT Form: grid 86,l10n_be.tax_tag_86
+88,Acquisition services intra-communautaires,Belgium VAT Form: grid 88,l10n_be.tax_tag_88
+87,Autres opérations à l'entrée,Belgium VAT Form: base in 87,l10n_be.tax_tag_87
+,,Belgium VAT Form: Tax not deductible (grid 81),l10n_be.tax_tag_81_not_deductible
+,,Belgium VAT Form: Tax not deductible (grid 82),l10n_be.tax_tag_82_not_deductible
+,,Belgium VAT Form: Tax not deductible (grid 83),l10n_be.tax_tag_83_not_deductible
+,,Belgium VAT Form: Tax not deductible (grid 85),l10n_be.tax_tag_85_not_deductible

--- a/addons/l10n_be/migrations/9.0.1.1/tax_code2tag.csv
+++ b/addons/l10n_be/migrations/9.0.1.1/tax_code2tag.csv
@@ -1,37 +1,37 @@
-account.tax.code:code,account.tax.code:name,account.account.tag:name,account.account.tag:xmlid
-00,Opérations soumises à un régime particulier,Belgium VAT Form: grid 0,l10n_be.tax_tag_00
-01,Opérations avec TVA à 6%,Belgium VAT Form: grid 01,l10n_be.tax_tag_01
-02,Opérations avec TVA à 12%,Belgium VAT Form: grid 02,l10n_be.tax_tag_02
-03,Opérations avec TVA à 21%,Belgium VAT Form: grid 03,l10n_be.tax_tag_03
-44,Services intra-communautaires,Belgium VAT Form: grid 44,l10n_be.tax_tag_44
-45,Opérations avec TVA due par le cocontractant,Belgium VAT Form: grid 45,l10n_be.tax_tag_45
-46,Livraisons intra-communautaire exemptées,,
-46L,Livraisons biens intra-communautaire exemptées,Belgium VAT Form: grid 46L,l10n_be.tax_tag_46L
-46T,ABC intra-communautaires,Belgium VAT Form: grid 46T,l10n_be.tax_tag_46T
-47,Autres operations exemptées,Belgium VAT Form: grid 47,l10n_be.tax_tag_47
-48,Notes de crédit aux opérations grilles [44] et [46],,
-48s44,Notes de crédit aux opérations grille [44],Belgium VAT Form: grid 48s44,l10n_be.tax_tag_48s44
-48s46L,Notes de crédit aux opérations grille [46L],Belgium VAT Form: grid 48s46L,l10n_be.tax_tag_48s46L
-48s46T,Notes de crédit aux opérations grille [46T],Belgium VAT Form: grid 48s46T,l10n_be.tax_tag_48s46T
-49,Notes de crédit aux opérations du point II,Belgium VAT Form: grid 49,l10n_be.tax_tag_49
-54,"TVA sur opérations des grilles [01], [02], [03]",Belgium VAT Form: grid 54,l10n_be.tax_tag_54
-55,TVA sur opérations des grilles [86] et [88],Belgium VAT Form: grid 55,l10n_be.tax_tag_55
-56,TVA sur opérations de la grille [87],Belgium VAT Form: grid 56,l10n_be.tax_tag_56
-57,TVA relatives aux importations,Belgium VAT Form: grid 57,l10n_be.tax_tag_57
-59,TVA déductible,Belgium VAT Form: grid 59,l10n_be.tax_tag_59
-61,Diverses régularisations en faveur de l'Etat,Belgium VAT Form: grid 61,l10n_be.tax_tag_61
-62,Régularisations TVA en faveur du déclarant,Belgium VAT Form: grid 62,l10n_be.tax_tag_62
-63,TVA à reverser sur notes de crédit reçues,Belgium VAT Form: grid 63,l10n_be.tax_tag_63
-64,TVA à recuperer sur notes de crédit delivrées,Belgium VAT Form: grid 64,l10n_be.tax_tag_64
-81,"Marchandises, matières premières et auxiliaires",Belgium VAT Form: grid 81,l10n_be.tax_tag_81
-82,Services et biens divers,Belgium VAT Form: grid 82,l10n_be.tax_tag_82
-83,Biens d'investissement,Belgium VAT Form: grid 83,l10n_be.tax_tag_83
-84,Notes de crédits sur opérations case [86] et [88],Belgium VAT Form: grid 84,l10n_be.tax_tag_84
-85,Notes de crédits autres opérations,Belgium VAT Form: grid 85,l10n_be.tax_tag_85
-86,Acquisition intra-communautaires et ventes ABC,Belgium VAT Form: grid 86,l10n_be.tax_tag_86
-88,Acquisition services intra-communautaires,Belgium VAT Form: grid 88,l10n_be.tax_tag_88
-87,Autres opérations à l'entrée,Belgium VAT Form: base in 87,l10n_be.tax_tag_87
-,,Belgium VAT Form: Tax not deductible (grid 81),l10n_be.tax_tag_81_not_deductible
-,,Belgium VAT Form: Tax not deductible (grid 82),l10n_be.tax_tag_82_not_deductible
-,,Belgium VAT Form: Tax not deductible (grid 83),l10n_be.tax_tag_83_not_deductible
-,,Belgium VAT Form: Tax not deductible (grid 85),l10n_be.tax_tag_85_not_deductible
+account.tax.code:code,account.tax.code:name,account.account.tag:name,account.account.tag:xmlid,ttype
+00,Opérations soumises à un régime particulier,Belgium VAT Form: grid 0,l10n_be.tax_tag_00,base
+01,Opérations avec TVA à 6%,Belgium VAT Form: grid 01,l10n_be.tax_tag_01,base
+02,Opérations avec TVA à 12%,Belgium VAT Form: grid 02,l10n_be.tax_tag_02,base
+03,Opérations avec TVA à 21%,Belgium VAT Form: grid 03,l10n_be.tax_tag_03,base
+44,Services intra-communautaires,Belgium VAT Form: grid 44,l10n_be.tax_tag_44,base
+45,Opérations avec TVA due par le cocontractant,Belgium VAT Form: grid 45,l10n_be.tax_tag_45,base
+46,Livraisons intra-communautaire exemptées,,,base
+46L,Livraisons biens intra-communautaire exemptées,Belgium VAT Form: grid 46L,l10n_be.tax_tag_46L,base
+46T,ABC intra-communautaires,Belgium VAT Form: grid 46T,l10n_be.tax_tag_46T,base
+47,Autres operations exemptées,Belgium VAT Form: grid 47,l10n_be.tax_tag_47,base
+48,Notes de crédit aux opérations grilles [44] et [46],,,base
+48s44,Notes de crédit aux opérations grille [44],Belgium VAT Form: grid 48s44,l10n_be.tax_tag_48s44,base
+48s46L,Notes de crédit aux opérations grille [46L],Belgium VAT Form: grid 48s46L,l10n_be.tax_tag_48s46L,base
+48s46T,Notes de crédit aux opérations grille [46T],Belgium VAT Form: grid 48s46T,l10n_be.tax_tag_48s46T,base
+49,Notes de crédit aux opérations du point II,Belgium VAT Form: grid 49,l10n_be.tax_tag_49,base
+54,"TVA sur opérations des grilles [01], [02], [03]",Belgium VAT Form: grid 54,l10n_be.tax_tag_54,tax
+55,TVA sur opérations des grilles [86] et [88],Belgium VAT Form: grid 55,l10n_be.tax_tag_55,tax
+56,TVA sur opérations de la grille [87],Belgium VAT Form: grid 56,l10n_be.tax_tag_56,tax
+57,TVA relatives aux importations,Belgium VAT Form: grid 57,l10n_be.tax_tag_57,tax
+59,TVA déductible,Belgium VAT Form: grid 59,l10n_be.tax_tag_59,tax
+61,Diverses régularisations en faveur de l'Etat,Belgium VAT Form: grid 61,l10n_be.tax_tag_61,
+62,Régularisations TVA en faveur du déclarant,Belgium VAT Form: grid 62,l10n_be.tax_tag_62,
+63,TVA à reverser sur notes de crédit reçues,Belgium VAT Form: grid 63,l10n_be.tax_tag_63,
+64,TVA à recuperer sur notes de crédit delivrées,Belgium VAT Form: grid 64,l10n_be.tax_tag_64,
+81,"Marchandises, matières premières et auxiliaires",Belgium VAT Form: grid 81,l10n_be.tax_tag_81,base
+82,Services et biens divers,Belgium VAT Form: grid 82,l10n_be.tax_tag_82,base
+83,Biens d'investissement,Belgium VAT Form: grid 83,l10n_be.tax_tag_83,base
+84,Notes de crédits sur opérations case [86] et [88],Belgium VAT Form: grid 84,l10n_be.tax_tag_84,base
+85,Notes de crédits autres opérations,Belgium VAT Form: grid 85,l10n_be.tax_tag_85,base
+86,Acquisition intra-communautaires et ventes ABC,Belgium VAT Form: grid 86,l10n_be.tax_tag_86,base
+88,Acquisition services intra-communautaires,Belgium VAT Form: grid 88,l10n_be.tax_tag_88,base
+87,Autres opérations à l'entrée,Belgium VAT Form: base in 87,l10n_be.tax_tag_87,base
+,,Belgium VAT Form: Tax not deductible (grid 81),l10n_be.tax_tag_81_not_deductible,
+,,Belgium VAT Form: Tax not deductible (grid 82),l10n_be.tax_tag_82_not_deductible,
+,,Belgium VAT Form: Tax not deductible (grid 83),l10n_be.tax_tag_83_not_deductible,
+,,Belgium VAT Form: Tax not deductible (grid 85),l10n_be.tax_tag_85_not_deductible,


### PR DESCRIPTION
The current migration of taxes on move lines does not work for l10n_be (and other localizations - see for instance #1172)

This one works for l10n_be and is quite generic, so should work for other localizations.

In a nutshell, it does the following:
* it uses a CSV file that maps tax codes to tax tags, tells if a code is for base or tax, and tells if a positive tax_amount is debit or credit
* from that it creates an inactive tax named "Mig Code {code}"
* it uses these taxes in the migrated move lines

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
