### PR TITLE
[FIX] uom_id is required when creating a product

### DIFF
--- a/addons/sale/migrations/9.0.1.0/post-migration.py
+++ b/addons/sale/migrations/9.0.1.0/post-migration.py
@@ -40,6 +40,7 @@ def set_dummy_product(env):
         'name': 'Any product',
         'type': 'service',
         'order_policy': 'manual',
+        'uom_id': env.ref('product.product_uom_unit').id,
     })
     env.cr.execute(
         """UPDATE sale_order_line


### PR DESCRIPTION
Creating a product requires the uom to be not null. This fix adds the
Unit(s) uom when creating the dummy product

Description of the issue/feature this PR addresses:
Creating a product requires the uom to be not null.

Current behavior before PR:
Migration fails when trying to create the product with null uom_id

Desired behavior after PR is merged:
The dummy product is created and migration continues




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
