### PR TITLE
[FIX] mass_mailing: Fix mass mailing list handling

### DIFF
--- a/addons/mass_mailing/migrations/11.0.2.0/post-migration.py
+++ b/addons/mass_mailing/migrations/11.0.2.0/post-migration.py
@@ -25,7 +25,26 @@ def map_mailing_model_to_mailing_model_id(cr):
     )
 
 
+def recompute_mailing_list_domain(env):
+    """Mass mailings always use a domain for getting the recipients.
+    If you select some mailing lists in UI, on background the mailing domain is
+    changed accordingly. As now mass mailing contacts can belong to multiple
+    lists, we force the computation of the domain for having the correct one.
+    """
+    mailings = env['mail.mass_mailing'].search([
+        ('mailing_model_name', '=', 'mail.mass_mailing.list'),
+        ('contact_list_ids', '!=', False),
+    ])
+    for mailing in mailings:
+        mailing.mailing_domain = (
+            "[('list_ids', 'in', [%s]), ('opt_out', '=', False)]" % (
+                ','.join(str(id) for id in mailing.contact_list_ids.ids),
+            )
+        )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     map_list_id_to_list_ids(env)
     map_mailing_model_to_mailing_model_id(env.cr)
+    recompute_mailing_list_domain(env)

--- a/addons/mass_mailing/migrations/11.0.2.0/pre-migration.py
+++ b/addons/mass_mailing/migrations/11.0.2.0/pre-migration.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def switch_mailing_model_list(env):
+    """Doing a mass mailing on lists now points to the 'mail.mass_mailing.list'
+    model instead of the contact one.
+    """
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE mail_mass_mailing
+        SET mailing_model = 'mail.mass_mailing.list'
+        WHERE mailing_model = 'mail.mass_mailing.contact'""",
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    switch_mailing_model_list(env)


### PR DESCRIPTION
* Doing a mass mailing on lists now points to the 'mail.mass_mailing.list' model instead of the contact one.
* Mass mailings always use a domain for getting the recipients. If you select some mailing lists in UI, on background the mailing domain is changed accordingly. As now mass mailing contacts can belong to multiple lists, we force the computation of the domain for having the correct one.

@Tecnativa