### PR TITLE
[10.0][FIX] Ensure no duplications in res.country.state model

### DIFF
--- a/odoo/addons/base/migrations/10.0.1.3/openupgrade_analysis_work.txt
+++ b/odoo/addons/base/migrations/10.0.1.3/openupgrade_analysis_work.txt
@@ -68,6 +68,8 @@ DEL ir.ui.menu: base.menu_sale_config
 DEL ir.ui.menu: base.menu_sales
 NEW ir.ui.view: base.action_view_company_form_link_2_currencies
 NEW ir.ui.view: base.view_translation_dialog_tree
+# NOTHING TO DO
+
 NEW res.country.state: base.state_ae_aj
 NEW res.country.state: base.state_ae_az
 NEW res.country.state: base.state_ae_du
@@ -654,6 +656,8 @@ NEW res.country.state: base.state_za_nc
 NEW res.country.state: base.state_za_nl
 NEW res.country.state: base.state_za_nw
 NEW res.country.state: base.state_za_wc
+# DONE: post-migration: assured no duplications, due to new 'name_code_uniq' constraint
+
 NEW res.currency: base.TJS
 DEL res.currency: base.GWP
 DEL res.currency: base.SIT

--- a/odoo/addons/base/migrations/10.0.1.3/post-migration.py
+++ b/odoo/addons/base/migrations/10.0.1.3/post-migration.py
@@ -1,7 +1,9 @@
 # coding: utf-8
 # © 2017-2018 Opener BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from openupgradelib import openupgrade
+import csv
+from openupgradelib import openupgrade, openupgrade_merge_records
+from odoo.modules.module import get_module_resource
 
 
 def handle_im_odoo_support_views(env):
@@ -17,9 +19,126 @@ def handle_im_odoo_support_views(env):
             view.unlink()
 
 
+def clean_states_with_no_code(env):
+    """This method ensures that if you have countries
+    introduced manually without code, then merge them with the same countries
+    but with coded ones"""
+    country_model = env['res.country']
+    wrong_countries = country_model.search([('code', '=', False)])
+    for wrong_country in wrong_countries:
+        good_country = country_model.search(
+            [('name', 'in',
+              [
+                  wrong_country.name.strip(),
+                  wrong_country.name.strip().title(),
+              ]),
+             ('code', '!=', False),
+             ])
+        if good_country:
+            openupgrade_merge_records.merge_records(
+                env, 'res.country',
+                wrong_country.ids,
+                good_country.id,
+                {
+                    'address_format': 'other',
+                    'phone_code': 'min',
+                    'country_group_ids': 'merge',
+                    'state_ids': 'merge',
+                }
+            )
+
+
+def merge_country_states(env):
+    """"You may have duplicated countries states,
+    so ensure you merge the duplicated ones"""
+    clean_states_with_no_code(env)
+    group_list = [
+        'country_id', 'code',
+    ]
+    country_state_model = env['res.country.state']
+    groups = country_state_model.read_group(
+        [], group_list, group_list, lazy=False,
+    )
+    for group in groups:
+        country_states = country_state_model.search(group['__domain'])
+        if len(country_states) == 1:
+            continue
+        correct_country_states = country_states.filtered(
+            lambda cs: cs.country_id.address_format)
+        if correct_country_states:
+            openupgrade_merge_records.merge_records(
+                env, 'res.country.state',
+                (country_states - correct_country_states[-1]).ids,
+                correct_country_states[-1].id,
+            )
+        else:
+            openupgrade_merge_records.merge_records(
+                env, 'res.country.state',
+                (country_states - country_states[-1]).ids,
+                country_states[-1].id,
+            )
+    # Use here same method as pre-migration method, partially, just in case:
+    with open(get_module_resource('base', 'res', 'res.country.state.csv'),
+              'rb') as country_states_file:
+        states = csv.reader(country_states_file, delimiter=',', quotechar='"')
+        for row, state in enumerate(states):
+            if row == 0:
+                continue
+            data_name = state[0]
+            country_code = state[1]
+            name = state[2]
+            state_code = state[3]
+            env.cr.execute(
+                """
+                SELECT imd.id
+                FROM ir_model_data imd
+                INNER JOIN res_country_state rcs ON (
+                    imd.model = 'res.country.state' AND imd.res_id = rcs.id)
+                LEFT JOIN res_country rc ON rcs.country_id = rc.id
+                INNER JOIN ir_model_data imd2 ON (
+                    rc.id = imd2.res_id AND imd2.model = 'res.country')
+                WHERE imd2.name = '%(country_code)s'
+                    AND rcs.code = '%(state_code)s'
+                ORDER BY imd.id DESC
+                LIMIT 1
+                """ % {
+                    'country_code': country_code,
+                    'state_code': state_code,
+                }
+            )
+            found_id = env.cr.fetchone()
+            if not found_id:
+                continue
+            openupgrade.logged_query(
+                env.cr,
+                """
+                UPDATE ir_model_data
+                SET name = '%(data_name)s', module = 'base'
+                WHERE id = %(data_id)s AND model = 'res.country.state'
+                """ % {
+                    'data_name': data_name,
+                    'data_id': found_id[0],
+                }
+            )
+            env.cr.execute(
+                """
+                UPDATE res_country_state rcs
+                SET name = $$%(name)s$$
+                FROM ir_model_data imd
+                WHERE imd.id = %(data_id)s
+                    AND imd.model = 'res.country.state'
+                    AND imd.res_id = rcs.id
+                """ % {
+                    'name': name,
+                    'data_id': found_id[0],
+                }
+            )
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     handle_im_odoo_support_views(env)
+    merge_country_states(env)
     openupgrade.load_data(
         env.cr, 'base', 'migrations/10.0.1.3/noupdate_changes.xml'
     )

--- a/odoo/addons/base/migrations/10.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/10.0.1.3/pre-migration.py
@@ -1,14 +1,144 @@
 # -*- coding: utf-8 -*-
 # © 2017 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import csv
 from openupgradelib import openupgrade
 from odoo.addons.openupgrade_records.lib import apriori
+from odoo.modules.module import get_module_resource
 
 _column_renames = {
     'res_partner': [
         ('birthdate', None),
     ],
 }
+
+
+def ensure_country_state_id_on_existing_records(cr):
+    """Suppose you have country states introduced manually.
+    This method ensure you don't have problems later in the migration when
+    loading the res.country.state.csv"""
+    with open(get_module_resource('base', 'res', 'res.country.state.csv'),
+              'rb') as country_states_file:
+        states = csv.reader(country_states_file, delimiter=',', quotechar='"')
+        for row, state in enumerate(states):
+            if row == 0:
+                continue
+            data_name = state[0]
+            country_code = state[1]
+            name = state[2]
+            state_code = state[3]
+            # first: query to ensure the existing odoo countries have
+            # the code of the csv file, because maybe some code has changed
+            cr.execute(
+                """
+                UPDATE res_country_state rcs
+                SET code = '%(state_code)s'
+                FROM ir_model_data imd
+                WHERE imd.model = 'res.country.state'
+                    AND imd.res_id = rcs.id
+                    AND imd.name = '%(data_name)s'
+                """ % {
+                    'state_code': state_code,
+                    'data_name': data_name,
+                }
+            )
+            # second: find if csv record exists in ir_model_data
+            cr.execute(
+                """
+                SELECT imd.id
+                FROM ir_model_data imd
+                INNER JOIN res_country_state rcs ON (
+                    imd.model = 'res.country.state' AND imd.res_id = rcs.id)
+                LEFT JOIN res_country rc ON rcs.country_id = rc.id
+                INNER JOIN ir_model_data imd2 ON (
+                    rc.id = imd2.res_id AND imd2.model = 'res.country')
+                WHERE imd2.name = '%(country_code)s'
+                    AND rcs.code = '%(state_code)s'
+                    AND imd.name = '%(data_name)s'
+                """ % {
+                    'country_code': country_code,
+                    'state_code': state_code,
+                    'data_name': data_name,
+                }
+            )
+            found_id = cr.fetchone()
+            if found_id:
+                continue
+            # third: as csv record not exists in ir_model_data, search for one
+            # introduced manually that has same codes
+            cr.execute(
+                """
+                SELECT imd.id
+                FROM ir_model_data imd
+                INNER JOIN res_country_state rcs ON (
+                    imd.model = 'res.country.state' AND imd.res_id = rcs.id)
+                LEFT JOIN res_country rc ON rcs.country_id = rc.id
+                INNER JOIN ir_model_data imd2 ON (
+                    rc.id = imd2.res_id AND imd2.model = 'res.country')
+                WHERE imd2.name = '%(country_code)s'
+                    AND rcs.code = '%(state_code)s'
+                ORDER BY imd.id DESC
+                LIMIT 1
+                """ % {
+                    'country_code': country_code,
+                    'state_code': state_code,
+                }
+            )
+            found_id = cr.fetchone()
+            if not found_id:
+                continue
+            # fourth: if found, ensure it has the same xmlid as the csv record
+            openupgrade.logged_query(
+                cr,
+                """
+                UPDATE ir_model_data
+                SET name = '%(data_name)s', module = 'base'
+                WHERE id = %(data_id)s AND model = 'res.country.state'
+                """ % {
+                    'data_name': data_name,
+                    'data_id': found_id[0],
+                }
+            )
+            cr.execute(
+                """
+                UPDATE res_country_state rcs
+                SET name = $$%(name)s$$
+                FROM ir_model_data imd
+                WHERE imd.id = %(data_id)s
+                    AND imd.model = 'res.country.state'
+                    AND imd.res_id = rcs.id
+                """ % {
+                    'name': name,
+                    'data_id': found_id[0],
+                }
+            )
+        # fifth: search for duplicates, just in case, due to new constraint
+        cr.execute(
+            """
+            SELECT imd.id, imd.name, rcs.code
+            FROM ir_model_data imd
+            INNER JOIN res_country_state rcs ON (
+                imd.model = 'res.country.state' AND imd.res_id = rcs.id)
+            ORDER BY imd.id DESC
+            """
+        )
+        rows = []
+        for row in cr.fetchall():
+            if row in rows:
+                # rename old duplicated entries that post-migration will merge
+                openupgrade.logged_query(
+                    cr,
+                    """
+                    UPDATE ir_model_data
+                    SET name = $$%(data_name)s$$ || '_old_' || res_id
+                    WHERE id = %(data_id)s AND model = 'res.country.state'
+                    """ % {
+                        'data_name': row[1],
+                        'data_id': row[0],
+                    }
+                )
+            else:
+                rows.append(row)
 
 
 @openupgrade.migrate(use_env=False)
@@ -57,6 +187,7 @@ def migrate(cr, version):
         end,
         'res.lang', id
         from res_lang''')
+    ensure_country_state_id_on_existing_records(cr)
     openupgrade.update_module_names(
         cr, apriori.merged_modules, merge_modules=True,
     )


### PR DESCRIPTION
Solves https://github.com/OCA/OpenUpgrade/issues/1613.

In fact, solves several things:
- If manual data is introduced previously, then assures there is no duplicated data to avoid error of new constraint.
- If manual data is introduced previously, then solves that cvs v10 doesn't gives conflicts when migrating.
- Also, deletes marked "duplicated" data at the post-migration.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr