### PR TITLE
[FIX] Selection value of account.payment.term.line value

### DIFF
--- a/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
@@ -434,6 +434,7 @@ account      / account.payment.term.line / days2 (integer)               : DEL r
 account      / account.payment.term.line / option (selection)            : NEW required: required, selection_keys: ['day_after_invoice_date', 'fix_day_following_month', 'last_day_current_month', 'last_day_following_month'], req_default: day_after_invoice_date
 account      / account.payment.term.line / sequence (integer)            : NEW 
 account      / account.payment.term.line / value (selection)             : selection_keys is now '['balance', 'fixed', 'percent']' ('['balance', 'fixed', 'procent']')
+# Done: rewrote 'procent' entries to 'percent'
 
 
 #### FIELDS IN MODEL ACCOUNT.TAX ####

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -249,6 +249,14 @@ def map_account_tax_template_type(cr):
         table='account_tax_template', write='sql')
 
 
+def map_payment_term_line_value(cr):
+    """ Someone fixed a Flemishism """
+    openupgrade.logged_query(
+        cr,
+        """UPDATE account_payment_term_line
+        SET value = 'percent' WHERE value = 'procent';""")
+
+
 def blacklist_field_recomputation(env):
     """Create computed fields that take long time to compute, but will be
     filled with valid values by migration."""
@@ -335,6 +343,7 @@ def migrate(env, version):
     install_account_tax_python(cr)
     map_account_tax_type(cr)
     map_account_tax_template_type(cr)
+    map_payment_term_line_value(cr)
     remove_account_moves_from_special_periods(cr)
     blacklist_field_recomputation(env)
     merge_supplier_invoice_refs(env)


### PR DESCRIPTION
 [FIX] Selection value of account.payment.term.line value

This fixes

```
File "/home/odoo/odoo/addons/account/models/account_invoice.py", line 1472, in compute
    if amt:
UnboundLocalError: local variable 'amt' referenced before assignment
```

in migrated databases (when validating invoices).