### PR TITLE
[10.0][ADD] OCA implementation of hr_timesheet_invoice

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -31,6 +31,8 @@ renamed_modules = {
     # OCA/stock-logistics-workflow:
     'product_customer_code_picking':
         'product_supplierinfo_for_customer_picking',
+    # OCA/account-analytic:
+    'hr_timesheet_invoice': 'account_invoice_analytic_line',
 }
 
 merged_modules = [


### PR DESCRIPTION
this is currently more RFC than a serious PR: In v8, hr_timesheet_invoice was deprecated, and I created a [functional equivalent](https://github.com/OCA/account-analytic/pull/213) for v10 (let's not discuss if I'm better off with the standard sale order way, I'm not).

Given there won't be a version 9 of this (at least from my side), this is the only place I can put this in order to work, but conceptually it seems wrong to me because the module was dropped already in 9. Any opinion on this?