### PR TITLE
[FIX] don't write implied groups on all users

### DIFF
--- a/odoo/addons/base/res/res_users.py
+++ b/odoo/addons/base/res/res_users.py
@@ -639,7 +639,7 @@ class UsersImplied(models.Model):
             for user in self.with_context({}):
                 gs = set(concat(g.trans_implied_ids for g in user.groups_id))
                 vals = {'groups_id': [(4, g.id) for g in gs]}
-                super(UsersImplied, self).write(vals)
+                super(UsersImplied, user).write(vals)
         return res
 
 #


### PR DESCRIPTION
this caused weird group assignments during upgrade, as we sometimes write on all or almost all users during migration

see https://github.com/odoo/odoo/pull/26036