### PR TITLE
[10.0][IMP] mrp: bottleneck created to compute unit_factor

### DIFF
--- a/addons/mrp/migrations/10.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/10.0.2.0/post-migration.py
@@ -291,7 +291,8 @@ def fill_stock_move_unit_factor(env):
         productions = env['mrp.production'].browse(ids)
     productions._get_produced_qty()
 
-    for production in productions:
+    for production in productions.filtered(
+            lambda r: r.state not in ['done', 'cancel']):
         diff = production.product_qty - production.qty_produced
         cr.execute(
             """


### PR DESCRIPTION
Without this filtering calculating the unit_factor for all the moves associated to all MOs could take more than 24 hours in big databases. Plus, the field is not useful for done and cancel MOs, so not worth to compute it.

In my local testing each loop lasted around 0.8 seconds but sometimes it went up to 3!. This means that in a database with +100k MOs you will be in this loop, in the best case, for 80k seconds (22 hours). With this fix it only took 7 minutes in my use case.
