### PR TITLE
[12.0][FIX] openpgrade_records: be able to do analysis from v11

### DIFF
--- a/odoo/addons/openupgrade_records/__manifest__.py
+++ b/odoo/addons/openupgrade_records/__manifest__.py
@@ -16,6 +16,7 @@
         'views/install_all_wizard.xml',
         'security/ir.model.access.csv',
     ],
+    'depends': ['base', 'web'],  # web is need for adapt_to_v11.py
     'installable': True,
     'external_dependencies': {
         'python': ['odoorpc', 'openupgradelib'],

--- a/odoo/addons/openupgrade_records/models/__init__.py
+++ b/odoo/addons/openupgrade_records/models/__init__.py
@@ -3,3 +3,4 @@ from . import comparison_config
 from . import analysis_wizard
 from . import generate_records_wizard
 from . import install_all_wizard
+from . import adapt_to_v11

--- a/odoo/addons/openupgrade_records/models/adapt_to_v11.py
+++ b/odoo/addons/openupgrade_records/models/adapt_to_v11.py
@@ -1,0 +1,81 @@
+# coding: utf-8
+# Copyright 2019 Eficent <http://www.eficent.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import math
+from odoo import models
+from odoo.exceptions import AccessDenied
+from odoo.http import request
+
+
+class Users(models.Model):
+    _inherit = "res.users"
+
+    def _check_credentials(self, password):
+        cr = self.env.cr
+        cr.execute(
+            "SELECT latest_version FROM ir_module_module WHERE name=%s",
+            ('base', )
+        )
+        base_version = cr.fetchone()
+        if base_version:
+            local_version = '.'.join(base_version[0].split('.')[:2])
+            cr.execute(
+                "SELECT id FROM ir_module_module WHERE name=%s "
+                "AND state = 'installed'",
+                ('auth_crypt',)
+            )
+            auth_crypt = cr.fetchone()
+            if local_version == '11.0' and auth_crypt:
+                assert password
+                self.env.cr.execute(
+                    "SELECT password_crypt FROM res_users WHERE id=%s",
+                    [self.env.user.id]
+                )
+                [hashed] = self.env.cr.fetchone()
+                valid, replacement = self._crypt_context() \
+                    .verify_and_update(password, hashed)
+                if replacement is not None:
+                    self._set_encrypted_password(self.env.user.id, replacement)
+                if not valid:
+                    raise AccessDenied()
+                return
+        return super(Users, self)._check_credentials(password)
+
+
+class Http(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    def get_currencies(self):
+        cr = self.env.cr
+        cr.execute(
+            "SELECT latest_version FROM ir_module_module WHERE name=%s",
+            ('base', )
+        )
+        base_version = cr.fetchone()
+        if base_version:
+            local_version = '.'.join(base_version[0].split('.')[:2])
+            cr.execute(
+                "SELECT id FROM ir_module_module WHERE name=%s "
+                "AND state = 'installed'",
+                ('web',)
+            )
+            web = cr.fetchone()
+            if local_version == '11.0' and web:
+                currency_model = request.env['res.currency']
+                currencies = currency_model.with_context(
+                    prefetch_fields=False).search([]).read(
+                    ['symbol', 'position', 'rounding'])
+                for c in currencies:
+                    if 0 < c['rounding'] < 1:
+                        c['decimal_places'] = int(
+                            math.ceil(math.log10(1 / c['rounding'])))
+                    else:
+                        c['decimal_places'] = 0
+                return {
+                    c['id']: {
+                        'symbol': c['symbol'],
+                        'position': c['position'],
+                        'digits': [69, c['decimal_places']]
+                    } for c in currencies}
+        return super(Http, self).get_currencies()

--- a/odoo/addons/openupgrade_records/models/analysis_wizard.py
+++ b/odoo/addons/openupgrade_records/models/analysis_wizard.py
@@ -131,6 +131,8 @@ class AnalysisWizard(models.TransientModel):
         self.server_config.write({'last_log': general})
         self.write({'state': 'ready', 'log': general})
 
+        connection.logout()
+
         return {
             'name': self._description,
             'view_type': 'form',

--- a/odoo/addons/openupgrade_records/models/comparison_config.py
+++ b/odoo/addons/openupgrade_records/models/comparison_config.py
@@ -44,6 +44,7 @@ class OpenupgradeComparisonConfig(models.Model):
             user_model = connection.env["res.users"]
             ids = user_model.search([("login", "=", "admin")])
             user_info = user_model.read([ids[0]], ["name"])[0]
+            connection.logout()
         except Exception as e:
             raise UserError(_("Connection failed.\n\nDETAIL: %s") % e)
         raise UserError(
@@ -90,4 +91,5 @@ class OpenupgradeComparisonConfig(models.Model):
                       ','.join(local_modules.mapped('name')))
         if local_modules:
             local_modules.write({'state': 'to install'})
+        connection.logout()
         return {}


### PR DESCRIPTION
Trying to perform an analysis of records, I have issues:

1) was blocked by the `_check_credentials` method of res.users. In v11 you have `password` and `password_crypt` fields in res.users, but in v12 this two fields got merged into one (`password`). So, when accessing to the v11 database, the problem raised.

2) in ir_http in web, it's called get_currencies method and breaks. Happens that in v11, `decimal_places` field of res.currency was `store=False`, and in v12 this field is `store=True`.

For the second commit, absolutely secondary, is for when openupgrade open v11 connections. It surprised me that after using this connections, they never get closed. So I thought to add this secondary fix to close them. I am not sure if it's necessary but here it is. I can take it out.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr