### PR TITLE
[FIX] UOM categories are called product.uom.categ in v11

### DIFF
--- a/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
@@ -8,7 +8,7 @@ from openupgradelib import openupgrade
 
 model_renames = [
     ('product.uom', 'uom.uom'),
-    ('product.uom.category', 'uom.category'),
+    ('product.uom.categ', 'uom.category'),
 ]
 
 table_renames = [


### PR DESCRIPTION
cf https://github.com/OCA/OCB/blob/11.0/addons/product/models/product_uom.py#L8