### PR TITLE
[FIX] renamed project_task_materials

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -23,6 +23,8 @@ renamed_modules = {
     'report_mrp_bom_matrix': 'mrp_bom_matrix_report',
     # OCA/partner-contact:
     'res_partner_affiliate': 'partner_affiliate',
+    # OCA/project
+    'project_task_materials': 'project_task_material',
     # OCA/sale-workflow:
     'sale_delivery_block': 'sale_stock_picking_blocking',
     'sale_delivery_block_proc_group_by_line':


### PR DESCRIPTION
Description of the issue/feature this PR addresses: the module project_task_materials was renamed in project_task_material so is not correctly installed

Current behavior before PR: the module project_task_material in not correctly installed

Desired behavior after PR is merged: the module project_task_material is installed




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
