### PR TITLE
[9.0] #1338, set weight from weight_net

### DIFF
--- a/addons/product/migrations/9.0.1.2/pre-migration.py
+++ b/addons/product/migrations/9.0.1.2/pre-migration.py
@@ -125,3 +125,11 @@ def migrate(env, version):
     cr.execute(
         "update product_pricelist set active=False where type='purchase'"
     )
+
+    # if weight_net != 0.0 in product_template, override weight
+    # if not, do nothing
+    openupgrade.logged_query(cr, """
+            UPDATE product_template
+            SET weight = weight_net
+            WHERE weight_net != '0.0'
+            """)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: #1338 

Current behavior before PR: weight_net is not migrated

Desired behavior after PR is merged: weight_net if != 0.0 is migrated in weight




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
