### PR TITLE
[10.0][MIG] Rename of sale_delivery_block_proc_group_by_line

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -21,6 +21,8 @@ renamed_modules = {
     'report_mrp_bom_matrix': 'mrp_bom_matrix_report',
     # OCA/sale-workflow:
     'sale_delivery_block': 'sale_stock_picking_blocking',
+    'sale_delivery_block_proc_group_by_line':
+        'sale_stock_picking_blocking_proc_group_by_line',
     'product_customer_code_sale': 'product_supplierinfo_for_customer_sale',
     # OCA/server-tools:
     'mail_log_messages_to_process': 'mail_log_message_to_process',


### PR DESCRIPTION
Renamed to `sale_stock_picking_blocking_proc_group_by_line` here https://github.com/OCA/sale-workflow/pull/573.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr