### PR TITLE
[IMP] stock: drop slow constraint

### DIFF
--- a/addons/stock/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/11.0.1.1/pre-migration.py
@@ -38,8 +38,9 @@ def delete_quants_for_consumable(env):
 
 
 def drop_slow_constraint(env):
-    """Removing this constraint, that doesn't affect new data structure, we
-    get tons of more performance on quant removal.
+    """Removing this constraint, that doesn't affect new data structure, as
+    it belongs to an obsolete modelo, we get tons of more performance on
+    quant removal.
     """
     openupgrade.logged_query(
         env.cr, "ALTER TABLE stock_move_operation_link DROP CONSTRAINT "

--- a/addons/stock/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/11.0.1.1/pre-migration.py
@@ -39,7 +39,7 @@ def delete_quants_for_consumable(env):
 
 def drop_slow_constraint(env):
     """Removing this constraint, that doesn't affect new data structure, as
-    it belongs to an obsolete modelo, we get tons of more performance on
+    it belongs to an obsolete model, we get tons of more performance on
     quant removal.
     """
     openupgrade.logged_query(

--- a/addons/stock/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/11.0.1.1/pre-migration.py
@@ -37,10 +37,21 @@ def delete_quants_for_consumable(env):
     )
 
 
+def drop_slow_constraint(env):
+    """Removing this constraint, that doesn't affect new data structure, we
+    get tons of more performance on quant removal.
+    """
+    openupgrade.logged_query(
+        env.cr, "ALTER TABLE stock_move_operation_link DROP CONSTRAINT "
+                "stock_move_operation_link_reserved_quant_id_fkey",
+    )
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     copy_global_rules(env)
     delete_quants_for_consumable(env)
+    drop_slow_constraint(env)
     openupgrade.update_module_moved_fields(
         env.cr, 'stock.move', ['has_tracking'], 'mrp', 'stock',
     )


### PR DESCRIPTION
Removing this constraint that doesn't affect new data structure, we get tons of more performance on quant removal.

Credits go to @carlosdauden, who discovered the bottleneck.

@Tecnativa