### PR TITLE
[FIX+IMP] sale_timesheet: Map track_service to service_tracking + use openupgradelib method

### DIFF
--- a/addons/sale/migrations/11.0.1.1/pre-migration.py
+++ b/addons/sale/migrations/11.0.1.1/pre-migration.py
@@ -1,5 +1,4 @@
-# -*- coding: utf-8 -*-
-# Copyright 2017 Tecnativa - Pedro M. Baeza
+# Copyright 2017-2019 Tecnativa - Pedro M. Baeza
 # Copyright 2018 - Nicolas JEUDY
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
@@ -23,9 +22,16 @@ _portal_sale_xmlid_renames = [
     ('sale.portal_sale_order_line_rule', 'sale.sale_order_line_rule_portal'),
 ]
 
+COLUMN_COPIES = {
+    'product_template': [
+        ('track_service', None, None),
+    ],
+}
+
 
 @openupgrade.migrate()
 def migrate(env, version):
+    openupgrade.copy_columns(env.cr, COLUMN_COPIES)
     openupgrade.rename_xmlids(env.cr, _xmlid_renames)
     openupgrade.rename_xmlids(env.cr, _portal_xmlid_renames)
     openupgrade.rename_xmlids(env.cr, _portal_sale_xmlid_renames)

--- a/addons/sale_timesheet/migrations/11.0.1.0/pre-migration.py
+++ b/addons/sale_timesheet/migrations/11.0.1.0/pre-migration.py
@@ -3,18 +3,9 @@
 
 from openupgradelib import openupgrade
 
-COLUMN_COPIES = {
-    'product_template': [
-        ('service_type', None, None),
-    ],
-}
-
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.copy_columns(env.cr, COLUMN_COPIES)
-    try:
-        with env.cr.savepoint():
-            env.ref('sale_timesheet.duplicate_field_xmlid').unlink()
-    except Exception:
-        pass
+    openupgrade.delete_records_safely_by_xml_id(
+        env, ['sale_timesheet.duplicate_field_xmlid'],
+    )


### PR DESCRIPTION
* If you had "Create a task and track hours" option in `track_service` v10 field, the most similar one respecting task creation (new v11 field `service_tracking`) is "Create a task in a new project". Thus, we map that value.
* Use openupgradelib `delete_records_safely_by_xml_id` method for removing the `duplicate_field_xmlid` record.

cc @Tecnativa