### PR TITLE
unnecessary website_form_metadata

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -19,6 +19,7 @@ merged_modules = {
     'sale_payment': 'sale',
     'sale_service_rating': 'sale_timesheet',
     'web_planner': 'web',
+    'website_form_metadata': 'website_form',
     'website_quote': 'sale_quotation_builder',
     'website_rating_project': 'project',
     'website_sale_options': 'website_sale',


### PR DESCRIPTION
website_form_metadata is not needed for Odoo 12 since the functionalities that this module adds are included in the module website_form

Cc @Tecnativa