### PR TITLE
[FIX] Table renamed crm_lead_lost_reason using rename_tables

### DIFF
--- a/addons/crm/migrations/9.0.1.0/pre-migration.py
+++ b/addons/crm/migrations/9.0.1.0/pre-migration.py
@@ -12,6 +12,7 @@ table_renames = [
     ('crm_case_categ', 'crm_lead_tag'),
     ('crm_case_stage', 'crm_stage'),
     ('section_stage_rel', 'crm_team_stage_rel'),
+    ('crm_lead_lost_reason', 'crm_lost_reason'),
 ]
 
 column_renames = {
@@ -94,6 +95,3 @@ def migrate(env, version):
         [('4', '3')], table='crm_lead',
     )
     cr.execute("update crm_lead set type='opportunity' where type is null")
-    # Needed for crm_lead_lost_reason migration
-    cr.execute("ALTER TABLE IF EXISTS crm_lead_lost_reason "
-               "RENAME TO crm_lost_reason")

--- a/addons/crm/migrations/9.0.1.0/pre-migration.py
+++ b/addons/crm/migrations/9.0.1.0/pre-migration.py
@@ -12,7 +12,6 @@ table_renames = [
     ('crm_case_categ', 'crm_lead_tag'),
     ('crm_case_stage', 'crm_stage'),
     ('section_stage_rel', 'crm_team_stage_rel'),
-    ('crm_lead_lost_reason', 'crm_lost_reason'),
 ]
 
 column_renames = {
@@ -95,3 +94,5 @@ def migrate(env, version):
         [('4', '3')], table='crm_lead',
     )
     cr.execute("update crm_lead set type='opportunity' where type is null")
+    if openupgrade.table_exists(cr, 'crm_lead_lost_reason'):
+        openupgrade.rename_tables(cr, [('crm_lead_lost_reason', 'crm_lost_reason')])


### PR DESCRIPTION
This fixes renaming crm_lead_lost_reason to crm_lost_reason using
openupgrade's rename_tables so that sequences are renamed as well.

Description of the issue/feature this PR addresses:

Current behavior before PR:
Migration fails at sequence with new name

Desired behavior after PR is merged:
Migration runs.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
