### PR TITLE
[11.0] mail_activity, mail_activity_crm and mail_activity _calendar are now out of-the-box

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -86,6 +86,10 @@ merged_modules = {
     'product_brand_sale_report': 'product_brand',
     'sale_proforma_report': 'sale',
     'sale_reporting_weight': 'product_weight_through_uom',
+    # OCA/social:
+    'mail_activity': 'mail',
+    'mail_activity_crm': 'crm',
+    'mail_activity_calendar': 'calendar',
     # OCA/stock-logistics-workflow
     'stock_disable_force_availability_button': 'stock',
     'stock_picking_transfer_lot_autoassign': 'stock_pack_operation_auto_fill',


### PR DESCRIPTION
These modules were a backport of the v11 feature, so they are contained in the standard odoo modules.
