### PR TITLE
[FIX] mass_mailing: Rename list_id column in contact

### DIFF
--- a/addons/mass_mailing/migrations/11.0.2.0/post-migration.py
+++ b/addons/mass_mailing/migrations/11.0.2.0/post-migration.py
@@ -10,7 +10,7 @@ def map_list_id_to_list_ids(env):
     """Set the list_ids for the list_id in mail.mass_mailing.contact"""
     openupgrade.m2o_to_x2m(
         env.cr, env['mail.mass_mailing.contact'], 'mail_mass_mailing_contact',
-        'list_ids', 'list_id',
+        'list_ids', openupgrade.get_legacy_name('list_id'),
     )
 
 

--- a/addons/mass_mailing/migrations/11.0.2.0/pre-migration.py
+++ b/addons/mass_mailing/migrations/11.0.2.0/pre-migration.py
@@ -4,6 +4,12 @@
 
 from openupgradelib import openupgrade
 
+COLUMN_RENAMES = {
+    'mail_mass_mailing_contact': [
+        ('list_id', None),
+    ],
+}
+
 
 def switch_mailing_model_list(env):
     """Doing a mass mailing on lists now points to the 'mail.mass_mailing.list'
@@ -19,4 +25,5 @@ def switch_mailing_model_list(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
+    openupgrade.rename_columns(env.cr, COLUMN_RENAMES)
     switch_mailing_model_list(env)


### PR DESCRIPTION
Odoo uses an SQL for getting the number of contacts using the m2m table, which has a column named `list_id` for referencing the mailing list. Keeping old list_id column in mass mailing contact, provokes an ambiguous column error.

This renames the column the usual OpenUpgrade way.

cc @Tecnativa