### PR TITLE
[FIX] don't overwrite expenses' names & dates

### DIFF
--- a/addons/hr_expense/migrations/9.0.2.0/post-migration.py
+++ b/addons/hr_expense/migrations/9.0.2.0/post-migration.py
@@ -29,8 +29,6 @@ def hr_expense(env):
             journal_id = ot.journal_id,
             employee_id = ot.employee_id,
             state = ot.state,
-            name = ot.name,
-            date = ot.date,
             account_move_id = ot.account_move_id,
             payment_mode = 'own_account'
         FROM %(old_table)s ot

--- a/addons/hr_expense/migrations/9.0.2.0/pre-migration.py
+++ b/addons/hr_expense/migrations/9.0.2.0/pre-migration.py
@@ -18,6 +18,7 @@ field_renames = [
      'can_be_expensed'),
     ('hr.expense', 'hr_expense', 'note', 'description'),
     ('hr.expense.line', 'hr_expense_line', 'unit_quantity', 'quantity'),
+    ('hr.expense.line', 'hr_expense_line', 'date_value', 'date'),
 ]
 
 table_renames = [


### PR DESCRIPTION
I think we shouldn't touch existing data in expense lines. The name often contains valuable information about what the employee did, and v8's `value_date` is what's presented as the line's date, so we should keep this too imho.