### PR TITLE
[11.0][IMP] sale_stock: broader use of queries

### DIFF
--- a/addons/sale_stock/migrations/11.0.1.0/pre-migration.py
+++ b/addons/sale_stock/migrations/11.0.1.0/pre-migration.py
@@ -18,9 +18,10 @@ def update_procurement_field_from_sale(env):
     openupgrade.logged_query(
         env.cr, """
         UPDATE procurement_group pg
-        SET sale_id = so.id
-        FROM sale_order so
-        WHERE so.procurement_group_id = pg.id""",
+        SET sale_id = sol.order_id
+        FROM stock_move sm
+        INNER JOIN sale_order_line sol ON sm.sale_line_id = sol.id
+        WHERE sm.group_id = pg.id""",
     )
 
 
@@ -59,8 +60,8 @@ def update_stock_move_field_from_procurement_order(env):
     )
 
 
-@openupgrade.migrate()
+@openupgrade.migrate(use_env=True)
 def migrate(env, version):
+    update_stock_move_field_from_procurement_order(env)
     update_procurement_field_from_sale(env)
     update_picking_sale_related(env)
-    update_stock_move_field_from_procurement_order(env)


### PR DESCRIPTION
The queries should be compatible with the maximum possible of modules.

It happens that the query in `update_procurement_field_from_sale` method is not compatible with the `sale_procurement_group_by_line` module.

With the `sale_procurement_group_by_line` module installed, the query
```python
        UPDATE procurement_group pg
        SET sale_id = so.id
        FROM sale_order so
        WHERE so.procurement_group_id = pg.id
```
is partial. It would also need the following query
```python
        UPDATE procurement_group pg
        SET sale_id = so.id
        FROM sale_order_line sol
        WHERE sol.procurement_group_id = pg.id
```

To avoid to add more specific queries, I improved the problematic one with one that is full compatible with both people who have installed and not installed the `sale_procurement_group_by_line` module. This compatible one is
```python
        UPDATE procurement_group AS pg
        SET sale_id = sol.order_id
        FROM procurement_order AS po
        INNER JOIN sale_order_line AS sol ON sol.id = po.sale_line_id
        WHERE po.group_id = pg.id AND po.sale_line_id IS NOT NULL
```
But then, by just doing the trick to change the order of the methods, executing the `update_stock_move_field_from_procurement_order` method first, that is 
```python
         UPDATE stock_move sm
         SET sale_line_id = po.sale_line_id
         FROM procurement_order po
         WHERE sm.procurement_id = po.id AND po.sale_line_id IS NOT NULL
```
you can make use of the obtained `sm.sale_line_id` and thus you finally have the following query that is less longer
```python
        SET sale_id = sol.order_id
        FROM stock_move sm
        INNER JOIN sale_order_line sol ON sm.sale_line_id = sol.id
        WHERE sm.group_id = pg.id
```
--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr