### PR TITLE
9.0 imp account migration by sql

### DIFF
--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -384,7 +384,6 @@ def fast_create(env, settings):
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
-
     # 9.0 introduces a constraint enforcing this
     cr.execute(
         "update account_account set reconcile=True "


### PR DESCRIPTION
* add a new function fast_create, to create and populate a new field, by SQL.

* fast create of ``account_invoice_tax.currency_id``, ``account_bank_statement.difference``, ``account_invoice.amount_total_signed``

* fast create of ``account_invoice.amount_total_company_signed``, ``account_invoice.amount_untaxed_signed`` if there are not invoices with currency different from that of company.


**Current behavior before PR:**
migration of account is slow

**Desired behavior after PR is merged:**
make the migration faster

note : the function fast_create could be integrated in openupgradelib.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
