### PR TITLE
fix product_packaging INSERT query invalid syntax

### DIFF
--- a/addons/product/migrations/11.0.1.2/post-migration.py
+++ b/addons/product/migrations/11.0.1.2/post-migration.py
@@ -34,11 +34,11 @@ def map_product_tmpl_id_to_product_id(cr):
             for p in product_rows[1:]:
                 fields = values = column_names
                 cr.execute("""
-                   INSERT INTO product_packaging %s
+                   INSERT INTO product_packaging(%s)
                    SELECT %s
-                   FROM product_packaging WHERE id = %%s""" % (
+                   FROM product_packaging WHERE id = %s""" % (
                     ','.join(fields + ['product_id']),
-                    ','.join(values + [p[0]])), (r[0],))
+                    ','.join(values + [str(p[0])]), r[0]))
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
the SQL query to clone the product packaging lines from the template to the variants has a bad syntax. Of course if you don't have such packaging you won't see the issue. This patch fixes the syntax error.

cc @Benniphx