### PR TITLE
[10.0][FIX]purchase_requisition fill product

### DIFF
--- a/addons/purchase_requisition/migrations/10.0.0.1/post-migration.py
+++ b/addons/purchase_requisition/migrations/10.0.0.1/post-migration.py
@@ -10,8 +10,14 @@ def fill_product(env):
     """Fill with an pre-created product as it's required."""
     product = env['product.product'].create({
         'active': False,
+        'categ_id': env.ref('product.product_category_all').id,
         'name': 'OU purchase requisition line wildcard',
     })
+    if product.categ_id.type == 'view':
+        normal = env['product.category'].search(
+            [('type', '=', 'normal')], limit=1)
+        product.categ_id = normal
+
     openupgrade.logged_query(
         env.cr, """
         UPDATE purchase_requisition_line


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Missing mandatory field in purchase requisition post_migration script

Current behavior before PR:
An error raises asking for categ_id field when creating a product

Desired behavior after PR is merged:
No error is raised and the product is created for the purchase_requisition line

Solution: adding a default category. Actual migration run successfully after the fix.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
