### PR TITLE
[9.0][procurement] remove the value of 'src_model' from view 'action_procurement_compute',

### DIFF
--- a/addons/procurement/migrations/9.0.1.0/noupdate_changes.xml
+++ b/addons/procurement/migrations/9.0.1.0/noupdate_changes.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<openerp>
+  <data>
+        <!-- Force removal of values in src_model, as it is not needed in 9.0.
+        Having this field completed causes issues during migration in 11.0.-->
+        <record id="action_procurement_compute" model="ir.actions.act_window">
+            <field name="name">Run Reordering Rules</field>
+            <field name="res_model">procurement.orderpoint.compute</field>
+            <field name="view_type">form</field>
+            <field name="view_mode">form</field>
+            <field name="target">new</field>
+            <field name="src_model"></field>
+        </record>
+  </data>
+</openerp>

--- a/addons/procurement/migrations/9.0.1.0/pre-migration.py
+++ b/addons/procurement/migrations/9.0.1.0/pre-migration.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# © 2018 Eficent Business and IT Consulting Services S.L.
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+
+    openupgrade.load_data(
+        env.cr, 'procurement', 'migrations/9.0.1.0/noupdate_changes.xml',
+    )


### PR DESCRIPTION
Having value 'procurement.order' value in 'src_model' field of view  'action_procurement_compute' will cause errors during migration to 11.0. We have to force this removal because the view definition from 9.0
omits the field 'src_model'.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
