### PR TITLE
[REF] move merged_modules list into apriori files to make the analysis easier

### DIFF
--- a/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
@@ -45,75 +45,7 @@ def cleanup_modules(cr):
     """Don't report as missing these modules, as they are integrated in
     other modules."""
     openupgrade.update_module_names(
-        cr, [
-            ('account_chart', 'account'),
-            ('account_followup', 'account_credit_control'),
-            # We convert deprecated Odoo module into OCA one - The rest of
-            # the migration is in the module in OCA/sale-workflow
-            ('sale_journal', 'sale_order_type'),
-            ('contacts', 'mail'),
-            ('im_chat', 'mail'),
-            ('marketing_crm', 'crm'),
-            ('email_template', 'mail'),  # mail_template class
-            ('hr_applicant_document', 'hr_recruitment'),
-            ('portal_project', 'project'),
-            ('portal_project_issue', 'project_issue'),
-            ('procurement_jit_stock', 'procurement_jit'),
-            ('web_gantt', 'web'),
-            ('web_graph', 'web'),
-            ('web_kanban_sparkline', 'web'),
-            ('web_tests', 'web'),
-            ('website_report', 'report'),
-            # from OCA/account-financial-tools - Features changed
-            ('account_move_line_no_default_search', 'account'),
-            ('account_tax_chart_interval', 'account'),
-            # from OCA/account-financial-reporting
-            ('account_journal_report_xls', 'account_journal_report'),
-            ('account_financial_report_webkit_xls',
-             'account_financial_report_qweb'),
-            ('account_tax_report_no_zeroes', 'account'),
-            # from OCA/account_payment
-            ('account_payment_term_multi_day',
-             'account_payment_term_extension'),
-            # from OCA/bank-statement-reconcile
-            ('account_easy_reconcile', 'account_mass_reconcile'),
-            ('account_advanced_reconcile', 'account_mass_reconcile'),
-            ('account_bank_statement_period_from_line_date', 'account'),
-            # from OCA/connector-telephony
-            ('asterisk_click2dial_crm', 'crm_phone'),
-            # from OCA/product-attribute
-            ('product_pricelist_fixed_price', 'product'),
-            # from OCA/server-tools - features included now in core
-            ('base_concurrency', 'base'),
-            ('base_debug4all', 'base'),
-            ('cron_run_manually', 'base'),
-            ('shell', 'base'),
-            # from OCA/social - included in core
-            ('website_mail_snippet_table_edit', 'mass_mailing'),
-            ('mass_mailing_sending_queue', 'mass_mailing'),
-            ('website_mail_snippet_bg_color',
-             'web_editor_background_color'),  # this one now located in OCA/web
-            # from OCA/crm - included in core
-            ('crm_lead_lost_reason', 'crm'),
-            # from OCA/sale-workflow - included in core
-            ('account_invoice_reorder_lines', 'account'),
-            ('sale_order_back2draft', 'sale'),
-            ('partner_prepayment', 'sale_delivery_block'),
-            ('sale_fiscal_position_update', 'sale'),
-            ('sale_documents_comments', 'sale_comment_propagation'),
-            # from OCA/bank-payment
-            ('account_payment_sale_stock', 'account_payment_sale'),
-            # from OCA/website
-            ('website_event_register_free', 'website_event'),
-            ('website_event_register_free_with_sale', 'website_event_sale'),
-            ('website_sale_collapse_categories', 'website_sale'),
-            # OCA/reporting-engine
-            ('report_xls', 'report_xlsx'),
-            # OCA/l10n-spain
-            ('l10n_es_account_financial_report', 'account_journal_report'),
-            # OCA/stock-logistics-workflow
-            ('stock_dropshipping_dual_invoice', 'stock_dropshipping'),
-        ], merge_modules=True,
+        cr, apriori.merged_modules, merge_modules=True,
     )
 
 

--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -68,5 +68,75 @@ renamed_modules = {
     'web_shortcuts': 'web_shortcut',
 }
 
+merged_modules = [
+    ('account_chart', 'account'),
+    ('account_followup', 'account_credit_control'),
+    # We convert deprecated Odoo module into OCA one - The rest of
+    # the migration is in the module in OCA/sale-workflow
+    ('sale_journal', 'sale_order_type'),
+    ('contacts', 'mail'),
+    ('im_chat', 'mail'),
+    ('marketing_crm', 'crm'),
+    ('email_template', 'mail'),  # mail_template class
+    ('hr_applicant_document', 'hr_recruitment'),
+    ('portal_project', 'project'),
+    ('portal_project_issue', 'project_issue'),
+    ('procurement_jit_stock', 'procurement_jit'),
+    ('web_gantt', 'web'),
+    ('web_graph', 'web'),
+    ('web_kanban_sparkline', 'web'),
+    ('web_tests', 'web'),
+    ('website_report', 'report'),
+    # from OCA/account-financial-tools - Features changed
+    ('account_move_line_no_default_search', 'account'),
+    ('account_tax_chart_interval', 'account'),
+    # from OCA/account-financial-reporting
+    ('account_journal_report_xls', 'account_journal_report'),
+    ('account_financial_report_webkit_xls',
+     'account_financial_report_qweb'),
+    ('account_tax_report_no_zeroes', 'account'),
+    # from OCA/account_payment
+    ('account_payment_term_multi_day',
+     'account_payment_term_extension'),
+    # from OCA/bank-statement-reconcile
+    ('account_easy_reconcile', 'account_mass_reconcile'),
+    ('account_advanced_reconcile', 'account_mass_reconcile'),
+    ('account_bank_statement_period_from_line_date', 'account'),
+    # from OCA/connector-telephony
+    ('asterisk_click2dial_crm', 'crm_phone'),
+    # from OCA/product-attribute
+    ('product_pricelist_fixed_price', 'product'),
+    # from OCA/server-tools - features included now in core
+    ('base_concurrency', 'base'),
+    ('base_debug4all', 'base'),
+    ('cron_run_manually', 'base'),
+    ('shell', 'base'),
+    # from OCA/social - included in core
+    ('website_mail_snippet_table_edit', 'mass_mailing'),
+    ('mass_mailing_sending_queue', 'mass_mailing'),
+    ('website_mail_snippet_bg_color',
+     'web_editor_background_color'),  # this one now located in OCA/web
+    # from OCA/crm - included in core
+    ('crm_lead_lost_reason', 'crm'),
+    # from OCA/sale-workflow - included in core
+    ('account_invoice_reorder_lines', 'account'),
+    ('sale_order_back2draft', 'sale'),
+    ('partner_prepayment', 'sale_delivery_block'),
+    ('sale_fiscal_position_update', 'sale'),
+    ('sale_documents_comments', 'sale_comment_propagation'),
+    # from OCA/bank-payment
+    ('account_payment_sale_stock', 'account_payment_sale'),
+    # from OCA/website
+    ('website_event_register_free', 'website_event'),
+    ('website_event_register_free_with_sale', 'website_event_sale'),
+    ('website_sale_collapse_categories', 'website_sale'),
+    # OCA/reporting-engine
+    ('report_xls', 'report_xlsx'),
+    # OCA/l10n-spain
+    ('l10n_es_account_financial_report', 'account_journal_report'),
+    # OCA/stock-logistics-workflow
+    ('stock_dropshipping_dual_invoice', 'stock_dropshipping'),
+]
+
 renamed_models = {
 }


### PR DESCRIPTION
This PR is around a work I make, to analysis Openupgrade coverage of Odoo instances to evaluate the workload.

One of the difficulties is to know if a module is unported or if the features has been merged in another module. (OCA / Odoo SA)

For that purpose, I'm moving this list into the apriori file to make the analysis easier.

the PR doesn't change any behaviour of openupgrade, and has been locally tested.

CC : @StefanRijnhart 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
