### PR TITLE
[11.0][FIX] portal_sale migration

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -47,6 +47,7 @@ merged_modules = {
     # Odoo
     'account_tax_cash_basis': 'account',
     'portal_gamification': 'gamification',
+    'portal_sale': 'sale',
     'portal_stock': 'portal',
     'procurement': 'stock',
     'project_issue': 'project',


### PR DESCRIPTION
In https://github.com/OCA/OpenUpgrade/pull/1401 was done the migration scripts, but it was not merged in apriori file.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr