### PR TITLE
rename_xmlids now takes a list

### DIFF
--- a/addons/l10n_fr/migrations/11.0.2.0/pre-migration.py
+++ b/addons/l10n_fr/migrations/11.0.2.0/pre-migration.py
@@ -8,8 +8,8 @@ def migrate_l10n_fr_siret_field(env):
     """If l10n_fr_siret is installed in version 10.0, we must rename xmlid"""
     if openupgrade.is_module_installed(env.cr, 'l10n_fr_siret'):
         openupgrade.rename_xmlids(
-            env.cr, ('l10n_fr_siret.field_res_partner_siret',
-                     'l10n_fr.field_res_partner_siret'))
+            env.cr, [('l10n_fr_siret.field_res_partner_siret',
+                     'l10n_fr.field_res_partner_siret')])
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

l10n_fr migration is broken  because the openupgrade.rename_xmlids method was previously accepting a single tuple while now it requires a list of tuples.

Current behavior before PR:

breaks when running l10n_fr migration

Desired behavior after PR is merged:

it works



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
