### PR TITLE
[12.0][FIX] openupgrade_records: add description to models

### DIFF
--- a/odoo/addons/openupgrade_records/models/analysis_wizard.py
+++ b/odoo/addons/openupgrade_records/models/analysis_wizard.py
@@ -13,6 +13,7 @@ from odoo.addons.openupgrade_records.lib import compare
 class AnalysisWizard(models.TransientModel):
     _name = 'openupgrade.analysis.wizard'
     _description = 'OpenUpgrade Analysis Wizard'
+
     server_config = fields.Many2one(
         'openupgrade.comparison.config',
         'Configuration', required=True)

--- a/odoo/addons/openupgrade_records/models/comparison_config.py
+++ b/odoo/addons/openupgrade_records/models/comparison_config.py
@@ -12,8 +12,10 @@ from odoo.exceptions import UserError
 from odoo.tools.translate import _
 
 
-class openupgrade_comparison_config(models.Model):
+class OpenupgradeComparisonConfig(models.Model):
     _name = 'openupgrade.comparison.config'
+    _description = 'OpenUpgrade Comparison Configuration'
+
     name = fields.Char()
     server = fields.Char(required=True)
     port = fields.Integer(required=True, default=8069)

--- a/odoo/addons/openupgrade_records/models/generate_records_wizard.py
+++ b/odoo/addons/openupgrade_records/models/generate_records_wizard.py
@@ -13,6 +13,7 @@ class GenerateWizard(models.TransientModel):
     _name = 'openupgrade.generate.records.wizard'
     _description = 'OpenUpgrade Generate Records Wizard'
     _rec_name = 'state'
+
     state = fields.Selection(
         [('init', 'init'), ('ready', 'ready')], default='init')
 

--- a/odoo/addons/openupgrade_records/models/install_all_wizard.py
+++ b/odoo/addons/openupgrade_records/models/install_all_wizard.py
@@ -11,6 +11,7 @@ from odoo.addons.openupgrade_records.blacklist import BLACKLIST_MODULES
 class InstallAll(models.TransientModel):
     _name = 'openupgrade.install.all.wizard'
     _description = 'OpenUpgrade Install All Wizard'
+
     state = fields.Selection(
         [('init', 'init'), ('ready', 'ready')],
         readonly=True, default='init')

--- a/odoo/addons/openupgrade_records/models/openupgrade_record.py
+++ b/odoo/addons/openupgrade_records/models/openupgrade_record.py
@@ -8,6 +8,8 @@ from odoo import api, fields, models
 
 class Attribute(models.Model):
     _name = 'openupgrade.attribute'
+    _description = 'OpenUpgrade Attribute'
+
     name = fields.Char(readonly=True)
     value = fields.Char(readonly=True)
     record_id = fields.Many2one(
@@ -17,6 +19,8 @@ class Attribute(models.Model):
 
 class Record(models.Model):
     _name = 'openupgrade.record'
+    _description = 'OpenUpgrade Record'
+
     name = fields.Char(readonly=True)
     module = fields.Char(readonly=True)
     model = fields.Char(readonly=True)


### PR DESCRIPTION
In v12 all models shall have a description. If a model doesn't have a description, a bothering warning is shown.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr