### PR TITLE
[IMP] base: Remove error about removing constraint

### DIFF
--- a/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
@@ -43,6 +43,17 @@ def eliminate_duplicate_translations(cr):
             AND it1.id < it2.id); """)
 
 
+def fix_lang_constraints(env):
+    """Avoid error on normal update process due to the removal + re-addition of
+    constraints.
+    """
+    openupgrade.logged_query(
+        env.cr, """ALTER TABLE ir_translation
+        DROP CONSTRAINT ir_translation_lang_fkey_res_lang
+        """,
+    )
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     openupgrade.update_module_names(
@@ -65,7 +76,7 @@ def migrate(env, version):
         (SELECT module, 'partner_admin', model, res_id, noupdate
          FROM ir_model_data WHERE module = 'base' AND name = 'partner_root')
         """)
-
+    fix_lang_constraints(env)
     # for migration of web module
     openupgrade.rename_columns(
         env.cr, {'res_company': [('external_report_layout', None)]})


### PR DESCRIPTION
Avoids error:
```
ERROR openupgrade odoo.sql_db: bad query: b'ALTER TABLE "res_lang" DROP CONSTRAINT "res_lang_code_uniq"'
ERROR: cannot drop constraint res_lang_code_uniq on table res_lang because other objects depend on it
DETAIL:  constraint ir_translation_lang_fkey_res_lang on table ir_translation depends on index res_lang_code_uniq
HINT:  Use DROP ... CASCADE to drop the dependent objects too.
```

@Tecnativa