### PR TITLE
[11.0][FIX] website: Move social media data

### DIFF
--- a/addons/website/migrations/11.0.1.0/pre-migration.py
+++ b/addons/website/migrations/11.0.1.0/pre-migration.py
@@ -1,0 +1,20 @@
+# Copyright 2018 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+COLUMN_RENAMES = {
+    'website': [
+        ('social_twitter', None),
+        ('social_facebook', None),
+        ('social_github', None),
+        ('social_linkedin', None),
+        ('social_youtube', None),
+        ('social_googleplus', None),
+    ],
+}
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_columns(env.cr, COLUMN_RENAMES)


### PR DESCRIPTION
On v10, we had these social media links in website:

https://github.com/odoo/odoo/blob/258eaa7a3ce7c25e93f1b9940351335bfcda2aeb/addons/website/models/website.py#L170-L176

But on v11, they are non-stored, related fields to company:

https://github.com/odoo/odoo/blob/cac91731221b5ac122ad745ac408b406d335e5c7/addons/website/models/website.py#L55-L60

So we need to move the information from website to company.

@Tecnativa