### PR TITLE
[FIX] project: Transfer also magic columns

### DIFF
--- a/addons/project/migrations/11.0.1.1/post-migration.py
+++ b/addons/project/migrations/11.0.1.1/post-migration.py
@@ -107,6 +107,7 @@ def convert_issues(env):
     openupgrade.logged_query(
         env.cr, """
         INSERT INTO project_task (
+            create_date, create_uid, write_date, write_uid,
             %(issue_column)s, project_id,
             active, color, company_id, date_start, date_end,
             date_deadline, description, kanban_state, name,
@@ -115,6 +116,7 @@ def convert_issues(env):
             priority
         )
         SELECT
+            pi.create_date, pi.create_uid, pi.write_date, pi.write_uid,
             pi.id, COALESCE(pp.%(project_column)s, pp.id),
             pi.active, pi.color, pi.company_id, pi.date_open, pi.date_closed,
             pi.date_deadline, pi.description, pi.kanban_state, pi.name,


### PR DESCRIPTION
Magic columns (aka log fields) were not transferred on tasks created out of issues, and thus that fields were empty. With this, we transfer that information.

cc @Tecnativa