### PR TITLE
[ADD] migrate expense's attachments and messages

### DIFF
--- a/addons/hr_expense/migrations/9.0.2.0/post-migration.py
+++ b/addons/hr_expense/migrations/9.0.2.0/post-migration.py
@@ -41,6 +41,22 @@ def hr_expense(env):
             )
         },
     )
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE ir_attachment
+        SET res_model='hr.expense', res_id=hr_expense.id
+        FROM hr_expense
+        WHERE res_model='hr.expense.expense' AND hr_expense.expense_id=res_id
+        """
+    )
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE mail_message
+        SET model='hr.expense', res_id=hr_expense.id
+        FROM hr_expense
+        WHERE model='hr.expense.expense' AND hr_expense.expense_id=res_id
+        """
+    )
     Expense = env['hr.expense']
     expenses = Expense.search([])
     env.add_todo(Expense._fields['total_amount'], expenses)


### PR DESCRIPTION
this is not perfect because we can't know for which expense line an attachment/message is meant. We might duplicate all of them, but that doesn't seem worth bothering to me.
They will end up on whichever line will be the last in the join.