### PR TITLE
[10.0] mrp_production_unreserve not needed in v10

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -50,6 +50,8 @@ merged_modules = [
     ('account_journal_report', 'account_financial_report_qweb'),
     # OCA/e-commerce
     ('website_sale_b2c', 'sale'),  # used groups are in sale
+    # OCA/manufacture
+    ('mrp_production_unreserve', 'mrp'),
     # OCA/sale-workflow
     ('sale_order_back2draft', 'sale'),
     # OCA/social


### PR DESCRIPTION
See [module roadmap](https://github.com/OCA/manufacture/blob/9.0/mrp_production_unreserve/README.rst#known-issues--roadmap)

cc @mreficent 