### PR TITLE
[FIX] sale_timesheet: Restrict the SO line assignment to projects

### DIFF
--- a/addons/sale_timesheet/migrations/11.0.1.0/post-migration.py
+++ b/addons/sale_timesheet/migrations/11.0.1.0/post-migration.py
@@ -20,15 +20,30 @@ def migrate_project_sale_line(env):
     openupgrade.logged_query(
         env.cr, """
             UPDATE project_project pj
-            SET sale_line_id = sol.id
-            FROM sale_order_line sol, product_product pd, sale_order so,
-              product_template pt
-            WHERE sol.product_id = pd.id
-            AND sol.order_id = so.id
-            AND so.analytic_account_id = pj.id
-            AND pt.id = pd.product_tmpl_id
-            AND so.state in ('sale', 'done')
-            AND pt.%s in ('task', 'timesheet')
+            SET sale_line_id = sub.sol_id
+            FROM (
+                SELECT * FROM (
+                    SELECT pj.id AS project_id,
+                        sol.id AS sol_id,
+                        row_number() over (
+                            partition BY pj.id ORDER BY pj.id
+                        ) AS rnum
+                    FROM project_project pj,
+                        sale_order_line sol,
+                        product_product pd,
+                        sale_order so,
+                        product_template pt
+                    WHERE sol.product_id = pd.id
+                        AND sol.order_id = so.id
+                        AND so.analytic_account_id = pj.id
+                        AND pt.id = pd.product_tmpl_id
+                        AND so.state in ('sale', 'done')
+                        AND pt.%s in ('task', 'timesheet')
+                        AND pj.create_date > so.create_date
+                ) t
+                WHERE t.rnum = 1
+            ) AS sub
+            WHERE sub.project_id = pj.id
         """, (AsIs(service_column),))
 
 


### PR DESCRIPTION
Previous query were very greedy, assigning a lot of projects that have several sales order lines related or that have been created after the project creation.

This query prevents that restricting the update.

cc @Tecnativa