### PR TITLE
[UPD] Adapt postgresql version to fix errors about unrecognized parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
             - python-simplejson
             - python-serial
             - python-yaml
-    postgresql: "9.4"
+    postgresql: "9.6"
 
 env:
   - DB=openupgrade ODOO=./openerp-server


### PR DESCRIPTION
All of a sudden, Travis started to complain about unrecognized parameters when restoring the test database. It is true that the dump contains directives from a later version, so let's see if this works.

```$ wget -q -O- https://github.com/OCA/OpenUpgrade/releases/download/databases/8.0.psql | pg_restore -d $DB --no-owner
pg_restore: [archiver (db)] Error while INITIALIZING:
pg_restore: [archiver (db)] could not execute query: ERROR:  unrecognized configuration parameter "idle_in_transaction_session_timeout"
    Command was: SET idle_in_transaction_session_timeout = 0;
pg_restore: [archiver (db)] could not execute query: ERROR:  unrecognized configuration parameter "row_security"
    Command was: SET row_security = off;
WARNING: errors ignored on restore: 2
The command "wget -q -O- https://github.com/OCA/OpenUpgrade/releases/download/databases/8.0.psql | pg_restore -d $DB --no-owner" exited with 1.
```
