### PR TITLE
[10.0][FIX] account_asset: Fill expense account from asset one

### DIFF
--- a/addons/account_asset/migrations/10.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/account_asset/migrations/10.0.1.0/openupgrade_analysis_work.txt
@@ -6,6 +6,7 @@ account_asset / account.asset.asset      / website_message_ids (one2many): DEL r
 account_asset / account.asset.category   / account_income_recognition_id (many2one): now required
 account_asset / account.asset.category   / account_income_recognition_id (many2one): was renamed to account_depreciation_expense_id [nothing to do]
 account_asset / account.asset.category   / group_entries (boolean)       : NEW
+# Done: Run rename_fields + fill with account_asset_id when empty (as it was the previous value)
 
 account_asset / account.move             / asset_depreciation_ids (one2many): NEW relation: account.asset.depreciation.line
 # NOTHING TO DO

--- a/addons/account_asset/migrations/10.0.1.0/pre-migration.py
+++ b/addons/account_asset/migrations/10.0.1.0/pre-migration.py
@@ -19,7 +19,18 @@ field_renames = [
 ]
 
 
+def assign_expense_account(env):
+    """Put the asset account where you don't have any expense account."""
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE account_asset_category
+        SET account_depreciation_expense_id = account_asset_id
+        WHERE account_depreciation_expense_id IS NULL""",
+    )
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     openupgrade.rename_columns(env.cr, column_renames)
     openupgrade.rename_fields(env, field_renames)
+    assign_expense_account(env)


### PR DESCRIPTION
Following the behavior in previous version, if you don't have expense account, then the asset one is used. As now the field is required, we copy the asset account in those empty expense accounts

cc @Tecnativa