### PR TITLE
[IMP] account: Fill refund_invoice_id field

### DIFF
--- a/addons/account/migrations/10.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/10.0.1.1/openupgrade_analysis_work.txt
@@ -16,6 +16,8 @@ account      / account.full.reconcile   / exchange_partial_rec_id (many2one): NE
 # rate_diff_partial_rec_id of account_move.
 
 account      / account.invoice          / refund_invoice_id (many2one)  : NEW relation: account.invoice
+# Done: post-migration. Reuse acccount_invoice_refund_link OCA module info
+
 account      / account.invoice          / website_message_ids (one2many): DEL relation: mail.message
 # NOTHING TO DO
 


### PR DESCRIPTION
This method fills the new field refund_invoice_id in invoices using the information of the OCA/account-invoicing module `account_invoice_refund_link` if present.

@Tecnativa