### PR TITLE
[10.0][FIX] hr_timesheet: pass active field from analytic accounts to new projects

### DIFF
--- a/addons/hr_timesheet/migrations/10.0.1.0/post-migration.py
+++ b/addons/hr_timesheet/migrations/10.0.1.0/post-migration.py
@@ -22,7 +22,7 @@ def migrate_missing_projects(env):
     """Create a project and link it to the orphaned analytic accounts"""
     env.cr.execute(
         """
-        SELECT aaa.id, aaa.company_id, aaa.name
+        SELECT aaa.id, aaa.company_id, aaa.name, aaa.active
         FROM account_analytic_account aaa
         LEFT JOIN project_project pp ON pp.analytic_account_id = aaa.id
         WHERE %s = True
@@ -38,6 +38,7 @@ def migrate_missing_projects(env):
             'analytic_account_id': aaa_row[0],
             'company_id': aaa_row[1],
             'name': aaa_row[2],
+            'active': aaa_row[3],
             'allow_timesheets': True,
         })
 


### PR DESCRIPTION
It doesn't make sense to create active projects from inactive analytic accounts.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr