### PR TITLE
[FIX] column "picking_type_id" of  "mrp_production" already exists

### DIFF
--- a/addons/mrp/migrations/10.0.2.0/pre-migration.py
+++ b/addons/mrp/migrations/10.0.2.0/pre-migration.py
@@ -148,6 +148,8 @@ def rename_mrp_workorder(cr):
 
 
 def prepopulate_fields(cr):
+    if openupgrade.column_exists(cr, 'mrp_production', 'picking_type_id'):
+        return False
     cr.execute(
         """
         ALTER TABLE mrp_production


### PR DESCRIPTION

    2018-12-17 11:45:13,201 107 DEBUG dix OpenUpgrade: 793065 rows affected
2018-12-17 11:45:13,201 107 INFO dix OpenUpgrade: table mrp_workorder, column sequence: renaming to openupgrade_legacy_10_0_sequence
2018-12-17 11:45:13,202 107 INFO dix OpenUpgrade: table mrp_workorder, column cycle: renaming to openupgrade_legacy_10_0_cycle
2018-12-17 11:45:13,202 107 INFO dix OpenUpgrade: table mrp_workorder, column hour: renaming to openupgrade_legacy_10_0_hour
2018-12-17 11:45:13,203 107 INFO dix OpenUpgrade: table mrp_bom, column date_stop: renaming to openupgrade_legacy_10_0_date_stop
2018-12-17 11:45:13,203 107 INFO dix OpenUpgrade: table stock_move, column consumed_for: renaming to openupgrade_legacy_10_0_consumed_for
2018-12-17 11:45:14,205 107 INFO dix OpenUpgrade: table mrp_routing_workcenter, column hour_nbr: renaming to openupgrade_legacy_10_0_hour_nbr
2018-12-17 11:45:14,207 107 INFO dix OpenUpgrade: table mrp_routing_workcenter, column cycle_nbr: renaming to openupgrade_legacy_10_0_cycle_nbr
2018-12-17 11:45:14,210 107 INFO dix OpenUpgrade: table mrp_bom, column product_uom: renaming to product_uom_id
2018-12-17 11:45:14,237 107 INFO dix OpenUpgrade: table mrp_bom_line, column product_uom: renaming to product_uom_id
2018-12-17 11:45:14,253 107 INFO dix OpenUpgrade: table mrp_production, column date_planned: renaming to date_planned_start
2018-12-17 11:45:14,288 107 INFO dix OpenUpgrade: table mrp_production, column product_uom: renaming to product_uom_id
2018-12-17 11:45:14,310 107 INFO dix OpenUpgrade: table mrp_workcenter, column capacity_per_cycle: renaming to capacity
2018-12-17 11:45:14,317 107 INFO dix odoo.sql_db: bad query: 
        ALTER TABLE mrp_production
        ADD COLUMN picking_type_id INTEGER
        
2018-12-17 11:45:14,317 107 ERROR dix OpenUpgrade: mrp: error in migration script mrp/migrations/10.0.2.0/pre-migration.py: ProgrammingError('column "picking_type_id" of relation "mrp_production" already 
exists\n',)
2018-12-17 11:45:14,317 107 ERROR dix OpenUpgrade: column "picking_type_id" of relation "mrp_production" already exists
Traceback (most recent call last):
  File "/src/openupgradelib/openupgradelib/openupgrade.py", line 1445, in wrapped_function
    if use_env2 else cr, version)
  File "/odoo/src/addons/mrp/migrations/10.0.2.0/pre-migration.py", line 171, in migrate
    prepopulate_fields(cr)
  File "/odoo/src/addons/mrp/migrations/10.0.2.0/pre-migration.py", line 155, in prepopulate_fields
    """
  File "/odoo/src/odoo/sql_db.py", line 154, in wrapper
    return f(self, *args, **kwargs)
  File "/odoo/src/odoo/sql_db.py", line 231, in execute
    res = self._obj.execute(query, params)
ProgrammingError: column "picking_type_id" of relation "mrp_production" already exists

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
