### PR TITLE
[11.0][MIG] product_uom

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -21,6 +21,8 @@ renamed_modules = {
     'account_due_list_aging_comments': 'account_due_list_aging_comment',
     # OCA/partner-contact
     'partner_sector': 'partner_industry_secondary',
+    # OCA/product-attribute
+    'product_uom': 'product_uom_extra_data',  # -> OCA/community-data-files
     # OCA/purchase-workflow
     'purchase_request_to_rfq_order_approved': (
         'purchase_request_order_approved'


### PR DESCRIPTION
Renamed module `product_uom` in `OCA/product-attribute` to `product_uom_extra_data` in `OCA/community-data-files` as said in https://github.com/OCA/community-data-files/pull/54#discussion_r246338248.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr