### PR TITLE
[FIX] Prefer 'move' rules over buy and manufacture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 python:
   - "2.7"
@@ -14,7 +15,7 @@ addons:
     postgresql: "9.6"
 
 env:
-  - DB=openupgrade ODOO=./openerp-server OPENUPGRADE_TESTS=1
+  - DB=openupgrade ODOO=./openerp-server
 
 # Need flake8 for pep8 testing
 install:
@@ -31,23 +32,33 @@ script:
     - flake8 openerp/openupgrade --max-line-length=120
     - flake8 openerp/addons/openupgrade* --max-line-length=120 --filename=__init__.py --ignore=F401
     - flake8 openerp/addons/openupgrade* --max-line-length=120 --exclude=__init__.py
-    - flake8 . --max-line-length=120 --filename=pre-*.py,post-*.py
+# only flake8 migration scripts from the openupgrade project, presumably
+# identifyable by using the openupgrade helpers
+    - flake8 --max-line-length=120 $(find . -name 'pre-*.py' -or -name 'post-*.py' -exec grep -q openupgrade {} \; -print)
+    - flake8 openerp/addons/*/migrations/*/tests/ --max-line-length=120
+    - flake8 addons/*/migrations/*/tests/ --max-line-length=120
     - npm install -g less less-plugin-clean-css
-# These 2 command are needed for avoiding a pip error (https://stackoverflow.com/a/43250324)
-    - python -m pip install --upgrade --force pip
-    - pip install -q setuptools==33.1.1
-# Install OpenUpgrade requirements
+    # Install 8.0's requirements as 7.0 does not contain this file, plus a 7.0 specific dependency
     - pip install -q -r requirements.txt
-# don't use pypi's openupgradelib, but the one from source to avoid choking
-# on unreleased features in openupgradelib
-    - pip uninstall -q --yes openupgradelib
-    - pip install -q git+https://github.com/OCA/openupgradelib.git@master
+    - pip install pywebdav
     - createdb $DB
     - wget -q -O- https://github.com/OCA/OpenUpgrade/releases/download/databases/7.0.psql | pg_restore -d $DB --no-owner
-    - MODULES=base,$(sed -n '/^+========/,$p'  openerp/openupgrade/doc/source/modules70-80.rst | grep Done | sed -n '/^|/ s/^|\([0-9a-z_]*\) *|.*$/\1/g p' | paste -d, -s)
-    - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES | sed -e "s/,/','/g")')"
-    - echo Testing modules $MODULES
-    - coverage run $ODOO --database=$DB --update=$MODULES --stop-after-init
+    - cat openerp/addons/base/migrations/*/tests/*.yml addons/*/migrations/*/tests/*.yml > ../test_data70.yml
+    # Roundtrip to previous release to update the test database with additional test data
+    # Loading and committing test data without triggering post tests needs https://github.com/odoo/odoo/pull/13146. This is now included in OpenUpgrade.
+    - git fetch --depth 2 origin 7.0
+    - git reset --hard `git ls-remote |grep refs/heads/7.0 |awk '{print $1}'`
+    - $ODOO --addons-path openerp/addons,addons --database=$DB --test-file=`readlink -f ../test_data70.yml` --test-commit --stop-after-init
+    - git reset -q --hard $TRAVIS_COMMIT
+    # don't use pypi's openupgradelib, but the one from source to avoid choking
+    # on unreleased features in openupgradelib
+    - pip install --ignore-installed git+https://github.com/OCA/openupgradelib.git@master
+    # select modules and perform the upgrade
+    - MODULES_OLD=base,$(sed -n '/^+========/,$p'  openerp/openupgrade/doc/source/modules70-80.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|del\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
+    - MODULES_NEW=base,$(sed -n '/^+========/,$p'  openerp/openupgrade/doc/source/modules70-80.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
+    - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES_OLD | sed -e "s/,/','/g")')"
+    - echo Testing modules $MODULES_NEW
+    - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init
 
 after_success:
     coveralls

--- a/addons/mrp/migrations/8.0.1.1/tests/procurement.yml
+++ b/addons/mrp/migrations/8.0.1.1/tests/procurement.yml
@@ -7,7 +7,7 @@
     wf_service = netsvc.LocalService("workflow")
     wh = self.pool['stock.warehouse'].browse(cr, uid, ref('stock.warehouse0'))
     location_id = wh.lot_stock_id.id
-    output_id = wh.lot_output_id.id
+    output_id = ref('stock.stock_location_customers')
     product = self.pool['product.product'].browse(cr, uid, ref('product.product_product_4'))
     move_m2s_id = self.create(cr, uid, {
         'name': 'test m2s manufacture',

--- a/addons/mrp/migrations/8.0.1.1/tests/procurement.yml
+++ b/addons/mrp/migrations/8.0.1.1/tests/procurement.yml
@@ -1,0 +1,70 @@
+-
+  Create a couple of 'produce' procurements to validate that they are assigned the correct rule
+  during the deferred migration step
+-
+  !python {model: stock.move}: |
+    import netsvc
+    wf_service = netsvc.LocalService("workflow")
+    wh = self.pool['stock.warehouse'].browse(cr, uid, ref('stock.warehouse0'))
+    location_id = wh.lot_stock_id.id
+    output_id = wh.lot_output_id.id
+    product = self.pool['product.product'].browse(cr, uid, ref('product.product_product_4'))
+    move_m2s_id = self.create(cr, uid, {
+        'name': 'test m2s manufacture',
+        'product_id': product.id,
+        'date': '2018-01-01',
+        'date_expected': '2018-01-01',
+        'product_qty': 1,
+        'product_uom': product.uom_id.id,
+        'product_uos_qty': 1,
+        'product_uos': product.uom_id.id,
+        'location_id': location_id,
+        'location_dest_id': output_id,
+        'state': 'confirmed',
+    })
+    move = self.browse(cr, uid, move_m2s_id)
+    proc_m2s_id = self.pool['procurement.order'].create(cr, uid, {
+        'name': move.name,
+        'origin': move.name,
+        'date_planned': move.date,
+        'product_id': move.product_id.id,
+        'product_qty': move.product_qty,
+        'product_uom': move.product_uom.id,
+        'product_uos_qty': move.product_qty,
+        'product_uos': move.product_uom.id,
+        'location_id': location_id,
+        'procure_method': 'make_to_stock',
+        'move_id': move.id,
+        'note': move.name,
+    })
+    wf_service.trg_validate(uid, 'procurement.order', proc_m2s_id, 'button_confirm', cr)
+
+    move_m2o_id = self.create(cr, uid, {
+        'name': 'test m2s manufacture',
+        'product_id': product.id,
+        'date': '2018-01-01',
+        'date_expected': '2018-01-01',
+        'product_qty': 1,
+        'product_uom': product.uom_id.id,
+        'product_uos_qty': 1,
+        'product_uos': product.uom_id.id,
+        'location_id': location_id,
+        'location_dest_id': output_id,
+        'state': 'confirmed',
+    })
+    move = self.browse(cr, uid, move_m2o_id)
+    proc_m2o_id = self.pool['procurement.order'].create(cr, uid, {
+        'name': move.name,
+        'origin': move.name,
+        'date_planned': move.date,
+        'product_id': move.product_id.id,
+        'product_qty': move.product_qty,
+        'product_uom': move.product_uom.id,
+        'product_uos_qty': move.product_qty,
+        'product_uos': move.product_uom.id,
+        'location_id': location_id,
+        'procure_method': 'make_to_order',
+        'move_id': move.id,
+        'note': move.name,
+    })
+    wf_service.trg_validate(uid, 'procurement.order', proc_m2o_id, 'button_confirm', cr)

--- a/addons/purchase/migrations/8.0.1.1/tests/procurement.yml
+++ b/addons/purchase/migrations/8.0.1.1/tests/procurement.yml
@@ -7,7 +7,7 @@
     wf_service = netsvc.LocalService("workflow")
     wh = self.pool['stock.warehouse'].browse(cr, uid, ref('stock.warehouse0'))
     location_id = wh.lot_stock_id.id
-    output_id = wh.lot_output_id.id
+    output_id = ref('stock.stock_location_customers')
     product = self.pool['product.product'].browse(cr, uid, ref('product.product_product_31'))
     move_m2s_id = self.create(cr, uid, {
         'name': 'test m2s buy',

--- a/addons/purchase/migrations/8.0.1.1/tests/procurement.yml
+++ b/addons/purchase/migrations/8.0.1.1/tests/procurement.yml
@@ -1,0 +1,70 @@
+-
+  Create a couple of 'buy' procurements to validate that they are assigned the correct rule
+  during the deferred migration step
+-
+  !python {model: stock.move}: |
+    import netsvc
+    wf_service = netsvc.LocalService("workflow")
+    wh = self.pool['stock.warehouse'].browse(cr, uid, ref('stock.warehouse0'))
+    location_id = wh.lot_stock_id.id
+    output_id = wh.lot_output_id.id
+    product = self.pool['product.product'].browse(cr, uid, ref('product.product_product_31'))
+    move_m2s_id = self.create(cr, uid, {
+        'name': 'test m2s buy',
+        'product_id': product.id,
+        'date': '2018-01-01',
+        'date_expected': '2018-01-01',
+        'product_qty': 1,
+        'product_uom': product.uom_id.id,
+        'product_uos_qty': 1,
+        'product_uos': product.uom_id.id,
+        'location_id': location_id,
+        'location_dest_id': output_id,
+        'state': 'confirmed',
+    })
+    move = self.browse(cr, uid, move_m2s_id)
+    proc_m2s_id = self.pool['procurement.order'].create(cr, uid, {
+        'name': move.name,
+        'origin': move.name,
+        'date_planned': move.date,
+        'product_id': move.product_id.id,
+        'product_qty': move.product_qty,
+        'product_uom': move.product_uom.id,
+        'product_uos_qty': move.product_qty,
+        'product_uos': move.product_uom.id,
+        'location_id': location_id,
+        'procure_method': 'make_to_stock',
+        'move_id': move.id,
+        'note': move.name,
+    })
+    wf_service.trg_validate(uid, 'procurement.order', proc_m2s_id, 'button_confirm', cr)
+
+    move_m2o_id = self.create(cr, uid, {
+        'name': 'test m2s buy',
+        'product_id': product.id,
+        'date': '2018-01-01',
+        'date_expected': '2018-01-01',
+        'product_qty': 1,
+        'product_uom': product.uom_id.id,
+        'product_uos_qty': 1,
+        'product_uos': product.uom_id.id,
+        'location_id': location_id,
+        'location_dest_id': output_id,
+        'state': 'confirmed',
+    })
+    move = self.browse(cr, uid, move_m2o_id)
+    proc_m2o_id = self.pool['procurement.order'].create(cr, uid, {
+        'name': move.name,
+        'origin': move.name,
+        'date_planned': move.date,
+        'product_id': move.product_id.id,
+        'product_qty': move.product_qty,
+        'product_uom': move.product_uom.id,
+        'product_uos_qty': move.product_qty,
+        'product_uos': move.product_uom.id,
+        'location_id': location_id,
+        'procure_method': 'make_to_order',
+        'move_id': move.id,
+        'note': move.name,
+    })
+    wf_service.trg_validate(uid, 'procurement.order', proc_m2o_id, 'button_confirm', cr)

--- a/openerp/openupgrade/tests_deferred/test_procurement_rule.py
+++ b/openerp/openupgrade/tests_deferred/test_procurement_rule.py
@@ -1,0 +1,53 @@
+# coding: utf-8
+# Copyright 2018 Opener B.V. <https://opener.amsterdam>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+from psycopg2.extensions import AsIs
+from openupgradelib import openupgrade
+from openerp.tests.common import TransactionCase
+
+_logger = logging.getLogger(__name__)
+
+
+class TestProcurementRule(TransactionCase):
+    def get_procurement(self, procure_method, supply_method):
+        stock = self.env.ref('stock.stock_location_stock')
+        customers = self.env.ref('stock.stock_location_customers')
+        self.env.cr.execute(
+            """ SELECT po.id FROM procurement_order po
+            JOIN product_product pp ON po.product_id = pp.id
+            JOIN product_template pt ON pp.product_tmpl_id = pt.id
+            WHERE po.%s = %s AND pt.%s = %s
+                AND po.state NOT IN ('cancel', 'done')""", (
+                    AsIs(openupgrade.get_legacy_name('procure_method')),
+                    procure_method,
+                    AsIs(openupgrade.get_legacy_name('supply_method')),
+                    supply_method))
+        procurement_ids = [proc_id for proc_id, in self.env.cr.fetchall()]
+        procurement = self.env['stock.move'].search([
+            ('location_id', '=', stock.id),
+            ('location_dest_id', '=', customers.id),
+            ('procurement_id', 'in', procurement_ids)
+        ], limit=1).procurement_id
+        if not procurement:
+            _logger.warn(
+                'No pending procurement found for a %s/%s product',
+                procure_method, supply_method)
+        return procurement
+
+    def test_procurement_rule(self):
+        """ Make2stock procurements for outgoing moves got a 'move' rule
+        assigned. """
+        try:
+            self.env['stock.location.route']
+        except KeyError:
+            return
+
+        for (procure_method, supply_method, action) in [
+                ('make_to_order', 'buy', 'buy'),
+                ('make_to_stock', 'buy', 'move'),
+                ('make_to_order', 'produce', 'manufacture'),
+                ('make_to_stock', 'produce', 'move')]:
+            procurement = self.get_procurement(procure_method, supply_method)
+            if procurement:
+                self.assertEqual(procurement.rule_id.action, action)


### PR DESCRIPTION
and [IMP] Call native Odoo method if no 'move' rule is found

Currently in Openupgrade, make_to_stock procurements for moves from stock to
customer location could get assigned a manufacture action if mrp was installed, which does not make sense regardless of the supply method because a make_to_stock procurement should always result in a move.

Also, group procurements and look up the rule per group instead of iterating over all pending procurements.

Backport the deferred tests mechanism and add a deferred test for this.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
