### PR TITLE
[11.0][FIX] fetchmail: avoid warning

### DIFF
--- a/addons/fetchmail/migrations/11.0.1.0/noupdate_changes.xml
+++ b/addons/fetchmail/migrations/11.0.1.0/noupdate_changes.xml
@@ -1,10 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
     <record id="ir_cron_mail_gateway_action" model="ir.cron">
-        <field name="model"/>
-        <field name="args"/>
         <field name="name">Mail: Fetchmail Service</field>
-        <field name="function"/>
         <field name="state">code</field>
         <field name="code">model._fetch_mails()</field>
         <field name="model_id" ref="model_fetchmail_server"/>


### PR DESCRIPTION
Old fields of `ir.cron` should be removed from noupdate_changes file to avoid warning.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr