### PR TITLE
[11.0][IMP] calendar: res_model column could exist before migration.

### DIFF
--- a/addons/calendar/migrations/11.0.1.0/pre-migration.py
+++ b/addons/calendar/migrations/11.0.1.0/pre-migration.py
@@ -35,13 +35,18 @@ def set_calendar_event_res_model(env):
     for avoiding an error when writing back the value on virtual records
     created by recurring events. No need of writing any possible value, as
     this is a new feature not available in v10.
+
+    If the OCA module `mail_activity_calendar` was installed in
+    previous version this field would already exist, thus no need to
+    pre-create it.
     """
-    openupgrade.add_fields(
-        env, [
-            ('res_model', 'calendar.event', 'calendar_event', 'char', False,
-             'calendar'),
-        ],
-    )
+    if not openupgrade.column_exists(env.cr, 'calendar_event', 'res_model'):
+        openupgrade.add_fields(
+            env, [
+                ('res_model', 'calendar.event', 'calendar_event', 'char',
+                 False, 'calendar'),
+            ],
+        )
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
add a check for res_model column in calendar.event because it could already be present in a database with OCA module mail_activity_calendar installed.