### PR TITLE
[FIX] purchase_requisition post-migration create product only if necessry & fix bug categ_id required

### DIFF
--- a/addons/purchase_requisition/migrations/10.0.0.1/post-migration.py
+++ b/addons/purchase_requisition/migrations/10.0.0.1/post-migration.py
@@ -8,16 +8,24 @@ from openupgradelib import openupgrade
 
 def fill_product(env):
     """Fill with an pre-created product as it's required."""
-    product = env['product.product'].create({
-        'active': False,
-        'name': 'OU purchase requisition line wildcard',
-    })
-    openupgrade.logged_query(
-        env.cr, """
-        UPDATE purchase_requisition_line
-        SET product_id = %s
-        WHERE product_id IS NULL;""", (product.id, ),
-    )
+    if env['purchase.requisition.line'].search_count(
+            [('product_id', '=', False)]) > 0:
+        categ_id = env["product.template"]._get_default_category_id()
+        if not categ_id:
+            categ_id = env["product.category"].search(
+                [], limit=1, order='id asc').id
+        product = env['product.product'].create({
+            'active': False,
+            'categ_id': categ_id,  # categ_id is required
+            'company_id': False,  # tacke into account multi-company context
+            'name': 'OU purchase requisition line wildcard',
+        })
+        openupgrade.logged_query(
+            env.cr, """
+            UPDATE purchase_requisition_line
+            SET product_id = %s
+            WHERE product_id IS NULL;""", (product.id, ),
+        )
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
product creation fails because categ_id is required. 
update is only for 
Current behavior before PR:
we create a new product even update is not applicable (no purchase_requisition_line with product_id IS NULL)
Desired behavior after PR is merged:
Create product only if there is some purchase_requisition_line with product_id IS NUL.
Fix bug categ_id required for product creation.

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
