### PR TITLE
[12.0][IMP] openupgrade_records: handle moved/renamed xmlids

### DIFF
--- a/addons/account/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/account/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -1,14 +1,14 @@
 ---Fields in module 'account'---
 account      / account.account          / internal_group (selection)    : NEW selection_keys: function
 account      / account.account.type     / internal_group (selection)    : NEW selection_keys: ['asset', 'equity', 'expense', 'income', 'liability']
-account      / account.analytic.line    / amount_currency (float)       : DEL 
+account      / account.analytic.line    / amount_currency (float)       : DEL
 account      / account.analytic.line    / currency_id (False)           : DEL mode: modify
 account      / account.analytic.line    / product_uom_id (many2one)     : module is now 'analytic' ('account')
 account      / account.analytic.line    / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
-account      / account.bank.statement   / accounting_date (date)        : NEW 
-account      / account.bank.statement   / message_last_post (datetime)  : DEL 
+account      / account.bank.statement   / accounting_date (date)        : NEW
+account      / account.bank.statement   / message_last_post (datetime)  : DEL
 account      / account.bank.statement   / message_main_attachment_id (many2one): NEW relation: ir.attachment
-account      / account.bank.statement.line / account_number (char)         : NEW 
+account      / account.bank.statement.line / account_number (char)         : NEW
 account      / account.chart.template   / bank_account_code_prefix (char): now required
 account      / account.chart.template   / cash_account_code_prefix (char): now required
 account      / account.chart.template   / company_id (many2one)         : DEL relation: res.company
@@ -18,86 +18,86 @@ account      / account.fiscal.year      / company_id (many2one)         : NEW re
 account      / account.fiscal.year      / date_from (date)              : NEW required: required
 account      / account.fiscal.year      / date_to (date)                : NEW required: required
 account      / account.fiscal.year      / name (char)                   : NEW required: required
-account      / account.group            / parent_left (integer)         : DEL 
-account      / account.group            / parent_path (char)            : NEW 
-account      / account.group            / parent_right (integer)        : DEL 
+account      / account.group            / parent_left (integer)         : DEL
+account      / account.group            / parent_path (char)            : NEW
+account      / account.group            / parent_right (integer)        : DEL
 account      / account.invoice          / activity_date_deadline (date) : not related anymore
 account      / account.invoice          / activity_date_deadline (date) : not stored anymore
 account      / account.invoice          / activity_date_deadline (date) : now a function
 account      / account.invoice          / incoterm_id (many2one)        : previously in module l10n_be_intrastat
-account      / account.invoice          / message_last_post (datetime)  : DEL 
+account      / account.invoice          / message_last_post (datetime)  : DEL
 account      / account.invoice          / message_main_attachment_id (many2one): NEW relation: ir.attachment
 account      / account.invoice          / reference_type (selection)    : DEL required: required, selection_keys: function, req_default: function
-account      / account.invoice          / source_email (char)           : NEW 
+account      / account.invoice          / source_email (char)           : NEW
 account      / account.invoice          / state (selection)             : selection_keys is now '['cancel', 'draft', 'in_payment', 'open', 'paid']' ('['cancel', 'draft', 'open', 'paid']')
 account      / account.invoice          / vendor_bill_id (many2one)     : NEW relation: account.invoice
-account      / account.invoice          / vendor_display_name (char)    : NEW 
+account      / account.invoice          / vendor_display_name (char)    : NEW
 account      / account.invoice.line     / display_type (selection)      : NEW selection_keys: ['line_note', 'line_section']
 account      / account.invoice.line     / uom_id (many2one)             : relation is now 'uom.uom' ('product.uom')
 account      / account.invoice.tax      / analytic_tag_ids (many2many)  : NEW relation: account.analytic.tag
 account      / account.journal          / alias_id (many2one)           : NEW relation: mail.alias
 account      / account.journal          / bank_statements_source (selection): selection_keys is now 'function' ('['manual', 'undefined']')
-account      / account.journal          / post_at_bank_rec (boolean)    : NEW 
-account      / account.move             / auto_reverse (boolean)        : NEW 
-account      / account.move             / reverse_date (date)           : NEW 
+account      / account.journal          / post_at_bank_rec (boolean)    : NEW
+account      / account.move             / auto_reverse (boolean)        : NEW
+account      / account.move             / reverse_date (date)           : NEW
 account      / account.move             / reverse_entry_id (many2one)   : NEW relation: account.move
-account      / account.move             / tax_type_domain (char)        : NEW 
+account      / account.move             / tax_type_domain (char)        : NEW
 account      / account.move.line        / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
-account      / account.move.line        / recompute_tax_line (boolean)  : NEW 
-account      / account.move.line        / tax_line_grouping_key (char)  : NEW 
+account      / account.move.line        / recompute_tax_line (boolean)  : NEW
+account      / account.move.line        / tax_line_grouping_key (char)  : NEW
 account      / account.payment          / company_id (many2one)         : not stored anymore
-account      / account.payment          / message_last_post (datetime)  : DEL 
+account      / account.payment          / message_last_post (datetime)  : DEL
 account      / account.payment          / message_main_attachment_id (many2one): NEW relation: ir.attachment
-account      / account.payment          / multi (boolean)               : NEW 
+account      / account.payment          / multi (boolean)               : NEW
 account      / account.payment          / partner_bank_account_id (many2one): NEW relation: res.partner.bank
-account      / account.payment.term.line / day_of_the_month (integer)    : NEW 
+account      / account.payment.term.line / day_of_the_month (integer)    : NEW
 account      / account.payment.term.line / option (selection)            : selection_keys is now '['after_invoice_month', 'day_after_invoice_date', 'day_current_month', 'day_following_month']' ('['day_after_invoice_date', 'fix_day_following_month', 'last_day_current_month', 'last_day_following_month']')
 account      / account.reconcile.model  / analytic_tag_ids (many2many)  : NEW relation: account.analytic.tag
-account      / account.reconcile.model  / auto_reconcile (boolean)      : NEW 
-account      / account.reconcile.model  / force_second_tax_included (boolean): NEW 
-account      / account.reconcile.model  / force_tax_included (boolean)  : NEW 
+account      / account.reconcile.model  / auto_reconcile (boolean)      : NEW
+account      / account.reconcile.model  / force_second_tax_included (boolean): NEW
+account      / account.reconcile.model  / force_tax_included (boolean)  : NEW
 account      / account.reconcile.model  / match_amount (selection)      : NEW selection_keys: ['between', 'greater', 'lower']
-account      / account.reconcile.model  / match_amount_max (float)      : NEW 
-account      / account.reconcile.model  / match_amount_min (float)      : NEW 
+account      / account.reconcile.model  / match_amount_max (float)      : NEW
+account      / account.reconcile.model  / match_amount_min (float)      : NEW
 account      / account.reconcile.model  / match_journal_ids (many2many) : NEW relation: account.journal
 account      / account.reconcile.model  / match_label (selection)       : NEW selection_keys: ['contains', 'match_regex', 'not_contains']
-account      / account.reconcile.model  / match_label_param (char)      : NEW 
+account      / account.reconcile.model  / match_label_param (char)      : NEW
 account      / account.reconcile.model  / match_nature (selection)      : NEW required: required, selection_keys: ['amount_paid', 'amount_received', 'both'], req_default: function
-account      / account.reconcile.model  / match_partner (boolean)       : NEW 
+account      / account.reconcile.model  / match_partner (boolean)       : NEW
 account      / account.reconcile.model  / match_partner_category_ids (many2many): NEW relation: res.partner.category
 account      / account.reconcile.model  / match_partner_ids (many2many) : NEW relation: res.partner
-account      / account.reconcile.model  / match_same_currency (boolean) : NEW 
-account      / account.reconcile.model  / match_total_amount (boolean)  : NEW 
-account      / account.reconcile.model  / match_total_amount_param (float): NEW 
+account      / account.reconcile.model  / match_same_currency (boolean) : NEW
+account      / account.reconcile.model  / match_total_amount (boolean)  : NEW
+account      / account.reconcile.model  / match_total_amount_param (float): NEW
 account      / account.reconcile.model  / rule_type (selection)         : NEW required: required, selection_keys: ['invoice_matching', 'writeoff_button', 'writeoff_suggestion'], req_default: function
 account      / account.reconcile.model  / second_analytic_tag_ids (many2many): NEW relation: account.analytic.tag
-account      / account.reconcile.model.template / auto_reconcile (boolean)      : NEW 
-account      / account.reconcile.model.template / force_second_tax_included (boolean): NEW 
-account      / account.reconcile.model.template / force_tax_included (boolean)  : NEW 
+account      / account.reconcile.model.template / auto_reconcile (boolean)      : NEW
+account      / account.reconcile.model.template / force_second_tax_included (boolean): NEW
+account      / account.reconcile.model.template / force_tax_included (boolean)  : NEW
 account      / account.reconcile.model.template / match_amount (selection)      : NEW selection_keys: ['between', 'greater', 'lower']
-account      / account.reconcile.model.template / match_amount_max (float)      : NEW 
-account      / account.reconcile.model.template / match_amount_min (float)      : NEW 
+account      / account.reconcile.model.template / match_amount_max (float)      : NEW
+account      / account.reconcile.model.template / match_amount_min (float)      : NEW
 account      / account.reconcile.model.template / match_journal_ids (many2many) : NEW relation: account.journal
 account      / account.reconcile.model.template / match_label (selection)       : NEW selection_keys: ['contains', 'match_regex', 'not_contains']
-account      / account.reconcile.model.template / match_label_param (char)      : NEW 
+account      / account.reconcile.model.template / match_label_param (char)      : NEW
 account      / account.reconcile.model.template / match_nature (selection)      : NEW required: required, selection_keys: ['amount_paid', 'amount_received', 'both'], req_default: function
-account      / account.reconcile.model.template / match_partner (boolean)       : NEW 
+account      / account.reconcile.model.template / match_partner (boolean)       : NEW
 account      / account.reconcile.model.template / match_partner_category_ids (many2many): NEW relation: res.partner.category
 account      / account.reconcile.model.template / match_partner_ids (many2many) : NEW relation: res.partner
-account      / account.reconcile.model.template / match_same_currency (boolean) : NEW 
-account      / account.reconcile.model.template / match_total_amount (boolean)  : NEW 
-account      / account.reconcile.model.template / match_total_amount_param (float): NEW 
+account      / account.reconcile.model.template / match_same_currency (boolean) : NEW
+account      / account.reconcile.model.template / match_total_amount (boolean)  : NEW
+account      / account.reconcile.model.template / match_total_amount_param (float): NEW
 account      / account.reconcile.model.template / rule_type (selection)         : NEW required: required, selection_keys: ['invoice_matching', 'writeoff_button', 'writeoff_suggestion'], req_default: function
 account      / account.tax              / cash_basis_account (many2one) : was renamed to cash_basis_account_id [nothing to do]
-account      / account.tax              / tax_adjustment (boolean)      : DEL 
+account      / account.tax              / tax_adjustment (boolean)      : DEL
 account      / account.tax              / type_tax_use (selection)      : selection_keys is now '['adjustment', 'none', 'purchase', 'sale']' ('['none', 'purchase', 'sale']')
 account      / account.tax.template     / cash_basis_account (many2one) : was renamed to cash_basis_account_id [nothing to do]
 account      / account.tax.template     / cash_basis_base_account_id (many2one): NEW relation: account.account.template
 account      / account.tax.template     / company_id (many2one)         : DEL relation: res.company
-account      / account.tax.template     / tax_adjustment (boolean)      : DEL 
+account      / account.tax.template     / tax_adjustment (boolean)      : DEL
 account      / account.tax.template     / type_tax_use (selection)      : selection_keys is now '['adjustment', 'none', 'purchase', 'sale']' ('['none', 'purchase', 'sale']')
-account      / digest.digest            / kpi_account_total_revenue (boolean): NEW 
-account      / res.company              / account_bank_reconciliation_start (date): NEW 
+account      / digest.digest            / kpi_account_total_revenue (boolean): NEW
+account      / res.company              / account_bank_reconciliation_start (date): NEW
 account      / res.company              / account_dashboard_onboarding_state (selection): NEW selection_keys: ['closed', 'done', 'just_done', 'not_done']
 account      / res.company              / account_invoice_onboarding_state (selection): NEW selection_keys: ['closed', 'done', 'just_done', 'not_done']
 account      / res.company              / account_onboarding_invoice_layout_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
@@ -105,21 +105,21 @@ account      / res.company              / account_onboarding_sale_tax_state (sel
 account      / res.company              / account_onboarding_sample_invoice_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
 account      / res.company              / account_purchase_tax_id (many2one): NEW relation: account.tax
 account      / res.company              / account_sale_tax_id (many2one): NEW relation: account.tax
-account      / res.company              / account_setup_bank_data_done (boolean): DEL 
+account      / res.company              / account_setup_bank_data_done (boolean): DEL
 account      / res.company              / account_setup_bank_data_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
-account      / res.company              / account_setup_bar_closed (boolean): DEL 
-account      / res.company              / account_setup_coa_done (boolean): DEL 
+account      / res.company              / account_setup_bar_closed (boolean): DEL
+account      / res.company              / account_setup_coa_done (boolean): DEL
 account      / res.company              / account_setup_coa_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
-account      / res.company              / account_setup_company_data_done (boolean): DEL 
-account      / res.company              / account_setup_fy_data_done (boolean): DEL 
+account      / res.company              / account_setup_company_data_done (boolean): DEL
+account      / res.company              / account_setup_fy_data_done (boolean): DEL
 account      / res.company              / account_setup_fy_data_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
-account      / res.company              / accounts_code_digits (integer): DEL 
+account      / res.company              / accounts_code_digits (integer): DEL
 account      / res.company              / incoterm_id (many2one)        : previously in module l10n_be_intrastat
-account      / res.company              / invoice_is_email (boolean)    : NEW 
-account      / res.company              / invoice_is_print (boolean)    : NEW 
+account      / res.company              / invoice_is_email (boolean)    : NEW
+account      / res.company              / invoice_is_print (boolean)    : NEW
 account      / res.company              / invoice_reference_type (selection): NEW selection_keys: function
-account      / res.company              / qr_code (boolean)             : NEW 
-account      / res.company              / transfer_account_code_prefix (char): NEW 
+account      / res.company              / qr_code (boolean)             : NEW
+account      / res.company              / transfer_account_code_prefix (char): NEW
 account      / stock.incoterms          / __last_update (datetime)      : previously in module stock
 account      / stock.incoterms          / active (boolean)              : previously in module stock
 account      / stock.incoterms          / code (char)                   : previously in module stock
@@ -134,21 +134,21 @@ DEL account.financial.report: account.account_financial_report_liability0 (noupd
 DEL account.financial.report: account.account_financial_report_liabilitysum0 (noupdate)
 DEL account.financial.report: account.account_financial_report_profitandloss0 (noupdate)
 DEL account.financial.report: account.account_financial_report_profitloss_toreport0 (noupdate)
-NEW account.incoterms: account.incoterm_CFR
-NEW account.incoterms: account.incoterm_CIF
-NEW account.incoterms: account.incoterm_CIP
-NEW account.incoterms: account.incoterm_CPT
-NEW account.incoterms: account.incoterm_DAF
-NEW account.incoterms: account.incoterm_DAP
-NEW account.incoterms: account.incoterm_DAT
-NEW account.incoterms: account.incoterm_DDP
-NEW account.incoterms: account.incoterm_DDU
-NEW account.incoterms: account.incoterm_DEQ
-NEW account.incoterms: account.incoterm_DES
-NEW account.incoterms: account.incoterm_EXW
-NEW account.incoterms: account.incoterm_FAS
-NEW account.incoterms: account.incoterm_FCA
-NEW account.incoterms: account.incoterm_FOB
+NEW account.incoterms: account.incoterm_CFR [renamed from stock module]
+NEW account.incoterms: account.incoterm_CIF [renamed from stock module]
+NEW account.incoterms: account.incoterm_CIP [renamed from stock module]
+NEW account.incoterms: account.incoterm_CPT [renamed from stock module]
+NEW account.incoterms: account.incoterm_DAF [renamed from stock module]
+NEW account.incoterms: account.incoterm_DAP [renamed from stock module]
+NEW account.incoterms: account.incoterm_DAT [renamed from stock module]
+NEW account.incoterms: account.incoterm_DDP [renamed from stock module]
+NEW account.incoterms: account.incoterm_DDU [renamed from stock module]
+NEW account.incoterms: account.incoterm_DEQ [renamed from stock module]
+NEW account.incoterms: account.incoterm_DES [renamed from stock module]
+NEW account.incoterms: account.incoterm_EXW [renamed from stock module]
+NEW account.incoterms: account.incoterm_FAS [renamed from stock module]
+NEW account.incoterms: account.incoterm_FCA [renamed from stock module]
+NEW account.incoterms: account.incoterm_FOB [renamed from stock module]
 NEW account.payment.term: account.account_payment_term_2months (noupdate)
 NEW account.payment.term: account.account_payment_term_45days (noupdate)
 NEW account.reconcile.model: account.reconciliation_model_default_rule (noupdate)
@@ -293,9 +293,9 @@ NEW res.groups: account.group_fiscal_year
 NEW res.groups: account.group_products_in_bills
 NEW res.groups: account.group_show_line_subtotals_tax_excluded
 NEW res.groups: account.group_show_line_subtotals_tax_included
-NEW res.groups: base.group_portal
-NEW res.groups: base.group_public
-NEW res.groups: base.group_user (noupdate)
+NEW res.groups: base.group_portal [moved from sale module]
+NEW res.groups: base.group_public [moved from sale module]
+NEW res.groups: base.group_user [moved from sale module] (noupdate)
 DEL res.request.link: account.req_link_invoice (noupdate)
 NEW res.users: base.user_admin (noupdate)
 DEL res.users: base.user_root (noupdate)

--- a/addons/account_check_printing/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/account_check_printing/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,10 +1,10 @@
 ---Fields in module 'account_check_printing'---
-account_check_printing / res.company              / account_check_printing_date_label (boolean): NEW 
+account_check_printing / res.company              / account_check_printing_date_label (boolean): NEW
 account_check_printing / res.company              / account_check_printing_layout (selection): NEW required: required, selection_keys: ['action_print_check_bottom', 'action_print_check_middle', 'action_print_check_top', 'disabled'], req_default: function
-account_check_printing / res.company              / account_check_printing_margin_left (float): NEW 
-account_check_printing / res.company              / account_check_printing_margin_right (float): NEW 
-account_check_printing / res.company              / account_check_printing_margin_top (float): NEW 
-account_check_printing / res.company              / account_check_printing_multi_stub (boolean): NEW 
+account_check_printing / res.company              / account_check_printing_margin_left (float): NEW
+account_check_printing / res.company              / account_check_printing_margin_right (float): NEW
+account_check_printing / res.company              / account_check_printing_margin_top (float): NEW
+account_check_printing / res.company              / account_check_printing_multi_stub (boolean): NEW
 ---XML records in module 'account_check_printing'---
 NEW ir.ui.view: account_check_printing.res_config_settings_view_form
 DEL ir.ui.view: account_check_printing.view_account_bank_journal_form_inherited_check_printing

--- a/addons/account_voucher/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/account_voucher/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,9 +1,9 @@
 ---Fields in module 'account_voucher'---
 account_voucher / account.voucher          / company_id (many2one)         : is now stored
 account_voucher / account.voucher          / currency_id (many2one)        : is now stored
-account_voucher / account.voucher          / message_last_post (datetime)  : DEL 
+account_voucher / account.voucher          / message_last_post (datetime)  : DEL
 account_voucher / account.voucher          / message_main_attachment_id (many2one): NEW relation: ir.attachment
-account_voucher / account.voucher          / payment_journal_id (many2one) : not a function anymore
 account_voucher / account.voucher          / payment_journal_id (many2one) : is now stored
+account_voucher / account.voucher          / payment_journal_id (many2one) : not a function anymore
 account_voucher / account.voucher.line     / analytic_tag_ids (many2many)  : NEW relation: account.analytic.tag
 ---XML records in module 'account_voucher'---

--- a/addons/analytic/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/analytic/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -1,6 +1,6 @@
 ---Fields in module 'analytic'---
 analytic     / account.analytic.account / group_id (many2one)           : NEW relation: account.analytic.group
-analytic     / account.analytic.account / message_last_post (datetime)  : DEL 
+analytic     / account.analytic.account / message_last_post (datetime)  : DEL
 analytic     / account.analytic.account / message_main_attachment_id (many2one): NEW relation: ir.attachment
 analytic     / account.analytic.account / tag_ids (many2many)           : DEL relation: account.analytic.tag
 analytic     / account.analytic.distribution / account_id (many2one)         : NEW relation: account.analytic.account, required: required
@@ -8,17 +8,17 @@ analytic     / account.analytic.distribution / percentage (float)            : N
 analytic     / account.analytic.distribution / tag_id (many2one)             : NEW relation: account.analytic.tag, required: required
 analytic     / account.analytic.group   / children_ids (one2many)       : NEW relation: account.analytic.group
 analytic     / account.analytic.group   / company_id (many2one)         : NEW relation: res.company
-analytic     / account.analytic.group   / complete_name (char)          : NEW 
-analytic     / account.analytic.group   / description (text)            : NEW 
+analytic     / account.analytic.group   / complete_name (char)          : NEW
+analytic     / account.analytic.group   / description (text)            : NEW
 analytic     / account.analytic.group   / name (char)                   : NEW required: required
 analytic     / account.analytic.group   / parent_id (many2one)          : NEW relation: account.analytic.group
-analytic     / account.analytic.group   / parent_path (char)            : NEW 
+analytic     / account.analytic.group   / parent_path (char)            : NEW
 analytic     / account.analytic.line    / company_id (many2one)         : not related anymore
 analytic     / account.analytic.line    / company_id (many2one)         : now required, default = function
 analytic     / account.analytic.line    / currency_id (many2one)        : is now stored
 analytic     / account.analytic.line    / group_id (many2one)           : NEW relation: account.analytic.group
 analytic     / account.analytic.line    / product_uom_id (many2one)     : previously in module account
-analytic     / account.analytic.tag     / active_analytic_distribution (boolean): NEW 
+analytic     / account.analytic.tag     / active_analytic_distribution (boolean): NEW
 analytic     / account.analytic.tag     / analytic_distribution_ids (one2many): NEW relation: account.analytic.distribution
 analytic     / account.analytic.tag     / company_id (many2one)         : NEW relation: res.company
 ---XML records in module 'analytic'---

--- a/addons/base_import/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/base_import/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,16 +1,16 @@
 ---Fields in module 'base_import'---
-base_import  / base_import.mapping      / column_name (char)            : NEW 
-base_import  / base_import.mapping      / field_name (char)             : NEW 
-base_import  / base_import.mapping      / res_model (char)              : NEW 
-base_import  / base_import.tests.models.complex / c (char)                      : NEW 
+base_import  / base_import.mapping      / column_name (char)            : NEW
+base_import  / base_import.mapping      / field_name (char)             : NEW
+base_import  / base_import.mapping      / res_model (char)              : NEW
+base_import  / base_import.tests.models.complex / c (char)                      : NEW
 base_import  / base_import.tests.models.complex / currency_id (many2one)        : NEW relation: res.currency
-base_import  / base_import.tests.models.complex / d (date)                      : NEW 
-base_import  / base_import.tests.models.complex / dt (datetime)                 : NEW 
-base_import  / base_import.tests.models.complex / f (float)                     : NEW 
-base_import  / base_import.tests.models.complex / m (float)                     : NEW 
+base_import  / base_import.tests.models.complex / d (date)                      : NEW
+base_import  / base_import.tests.models.complex / dt (datetime)                 : NEW
+base_import  / base_import.tests.models.complex / f (float)                     : NEW
+base_import  / base_import.tests.models.complex / m (float)                     : NEW
 base_import  / base_import.tests.models.float / currency_id (many2one)        : NEW relation: res.currency
-base_import  / base_import.tests.models.float / value (float)                 : NEW 
-base_import  / base_import.tests.models.float / value2 (float)                : NEW 
+base_import  / base_import.tests.models.float / value (float)                 : NEW
+base_import  / base_import.tests.models.float / value2 (float)                : NEW
 ---XML records in module 'base_import'---
 NEW ir.model.access: base_import.access_base_import_mapping
 NEW ir.model.access: base_import.access_base_import_tests_models_complex

--- a/addons/calendar/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/calendar/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'calendar'---
-calendar     / calendar.event           / message_last_post (datetime)  : DEL 
+calendar     / calendar.event           / message_last_post (datetime)  : DEL
 calendar     / calendar.event           / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'calendar'---
 DEL calendar.event.type: calendar.categ_meet1 (noupdate)

--- a/addons/crm/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/crm/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -2,13 +2,13 @@
 crm          / crm.lead                 / activity_date_deadline (date) : not related anymore
 crm          / crm.lead                 / activity_date_deadline (date) : not stored anymore
 crm          / crm.lead                 / activity_date_deadline (date) : now a function
-crm          / crm.lead                 / expected_revenue (float)      : NEW 
-crm          / crm.lead                 / message_last_post (datetime)  : DEL 
+crm          / crm.lead                 / expected_revenue (float)      : NEW
+crm          / crm.lead                 / message_last_post (datetime)  : DEL
 crm          / crm.lead                 / message_main_attachment_id (many2one): NEW relation: ir.attachment
-crm          / crm.lead                 / opt_out (boolean)             : DEL 
+crm          / crm.lead                 / opt_out (boolean)             : DEL
 crm          / crm.team                 / dashboard_graph_model (False) : selection_keys is now '['crm.lead']' ('['crm.opportunity.report']')
-crm          / digest.digest            / kpi_crm_lead_created (boolean): NEW 
-crm          / digest.digest            / kpi_crm_opportunities_won (boolean): NEW 
+crm          / digest.digest            / kpi_crm_lead_created (boolean): NEW
+crm          / digest.digest            / kpi_crm_opportunities_won (boolean): NEW
 ---XML records in module 'crm'---
 NEW digest.digest: digest.digest_digest_default (noupdate)
 NEW digest.tip: crm.digest_tip_crm_0

--- a/addons/crm_reveal/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/crm_reveal/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,19 +1,19 @@
 ---Fields in module 'crm_reveal'---
-crm_reveal   / crm.lead                 / reveal_iap_credits (integer)  : NEW 
-crm_reveal   / crm.lead                 / reveal_id (char)              : NEW 
-crm_reveal   / crm.lead                 / reveal_ip (char)              : NEW 
+crm_reveal   / crm.lead                 / reveal_iap_credits (integer)  : NEW
+crm_reveal   / crm.lead                 / reveal_id (char)              : NEW
+crm_reveal   / crm.lead                 / reveal_ip (char)              : NEW
 crm_reveal   / crm.lead                 / reveal_rule_id (many2one)     : NEW relation: crm.reveal.rule
-crm_reveal   / crm.reveal.industry      / color (integer)               : NEW 
+crm_reveal   / crm.reveal.industry      / color (integer)               : NEW
 crm_reveal   / crm.reveal.industry      / name (char)                   : NEW required: required
 crm_reveal   / crm.reveal.industry      / reveal_id (char)              : NEW required: required
-crm_reveal   / crm.reveal.role          / color (integer)               : NEW 
+crm_reveal   / crm.reveal.role          / color (integer)               : NEW
 crm_reveal   / crm.reveal.role          / name (char)                   : NEW required: required
 crm_reveal   / crm.reveal.role          / reveal_id (char)              : NEW required: required
-crm_reveal   / crm.reveal.rule          / active (boolean)              : NEW 
-crm_reveal   / crm.reveal.rule          / company_size_max (integer)    : NEW 
-crm_reveal   / crm.reveal.rule          / company_size_min (integer)    : NEW 
+crm_reveal   / crm.reveal.rule          / active (boolean)              : NEW
+crm_reveal   / crm.reveal.rule          / company_size_max (integer)    : NEW
+crm_reveal   / crm.reveal.rule          / company_size_min (integer)    : NEW
 crm_reveal   / crm.reveal.rule          / country_ids (many2many)       : NEW relation: res.country
-crm_reveal   / crm.reveal.rule          / extra_contacts (integer)      : NEW 
+crm_reveal   / crm.reveal.rule          / extra_contacts (integer)      : NEW
 crm_reveal   / crm.reveal.rule          / industry_tag_ids (many2many)  : NEW relation: crm.reveal.industry
 crm_reveal   / crm.reveal.rule          / lead_for (selection)          : NEW required: required, selection_keys: ['companies', 'people'], req_default: function
 crm_reveal   / crm.reveal.rule          / lead_ids (one2many)           : NEW relation: crm.lead
@@ -22,16 +22,16 @@ crm_reveal   / crm.reveal.rule          / name (char)                   : NEW re
 crm_reveal   / crm.reveal.rule          / other_role_ids (many2many)    : NEW relation: crm.reveal.role
 crm_reveal   / crm.reveal.rule          / preferred_role_id (many2one)  : NEW relation: crm.reveal.role
 crm_reveal   / crm.reveal.rule          / priority (selection)          : NEW selection_keys: ['0', '1', '2', '3']
-crm_reveal   / crm.reveal.rule          / regex_url (char)              : NEW 
+crm_reveal   / crm.reveal.rule          / regex_url (char)              : NEW
 crm_reveal   / crm.reveal.rule          / seniority_id (many2one)       : NEW relation: crm.reveal.seniority
-crm_reveal   / crm.reveal.rule          / sequence (integer)            : NEW 
-crm_reveal   / crm.reveal.rule          / suffix (char)                 : NEW 
+crm_reveal   / crm.reveal.rule          / sequence (integer)            : NEW
+crm_reveal   / crm.reveal.rule          / suffix (char)                 : NEW
 crm_reveal   / crm.reveal.rule          / tag_ids (many2many)           : NEW relation: crm.lead.tag
 crm_reveal   / crm.reveal.rule          / team_id (many2one)            : NEW relation: crm.team
 crm_reveal   / crm.reveal.rule          / user_id (many2one)            : NEW relation: res.users
 crm_reveal   / crm.reveal.seniority     / name (char)                   : NEW required: required
 crm_reveal   / crm.reveal.seniority     / reveal_id (char)              : NEW required: required
-crm_reveal   / crm.reveal.view          / reveal_ip (char)              : NEW 
+crm_reveal   / crm.reveal.view          / reveal_ip (char)              : NEW
 crm_reveal   / crm.reveal.view          / reveal_rule_id (many2one)     : NEW relation: crm.reveal.rule
 crm_reveal   / crm.reveal.view          / reveal_state (selection)      : NEW selection_keys: ['not_found', 'to_process']
 ---XML records in module 'crm_reveal'---

--- a/addons/delivery/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/delivery/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -2,7 +2,7 @@
 delivery     / product.product          / hs_code (char)                : module is now 'delivery_hs_code' ('delivery')
 delivery     / product.template         / hs_code (char)                : module is now 'delivery_hs_code' ('delivery')
 delivery     / stock.move               / weight_uom_id (many2one)      : DEL relation: product.uom, required: required, req_default: function
-delivery     / stock.picking            / number_of_packages (integer)  : DEL 
+delivery     / stock.picking            / number_of_packages (integer)  : DEL
 delivery     / stock.picking            / weight_uom_id (many2one)      : not stored anymore
 delivery     / stock.picking            / weight_uom_id (many2one)      : now a function
 delivery     / stock.picking            / weight_uom_id (many2one)      : relation is now 'uom.uom' ('product.uom')

--- a/addons/digest/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/digest/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,16 +1,16 @@
 ---Fields in module 'digest'---
 digest       / digest.digest            / company_id (many2one)         : NEW relation: res.company
-digest       / digest.digest            / kpi_mail_message_total (boolean): NEW 
-digest       / digest.digest            / kpi_res_users_connected (boolean): NEW 
+digest       / digest.digest            / kpi_mail_message_total (boolean): NEW
+digest       / digest.digest            / kpi_res_users_connected (boolean): NEW
 digest       / digest.digest            / name (char)                   : NEW required: required
-digest       / digest.digest            / next_run_date (date)          : NEW 
+digest       / digest.digest            / next_run_date (date)          : NEW
 digest       / digest.digest            / periodicity (selection)       : NEW required: required, selection_keys: ['monthly', 'quarterly', 'weekly'], req_default: function
 digest       / digest.digest            / state (selection)             : NEW selection_keys: ['activated', 'deactivated']
 digest       / digest.digest            / template_id (many2one)        : NEW relation: mail.template, required: required, req_default: function
 digest       / digest.digest            / user_ids (many2many)          : NEW relation: res.users
 digest       / digest.tip               / group_id (many2one)           : NEW relation: res.groups
-digest       / digest.tip               / sequence (integer)            : NEW 
-digest       / digest.tip               / tip_description (html)        : NEW 
+digest       / digest.tip               / sequence (integer)            : NEW
+digest       / digest.tip               / tip_description (html)        : NEW
 digest       / digest.tip               / user_ids (many2many)          : NEW relation: res.users
 ---XML records in module 'digest'---
 NEW digest.digest: digest.digest_digest_default (noupdate)

--- a/addons/event/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/event/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,7 +1,7 @@
 ---Fields in module 'event'---
-event        / event.event              / message_last_post (datetime)  : DEL 
+event        / event.event              / message_last_post (datetime)  : DEL
 event        / event.event              / message_main_attachment_id (many2one): NEW relation: ir.attachment
-event        / event.registration       / message_last_post (datetime)  : DEL 
+event        / event.registration       / message_last_post (datetime)  : DEL
 event        / event.registration       / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'event'---
 DEL ir.actions.act_window: event.act_register_event_partner

--- a/addons/fleet/migrations/12.0.0.1/openupgrade_analysis.txt
+++ b/addons/fleet/migrations/12.0.0.1/openupgrade_analysis.txt
@@ -1,16 +1,16 @@
 ---Fields in module 'fleet'---
 fleet        / fleet.vehicle            / activity_ids (one2many)       : NEW relation: mail.activity
 fleet        / fleet.vehicle            / brand_id (many2one)           : NEW relation: fleet.vehicle.model.brand
-fleet        / fleet.vehicle            / first_contract_date (date)    : NEW 
+fleet        / fleet.vehicle            / first_contract_date (date)    : NEW
 fleet        / fleet.vehicle            / log_drivers (one2many)        : NEW relation: fleet.vehicle.assignation.log
-fleet        / fleet.vehicle            / message_last_post (datetime)  : DEL 
+fleet        / fleet.vehicle            / message_last_post (datetime)  : DEL
 fleet        / fleet.vehicle            / message_main_attachment_id (many2one): NEW relation: ir.attachment
-fleet        / fleet.vehicle.assignation.log / date_end (date)               : NEW 
-fleet        / fleet.vehicle.assignation.log / date_start (date)             : NEW 
+fleet        / fleet.vehicle.assignation.log / date_end (date)               : NEW
+fleet        / fleet.vehicle.assignation.log / date_start (date)             : NEW
 fleet        / fleet.vehicle.assignation.log / driver_id (many2one)          : NEW relation: res.partner, required: required
 fleet        / fleet.vehicle.assignation.log / vehicle_id (many2one)         : NEW relation: fleet.vehicle, required: required
 fleet        / fleet.vehicle.log.contract / activity_ids (one2many)       : NEW relation: mail.activity
-fleet        / fleet.vehicle.log.contract / message_last_post (datetime)  : DEL 
+fleet        / fleet.vehicle.log.contract / message_last_post (datetime)  : DEL
 fleet        / fleet.vehicle.log.contract / message_main_attachment_id (many2one): NEW relation: ir.attachment
 fleet        / fleet.vehicle.log.contract / user_id (many2one)            : NEW relation: res.users
 ---XML records in module 'fleet'---

--- a/addons/gamification/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/gamification/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,6 +1,6 @@
 ---Fields in module 'gamification'---
-gamification / gamification.badge       / message_last_post (datetime)  : DEL 
+gamification / gamification.badge       / message_last_post (datetime)  : DEL
 gamification / gamification.badge       / message_main_attachment_id (many2one): NEW relation: ir.attachment
-gamification / gamification.challenge   / message_last_post (datetime)  : DEL 
+gamification / gamification.challenge   / message_last_post (datetime)  : DEL
 gamification / gamification.challenge   / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'gamification'---

--- a/addons/hr/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/hr/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -1,26 +1,26 @@
 ---Fields in module 'hr'---
-hr           / hr.department            / message_last_post (datetime)  : DEL 
+hr           / hr.department            / message_last_post (datetime)  : DEL
 hr           / hr.department            / message_main_attachment_id (many2one): NEW relation: ir.attachment
 hr           / hr.employee              / activity_ids (one2many)       : NEW relation: mail.activity
-hr           / hr.employee              / additional_note (text)        : NEW 
+hr           / hr.employee              / additional_note (text)        : NEW
 hr           / hr.employee              / certificate (selection)       : NEW selection_keys: ['bachelor', 'master', 'other']
 hr           / hr.employee              / children (integer)            : previously in module hr_contract
 hr           / hr.employee              / country_of_birth (many2one)   : NEW relation: res.country
-hr           / hr.employee              / emergency_contact (char)      : NEW 
-hr           / hr.employee              / emergency_phone (char)        : NEW 
-hr           / hr.employee              / google_drive_link (char)      : NEW 
-hr           / hr.employee              / job_title (char)              : NEW 
-hr           / hr.employee              / km_home_work (integer)        : NEW 
-hr           / hr.employee              / message_last_post (datetime)  : DEL 
+hr           / hr.employee              / emergency_contact (char)      : NEW
+hr           / hr.employee              / emergency_phone (char)        : NEW
+hr           / hr.employee              / google_drive_link (char)      : NEW
+hr           / hr.employee              / job_title (char)              : NEW
+hr           / hr.employee              / km_home_work (integer)        : NEW
+hr           / hr.employee              / message_last_post (datetime)  : DEL
 hr           / hr.employee              / message_main_attachment_id (many2one): NEW relation: ir.attachment
 hr           / hr.employee              / place_of_birth (char)         : previously in module hr_contract
 hr           / hr.employee              / resource_calendar_id (many2one): is now stored
-hr           / hr.employee              / spouse_birthdate (date)       : NEW 
-hr           / hr.employee              / spouse_complete_name (char)   : NEW 
-hr           / hr.employee              / study_field (char)            : NEW 
-hr           / hr.employee              / study_school (char)           : NEW 
+hr           / hr.employee              / spouse_birthdate (date)       : NEW
+hr           / hr.employee              / spouse_complete_name (char)   : NEW
+hr           / hr.employee              / study_field (char)            : NEW
+hr           / hr.employee              / study_school (char)           : NEW
 hr           / hr.employee              / user_id (many2one)            : is now stored
-hr           / hr.job                   / message_last_post (datetime)  : DEL 
+hr           / hr.job                   / message_last_post (datetime)  : DEL
 hr           / hr.job                   / message_main_attachment_id (many2one): NEW relation: ir.attachment
 hr           / mail.channel             / subscription_department_ids (many2many): NEW relation: hr.department
 ---XML records in module 'hr'---

--- a/addons/hr_contract/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/hr_contract/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,12 +1,12 @@
 ---Fields in module 'hr_contract'---
-hr_contract  / hr.contract              / active (boolean)              : NEW 
+hr_contract  / hr.contract              / active (boolean)              : NEW
 hr_contract  / hr.contract              / activity_ids (one2many)       : NEW relation: mail.activity
-hr_contract  / hr.contract              / message_last_post (datetime)  : DEL 
+hr_contract  / hr.contract              / message_last_post (datetime)  : DEL
 hr_contract  / hr.contract              / message_main_attachment_id (many2one): NEW relation: ir.attachment
-hr_contract  / hr.contract              / reported_to_secretariat (boolean): NEW 
+hr_contract  / hr.contract              / reported_to_secretariat (boolean): NEW
 hr_contract  / hr.employee              / children (integer)            : module is now 'hr' ('hr_contract')
 hr_contract  / hr.employee              / place_of_birth (char)         : module is now 'hr' ('hr_contract')
-hr_contract  / hr.employee              / vehicle_distance (integer)    : DEL 
+hr_contract  / hr.employee              / vehicle_distance (integer)    : DEL
 ---XML records in module 'hr_contract'---
 DEL ir.model.access: hr_contract.access_hr_contract_type_user
 DEL ir.model.access: hr_contract.access_hr_contract_user

--- a/addons/hr_expense/migrations/12.0.2.0/openupgrade_analysis.txt
+++ b/addons/hr_expense/migrations/12.0.2.0/openupgrade_analysis.txt
@@ -3,13 +3,13 @@ hr_expense   / hr.employee              / expense_manager_id (many2one) : NEW re
 hr_expense   / hr.expense               / activity_ids (one2many)       : NEW relation: mail.activity
 hr_expense   / hr.expense               / analytic_tag_ids (many2many)  : NEW relation: account.analytic.tag
 hr_expense   / hr.expense               / company_currency_id (many2one): NEW relation: res.currency
-hr_expense   / hr.expense               / message_last_post (datetime)  : DEL 
+hr_expense   / hr.expense               / message_last_post (datetime)  : DEL
 hr_expense   / hr.expense               / message_main_attachment_id (many2one): NEW relation: ir.attachment
 hr_expense   / hr.expense               / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
 hr_expense   / hr.expense               / state (selection)             : selection_keys is now '['approved', 'done', 'draft', 'refused', 'reported']' ('['done', 'draft', 'refused', 'reported']')
-hr_expense   / hr.expense               / total_amount_company (float)  : NEW 
+hr_expense   / hr.expense               / total_amount_company (float)  : NEW
 hr_expense   / hr.expense.sheet         / activity_ids (one2many)       : NEW relation: mail.activity
-hr_expense   / hr.expense.sheet         / message_last_post (datetime)  : DEL 
+hr_expense   / hr.expense.sheet         / message_last_post (datetime)  : DEL
 hr_expense   / hr.expense.sheet         / message_main_attachment_id (many2one): NEW relation: ir.attachment
 hr_expense   / hr.expense.sheet         / responsible_id (many2one)     : was renamed to user_id [nothing to do]
 hr_expense   / hr.expense.sheet         / state (selection)             : selection_keys is now '['approve', 'cancel', 'done', 'draft', 'post', 'submit']' ('['approve', 'cancel', 'done', 'post', 'submit']')

--- a/addons/hr_holidays/migrations/12.0.1.5/openupgrade_analysis.txt
+++ b/addons/hr_holidays/migrations/12.0.1.5/openupgrade_analysis.txt
@@ -5,48 +5,48 @@ hr_holidays  / hr.holidays              / date_to (datetime)            : now re
 hr_holidays  / hr.holidays              / holiday_status_id (many2one)  : relation is now 'hr.leave.type' ('hr.holidays.status')
 hr_holidays  / hr.holidays              / holiday_type (selection)      : selection_keys is now '['category', 'company', 'department', 'employee']' ('['category', 'employee']')
 hr_holidays  / hr.holidays              / linked_request_ids (one2many) : relation is now 'hr.leave' ('hr.holidays')
-hr_holidays  / hr.holidays              / message_last_post (datetime)  : DEL 
+hr_holidays  / hr.holidays              / message_last_post (datetime)  : DEL
 hr_holidays  / hr.holidays              / number_of_days (float)        : not a function anymore
-hr_holidays  / hr.holidays              / number_of_days_temp (float)   : DEL 
+hr_holidays  / hr.holidays              / number_of_days_temp (float)   : DEL
 hr_holidays  / hr.holidays              / parent_id (many2one)          : relation is now 'hr.leave' ('hr.holidays')
 hr_holidays  / hr.holidays              / type (selection)              : DEL required: required, selection_keys: ['add', 'remove'], req_default: function
 hr_holidays  / hr.holidays.status       / double_validation (boolean)   : not stored anymore
 hr_holidays  / hr.holidays.status       / double_validation (boolean)   : now a function
-hr_holidays  / hr.holidays.status       / limit (boolean)               : DEL 
+hr_holidays  / hr.holidays.status       / limit (boolean)               : DEL
 hr_holidays  / hr.leave                 / activity_ids (one2many)       : NEW relation: mail.activity
 hr_holidays  / hr.leave                 / message_main_attachment_id (many2one): NEW relation: ir.attachment
 hr_holidays  / hr.leave                 / mode_company_id (many2one)    : NEW relation: res.company
-hr_holidays  / hr.leave                 / request_date_from (date)      : NEW 
+hr_holidays  / hr.leave                 / request_date_from (date)      : NEW
 hr_holidays  / hr.leave                 / request_date_from_period (selection): NEW selection_keys: ['am', 'pm']
-hr_holidays  / hr.leave                 / request_date_to (date)        : NEW 
+hr_holidays  / hr.leave                 / request_date_to (date)        : NEW
 hr_holidays  / hr.leave                 / request_hour_from (selection) : NEW selection_keys: [-24, -23, -22, -21, -20, -19, -18, -17, -16, -15, -14, -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
 hr_holidays  / hr.leave                 / request_hour_to (selection)   : NEW selection_keys: [-24, -23, -22, -21, -20, -19, -18, -17, -16, -15, -14, -13, -12, -11, -10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
-hr_holidays  / hr.leave                 / request_unit_custom (boolean) : NEW 
-hr_holidays  / hr.leave                 / request_unit_half (boolean)   : NEW 
-hr_holidays  / hr.leave                 / request_unit_hours (boolean)  : NEW 
-hr_holidays  / hr.leave.allocation      / accrual (boolean)             : NEW 
-hr_holidays  / hr.leave.allocation      / accrual_limit (integer)       : NEW 
+hr_holidays  / hr.leave                 / request_unit_custom (boolean) : NEW
+hr_holidays  / hr.leave                 / request_unit_half (boolean)   : NEW
+hr_holidays  / hr.leave                 / request_unit_hours (boolean)  : NEW
+hr_holidays  / hr.leave.allocation      / accrual (boolean)             : NEW
+hr_holidays  / hr.leave.allocation      / accrual_limit (integer)       : NEW
 hr_holidays  / hr.leave.allocation      / activity_ids (one2many)       : NEW relation: mail.activity
 hr_holidays  / hr.leave.allocation      / category_id (many2one)        : NEW relation: hr.employee.category
-hr_holidays  / hr.leave.allocation      / date_from (datetime)          : NEW 
-hr_holidays  / hr.leave.allocation      / date_to (datetime)            : NEW 
+hr_holidays  / hr.leave.allocation      / date_from (datetime)          : NEW
+hr_holidays  / hr.leave.allocation      / date_to (datetime)            : NEW
 hr_holidays  / hr.leave.allocation      / department_id (many2one)      : NEW relation: hr.department
 hr_holidays  / hr.leave.allocation      / employee_id (many2one)        : NEW relation: hr.employee
 hr_holidays  / hr.leave.allocation      / first_approver_id (many2one)  : NEW relation: hr.employee
 hr_holidays  / hr.leave.allocation      / holiday_status_id (many2one)  : NEW relation: hr.leave.type, required: required, req_default: function
 hr_holidays  / hr.leave.allocation      / holiday_type (selection)      : NEW required: required, selection_keys: ['category', 'company', 'department', 'employee'], req_default: function
-hr_holidays  / hr.leave.allocation      / interval_number (integer)     : NEW 
+hr_holidays  / hr.leave.allocation      / interval_number (integer)     : NEW
 hr_holidays  / hr.leave.allocation      / interval_unit (selection)     : NEW selection_keys: ['months', 'weeks', 'years']
 hr_holidays  / hr.leave.allocation      / linked_request_ids (one2many) : NEW relation: hr.leave.allocation
 hr_holidays  / hr.leave.allocation      / message_follower_ids (one2many): NEW relation: mail.followers
 hr_holidays  / hr.leave.allocation      / message_ids (one2many)        : NEW relation: mail.message
 hr_holidays  / hr.leave.allocation      / message_main_attachment_id (many2one): NEW relation: ir.attachment
 hr_holidays  / hr.leave.allocation      / mode_company_id (many2one)    : NEW relation: res.company
-hr_holidays  / hr.leave.allocation      / name (char)                   : NEW 
-hr_holidays  / hr.leave.allocation      / nextcall (date)               : NEW 
-hr_holidays  / hr.leave.allocation      / notes (text)                  : NEW 
-hr_holidays  / hr.leave.allocation      / number_of_days (float)        : NEW 
-hr_holidays  / hr.leave.allocation      / number_per_interval (float)   : NEW 
+hr_holidays  / hr.leave.allocation      / name (char)                   : NEW
+hr_holidays  / hr.leave.allocation      / nextcall (date)               : NEW
+hr_holidays  / hr.leave.allocation      / notes (text)                  : NEW
+hr_holidays  / hr.leave.allocation      / number_of_days (float)        : NEW
+hr_holidays  / hr.leave.allocation      / number_per_interval (float)   : NEW
 hr_holidays  / hr.leave.allocation      / parent_id (many2one)          : NEW relation: hr.leave.allocation
 hr_holidays  / hr.leave.allocation      / second_approver_id (many2one) : NEW relation: hr.employee
 hr_holidays  / hr.leave.allocation      / state (selection)             : NEW selection_keys: ['cancel', 'confirm', 'draft', 'refuse', 'validate', 'validate1']
@@ -54,12 +54,12 @@ hr_holidays  / hr.leave.allocation      / unit_per_interval (selection) : NEW se
 hr_holidays  / hr.leave.allocation      / website_message_ids (one2many): NEW relation: mail.message
 hr_holidays  / hr.leave.type            / allocation_type (selection)   : NEW selection_keys: ['fixed', 'fixed_allocation', 'no']
 hr_holidays  / hr.leave.type            / request_unit (selection)      : NEW required: required, selection_keys: ['day', 'hour'], req_default: function
-hr_holidays  / hr.leave.type            / sequence (integer)            : NEW 
+hr_holidays  / hr.leave.type            / sequence (integer)            : NEW
 hr_holidays  / hr.leave.type            / time_type (selection)         : NEW selection_keys: ['leave', 'other']
-hr_holidays  / hr.leave.type            / unpaid (boolean)              : NEW 
+hr_holidays  / hr.leave.type            / unpaid (boolean)              : NEW
 hr_holidays  / hr.leave.type            / validation_type (selection)   : NEW selection_keys: ['both', 'hr', 'manager']
-hr_holidays  / hr.leave.type            / validity_start (date)         : NEW 
-hr_holidays  / hr.leave.type            / validity_stop (date)          : NEW 
+hr_holidays  / hr.leave.type            / validity_start (date)         : NEW
+hr_holidays  / hr.leave.type            / validity_stop (date)          : NEW
 hr_holidays  / resource.calendar.leaves / holiday_id (many2one)         : relation is now 'hr.leave' ('hr.holidays')
 ---XML records in module 'hr_holidays'---
 NEW ir.actions.act_window: hr_holidays.hr_leave_action_action_approve_department

--- a/addons/hr_recruitment/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/hr_recruitment/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,10 +1,10 @@
 ---Fields in module 'hr_recruitment'---
-hr_recruitment / digest.digest            / kpi_hr_recruitment_new_colleagues (boolean): NEW 
+hr_recruitment / digest.digest            / kpi_hr_recruitment_new_colleagues (boolean): NEW
 hr_recruitment / hr.applicant             / activity_date_deadline (date) : not related anymore
 hr_recruitment / hr.applicant             / activity_date_deadline (date) : not stored anymore
 hr_recruitment / hr.applicant             / activity_date_deadline (date) : now a function
 hr_recruitment / hr.applicant             / kanban_state (selection)      : NEW required: required, selection_keys: ['blocked', 'done', 'normal'], req_default: function
-hr_recruitment / hr.applicant             / message_last_post (datetime)  : DEL 
+hr_recruitment / hr.applicant             / message_last_post (datetime)  : DEL
 hr_recruitment / hr.applicant             / message_main_attachment_id (many2one): NEW relation: ir.attachment
 hr_recruitment / hr.recruitment.stage     / legend_blocked (char)         : NEW required: required, req_default: function
 hr_recruitment / hr.recruitment.stage     / legend_done (char)            : NEW required: required, req_default: function

--- a/addons/hr_timesheet/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/hr_timesheet/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -6,12 +6,12 @@ hr_timesheet / hr.employee              / currency_id (many2one)        : previo
 hr_timesheet / hr.employee              / timesheet_cost (float)        : previously in module sale_timesheet
 hr_timesheet / project.project          / analytic_account_id (many2one): previously in module project
 hr_timesheet / project.task             / children_hours (float)        : was renamed to subtask_effective_hours [nothing to do]
-hr_timesheet / project.task             / delay_hours (float)           : DEL 
+hr_timesheet / project.task             / delay_hours (float)           : DEL
 hr_timesheet / project.task             / remaining_hours (float)       : previously in module project
-hr_timesheet / project.task             / total_hours (float)           : DEL 
+hr_timesheet / project.task             / total_hours (float)           : DEL
 hr_timesheet / res.company              / project_time_mode_id (many2one): previously in module project
 hr_timesheet / res.company              / timesheet_encode_uom_id (many2one): NEW relation: uom.uom, required: required, req_default: function
-hr_timesheet / uom.uom                  / timesheet_widget (char)       : NEW 
+hr_timesheet / uom.uom                  / timesheet_widget (char)       : NEW
 ---XML records in module 'hr_timesheet'---
 NEW ir.actions.act_window.view: hr_timesheet.timesheet_action_view_from_employee_form
 NEW ir.actions.act_window.view: hr_timesheet.timesheet_action_view_from_employee_list

--- a/addons/l10n_be_hr_payroll/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/l10n_be_hr_payroll/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,11 +1,11 @@
 ---Fields in module 'l10n_be_hr_payroll'---
 l10n_be_hr_payroll / hr.contract              / final_yearly_costs (float)    : is now stored
-l10n_be_hr_payroll / hr.contract              / ip (boolean)                  : NEW 
-l10n_be_hr_payroll / hr.contract              / ip_wage_rate (float)          : NEW 
+l10n_be_hr_payroll / hr.contract              / ip (boolean)                  : NEW
+l10n_be_hr_payroll / hr.contract              / ip_wage_rate (float)          : NEW
 l10n_be_hr_payroll / hr.contract              / transport_mode (selection)    : DEL selection_keys: ['company_car', 'others', 'public_transport']
-l10n_be_hr_payroll / hr.contract              / transport_mode_car (boolean)  : NEW 
-l10n_be_hr_payroll / hr.contract              / transport_mode_others (boolean): NEW 
-l10n_be_hr_payroll / hr.contract              / transport_mode_public (boolean): NEW 
+l10n_be_hr_payroll / hr.contract              / transport_mode_car (boolean)  : NEW
+l10n_be_hr_payroll / hr.contract              / transport_mode_others (boolean): NEW
+l10n_be_hr_payroll / hr.contract              / transport_mode_public (boolean): NEW
 ---XML records in module 'l10n_be_hr_payroll'---
 NEW hr.salary.rule: hr_payroll.hr_rule_basic
 NEW hr.salary.rule: l10n_be_hr_payroll.hr_salary_rule_gross_with_ip

--- a/addons/l10n_ch/migrations/12.0.10.0/openupgrade_analysis.txt
+++ b/addons/l10n_ch/migrations/12.0.10.0/openupgrade_analysis.txt
@@ -1,6 +1,6 @@
 ---Fields in module 'l10n_ch'---
-l10n_ch      / res.partner.bank         / l10n_ch_postal (char)         : not a function anymore
 l10n_ch      / res.partner.bank         / l10n_ch_postal (char)         : is now stored
+l10n_ch      / res.partner.bank         / l10n_ch_postal (char)         : not a function anymore
 ---XML records in module 'l10n_ch'---
 DEL account.account.tag: l10n_ch.vat_tag_301_a
 DEL account.account.tag: l10n_ch.vat_tag_301_b

--- a/addons/l10n_cn_small_business/migrations/12.0.1.8/openupgrade_analysis.txt
+++ b/addons/l10n_cn_small_business/migrations/12.0.1.8/openupgrade_analysis.txt
@@ -4,81 +4,81 @@ DEL account.account.tag: l10n_cn_small_business.tax_tag1 (noupdate)
 DEL account.account.tag: l10n_cn_small_business.tax_tag2 (noupdate)
 DEL account.account.tag: l10n_cn_small_business.tax_tag3 (noupdate)
 DEL account.account.tag: l10n_cn_small_business.tax_tag4 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1012 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1101 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1121 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1122 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1123 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1131 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1132 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1221 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1231 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1401 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1402 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1403 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1404 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1405 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1406 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1407 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1408 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1471 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1501 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1502 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1503 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1511 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1512 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1521 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1531 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1601 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1602 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1603 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1604 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1605 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1606 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1701 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1702 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1703 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1711 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_1801 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2001 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2201 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2202 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2203 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2211 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2221 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2231 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2241 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2501 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2502 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2701 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2711 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2801 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_2901 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_4001 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_4002 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_4003 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_4101 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_4103 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_4104 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_5001 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_5101 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_5201 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_5301 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6001 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6051 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6101 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6111 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6301 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6401 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6402 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6403 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6601 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6602 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6603 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6701 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6711 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6801 (noupdate)
-NEW account.account.template: l10n_cn_small_business.l10n_cn_6901 (noupdate)
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1012
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1101
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1121
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1122
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1123
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1131
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1132
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1221
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1231
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1401
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1402
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1403
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1404
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1405
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1406
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1407
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1408
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1471
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1501
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1502
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1503
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1511
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1512
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1521
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1531
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1601
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1602
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1603
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1604
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1605
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1606
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1701
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1702
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1703
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1711
+NEW account.account.template: l10n_cn_small_business.l10n_cn_1801
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2001
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2201
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2202
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2203
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2211
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2221
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2231
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2241
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2501
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2502
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2701
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2711
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2801
+NEW account.account.template: l10n_cn_small_business.l10n_cn_2901
+NEW account.account.template: l10n_cn_small_business.l10n_cn_4001
+NEW account.account.template: l10n_cn_small_business.l10n_cn_4002
+NEW account.account.template: l10n_cn_small_business.l10n_cn_4003
+NEW account.account.template: l10n_cn_small_business.l10n_cn_4101
+NEW account.account.template: l10n_cn_small_business.l10n_cn_4103
+NEW account.account.template: l10n_cn_small_business.l10n_cn_4104
+NEW account.account.template: l10n_cn_small_business.l10n_cn_5001
+NEW account.account.template: l10n_cn_small_business.l10n_cn_5101
+NEW account.account.template: l10n_cn_small_business.l10n_cn_5201
+NEW account.account.template: l10n_cn_small_business.l10n_cn_5301
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6001
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6051
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6101
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6111
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6301
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6401
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6402
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6403
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6601
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6602
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6603
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6701
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6711
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6801
+NEW account.account.template: l10n_cn_small_business.l10n_cn_6901
 DEL account.account.template: l10n_cn_small_business.small_business_chart1012 (noupdate)
 DEL account.account.template: l10n_cn_small_business.small_business_chart1101 (noupdate)
 DEL account.account.template: l10n_cn_small_business.small_business_chart1121 (noupdate)

--- a/addons/l10n_it_edi/migrations/12.0.0.3/openupgrade_analysis.txt
+++ b/addons/l10n_it_edi/migrations/12.0.0.3/openupgrade_analysis.txt
@@ -1,0 +1,49 @@
+---Fields in module 'l10n_it_edi'---
+l10n_it_edi  / account.invoice          / l10n_it_ddt_id (many2one)     : NEW relation: l10n_it.ddt
+l10n_it_edi  / account.invoice          / l10n_it_einvoice_id (many2one): NEW relation: ir.attachment
+l10n_it_edi  / account.invoice          / l10n_it_einvoice_name (char)  : NEW
+l10n_it_edi  / account.invoice          / l10n_it_send_state (selection): NEW selection_keys: ['delivered', 'delivered_accepted', 'delivered_expired', 'delivered_refused', 'failed_delivery', 'invalid', 'new', 'other', 'sent', 'to_send']
+l10n_it_edi  / account.invoice          / l10n_it_stamp_duty (float)    : NEW
+l10n_it_edi  / account.tax              / l10n_it_has_exoneration (boolean): NEW
+l10n_it_edi  / account.tax              / l10n_it_kind_exoneration (selection): NEW selection_keys: ['N1', 'N2', 'N3', 'N4', 'N5', 'N6', 'N7']
+l10n_it_edi  / account.tax              / l10n_it_law_reference (char)  : NEW
+l10n_it_edi  / account.tax              / l10n_it_vat_due_date (selection): NEW selection_keys: ['D', 'I', 'S']
+l10n_it_edi  / fetchmail.server         / l10n_it_is_pec (boolean)      : NEW
+l10n_it_edi  / fetchmail.server         / l10n_it_last_uid (integer)    : NEW
+l10n_it_edi  / l10n_it.ddt              / date (date)                   : NEW required: required
+l10n_it_edi  / l10n_it.ddt              / invoice_id (one2many)         : NEW relation: account.invoice
+l10n_it_edi  / l10n_it.ddt              / name (char)                   : NEW required: required
+l10n_it_edi  / res.company              / l10n_it_address_recipient_fatturapa (char): NEW
+l10n_it_edi  / res.company              / l10n_it_address_send_fatturapa (char): NEW
+l10n_it_edi  / res.company              / l10n_it_codice_fiscale (char) : NEW
+l10n_it_edi  / res.company              / l10n_it_eco_index_liquidation_state (selection): NEW selection_keys: ['LN', 'LS']
+l10n_it_edi  / res.company              / l10n_it_eco_index_number (char): NEW
+l10n_it_edi  / res.company              / l10n_it_eco_index_office (many2one): NEW relation: res.country.state
+l10n_it_edi  / res.company              / l10n_it_eco_index_share_capital (float): NEW
+l10n_it_edi  / res.company              / l10n_it_eco_index_sole_shareholder (selection): NEW selection_keys: ['NO', 'SM', 'SU']
+l10n_it_edi  / res.company              / l10n_it_has_eco_index (boolean): NEW
+l10n_it_edi  / res.company              / l10n_it_has_tax_representative (boolean): NEW
+l10n_it_edi  / res.company              / l10n_it_mail_pec_server_id (many2one): NEW relation: ir.mail_server
+l10n_it_edi  / res.company              / l10n_it_tax_representative_partner_id (many2one): NEW relation: res.partner
+l10n_it_edi  / res.company              / l10n_it_tax_system (selection): NEW selection_keys: ['RF01', 'RF02', 'RF04', 'RF05', 'RF06', 'RF07', 'RF08', 'RF09', 'RF10', 'RF11', 'RF12', 'RF13', 'RF14', 'RF15', 'RF16', 'RF17', 'RF18', 'RF19']
+l10n_it_edi  / res.partner              / l10n_it_codice_fiscale (char) : NEW
+l10n_it_edi  / res.partner              / l10n_it_pa_index (char)       : NEW
+l10n_it_edi  / res.partner              / l10n_it_pec_email (char)      : NEW
+---XML records in module 'l10n_it_edi'---
+NEW ir.actions.act_window: l10n_it_edi.action_ddt_account
+NEW ir.model.access: l10n_it_edi.access_it_ddt_manager
+NEW ir.ui.menu: l10n_it_edi.menu_action_ddt_account
+NEW ir.ui.view: l10n_it_edi.account_invoice_form_l10n_it
+NEW ir.ui.view: l10n_it_edi.account_invoice_it_FatturaPA_export
+NEW ir.ui.view: l10n_it_edi.account_invoice_it_FatturaPA_sede
+NEW ir.ui.view: l10n_it_edi.account_invoice_line_it_FatturaPA
+NEW ir.ui.view: l10n_it_edi.account_invoice_supplier_form_l10n_it
+NEW ir.ui.view: l10n_it_edi.account_tax_form_l10n_it
+NEW ir.ui.view: l10n_it_edi.fetchmail_server_form_l10n_it
+NEW ir.ui.view: l10n_it_edi.invoice_kanban_l10n_it
+NEW ir.ui.view: l10n_it_edi.invoice_supplier_tree_l10n_it
+NEW ir.ui.view: l10n_it_edi.l10n_it_ddt
+NEW ir.ui.view: l10n_it_edi.l10n_it_ddt_list_view
+NEW ir.ui.view: l10n_it_edi.res_company_form_l10n_it
+NEW ir.ui.view: l10n_it_edi.res_partner_form_l10n_it
+NEW ir.ui.view: l10n_it_edi.view_account_invoice_filter_l10n_it

--- a/addons/l10n_mx/migrations/12.0.2.0/openupgrade_analysis.txt
+++ b/addons/l10n_mx/migrations/12.0.2.0/openupgrade_analysis.txt
@@ -1,8 +1,8 @@
 ---Fields in module 'l10n_mx'---
 ---XML records in module 'l10n_mx'---
-NEW account.account.template: l10n_mx.cuenta107_05_01 (noupdate)
-NEW account.account.template: l10n_mx.cuenta205_06_01 (noupdate)
-NEW account.account.template: l10n_mx.cuenta206_05_01 (noupdate)
-NEW account.account.template: l10n_mx.cuenta801_01_99 (noupdate)
+NEW account.account.template: l10n_mx.cuenta107_05_01
+NEW account.account.template: l10n_mx.cuenta205_06_01
+NEW account.account.template: l10n_mx.cuenta206_05_01
+NEW account.account.template: l10n_mx.cuenta801_01_99
 DEL account.account.template: l10n_mx.cuenta102_01 (noupdate)
 NEW ir.ui.view: l10n_mx.view_account_journal_form_inherit

--- a/addons/l10n_sg/migrations/12.0.2.0/openupgrade_analysis.txt
+++ b/addons/l10n_sg/migrations/12.0.2.0/openupgrade_analysis.txt
@@ -1,7 +1,7 @@
 ---Fields in module 'l10n_sg'---
-l10n_sg      / account.invoice          / l10n_sg_permit_number (char)  : NEW 
-l10n_sg      / account.invoice          / l10n_sg_permit_number_date (date): NEW 
-l10n_sg      / res.partner              / l10n_sg_unique_entity_number (char): NEW 
+l10n_sg      / account.invoice          / l10n_sg_permit_number (char)  : NEW
+l10n_sg      / account.invoice          / l10n_sg_permit_number_date (date): NEW
+l10n_sg      / res.partner              / l10n_sg_unique_entity_number (char): NEW
 ---XML records in module 'l10n_sg'---
 NEW account.account.tag: l10n_sg.tag_sg_48 (noupdate)
 NEW account.account.tag: l10n_sg.tag_sg_49 (noupdate)

--- a/addons/mail/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/mail/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,53 +1,53 @@
 ---Fields in module 'mail'---
 mail         / ir.actions.act_window.view / view_mode (False)             : NEW selection_keys: ['activity', 'calendar', 'form', 'gantt', 'graph', 'kanban', 'pivot', 'tree'], mode: modify
-mail         / ir.actions.server        / activity_date_deadline_range (integer): NEW 
+mail         / ir.actions.server        / activity_date_deadline_range (integer): NEW
 mail         / ir.actions.server        / activity_date_deadline_range_type (selection): NEW selection_keys: ['days', 'months', 'weeks']
-mail         / ir.actions.server        / activity_note (html)          : NEW 
-mail         / ir.actions.server        / activity_summary (char)       : NEW 
+mail         / ir.actions.server        / activity_note (html)          : NEW
+mail         / ir.actions.server        / activity_summary (char)       : NEW
 mail         / ir.actions.server        / activity_type_id (many2one)   : NEW relation: mail.activity.type
-mail         / ir.actions.server        / activity_user_field_name (char): NEW 
+mail         / ir.actions.server        / activity_user_field_name (char): NEW
 mail         / ir.actions.server        / activity_user_id (many2one)   : NEW relation: res.users
 mail         / ir.actions.server        / activity_user_type (selection): NEW required: required, selection_keys: ['generic', 'specific'], req_default: function
 mail         / ir.actions.server        / state (False)                 : selection_keys is now '['code', 'email', 'followers', 'multi', 'next_activity', 'object_create', 'object_write']' ('['code', 'email', 'followers', 'multi', 'object_create', 'object_write']')
 mail         / ir.ui.view               / type (False)                  : NEW selection_keys: ['activity', 'calendar', 'diagram', 'form', 'gantt', 'graph', 'kanban', 'pivot', 'qweb', 'search', 'tree'], mode: modify
-mail         / mail.activity            / automated (boolean)           : NEW 
+mail         / mail.activity            / automated (boolean)           : NEW
 mail         / mail.activity            / create_user_id (many2one)     : NEW relation: res.users
-mail         / mail.activity.type       / active (boolean)              : NEW 
+mail         / mail.activity.type       / active (boolean)              : NEW
 mail         / mail.activity.type       / days (integer)                : was renamed to delay_count [nothing to do]
 mail         / mail.activity.type       / decoration_type (selection)   : NEW selection_keys: ['danger', 'warning']
 mail         / mail.activity.type       / default_next_type_id (many2one): NEW relation: mail.activity.type
 mail         / mail.activity.type       / delay_from (selection)        : NEW required: required, selection_keys: ['current_date', 'previous_activity'], req_default: function
 mail         / mail.activity.type       / delay_unit (selection)        : NEW required: required, selection_keys: ['days', 'months', 'weeks'], req_default: function
-mail         / mail.activity.type       / force_next (boolean)          : NEW 
+mail         / mail.activity.type       / force_next (boolean)          : NEW
 mail         / mail.activity.type       / mail_template_ids (many2many) : NEW relation: mail.template
-mail         / mail.activity.type       / res_model_change (boolean)    : NEW 
-mail         / mail.blacklist           / active (boolean)              : NEW 
+mail         / mail.activity.type       / res_model_change (boolean)    : NEW
+mail         / mail.blacklist           / active (boolean)              : NEW
 mail         / mail.blacklist           / email (char)                  : NEW required: required
 mail         / mail.blacklist           / message_follower_ids (one2many): NEW relation: mail.followers
 mail         / mail.blacklist           / message_ids (one2many)        : NEW relation: mail.message
 mail         / mail.blacklist           / message_main_attachment_id (many2one): NEW relation: ir.attachment
-mail         / mail.channel             / message_last_post (datetime)  : DEL 
+mail         / mail.channel             / message_last_post (datetime)  : DEL
 mail         / mail.channel             / message_main_attachment_id (many2one): NEW relation: ir.attachment
-mail         / mail.channel             / moderation (boolean)          : NEW 
-mail         / mail.channel             / moderation_guidelines (boolean): NEW 
-mail         / mail.channel             / moderation_guidelines_msg (text): NEW 
+mail         / mail.channel             / moderation (boolean)          : NEW
+mail         / mail.channel             / moderation_guidelines (boolean): NEW
+mail         / mail.channel             / moderation_guidelines_msg (text): NEW
 mail         / mail.channel             / moderation_ids (one2many)     : NEW relation: mail.moderation
-mail         / mail.channel             / moderation_notify (boolean)   : NEW 
-mail         / mail.channel             / moderation_notify_msg (text)  : NEW 
+mail         / mail.channel             / moderation_notify (boolean)   : NEW
+mail         / mail.channel             / moderation_notify_msg (text)  : NEW
 mail         / mail.channel             / moderator_ids (many2many)     : NEW relation: res.users
-mail         / mail.message             / add_sign (boolean)            : NEW 
-mail         / mail.message             / layout (char)                 : NEW 
+mail         / mail.message             / add_sign (boolean)            : NEW
+mail         / mail.message             / layout (char)                 : NEW
 mail         / mail.message             / moderation_status (selection) : NEW selection_keys: ['accepted', 'pending_moderation', 'rejected']
 mail         / mail.message             / moderator_id (many2one)       : NEW relation: res.users
 mail         / mail.moderation          / channel_id (many2one)         : NEW relation: mail.channel, required: required
 mail         / mail.moderation          / email (char)                  : NEW required: required
 mail         / mail.moderation          / status (selection)            : NEW required: required, selection_keys: ['allow', 'ban']
 mail         / mail.notification        / email_status (selection)      : selection_keys is now '['bounce', 'canceled', 'exception', 'ready', 'sent']' ('['bounce', 'exception', 'ready', 'sent']')
-mail         / mail.notification        / failure_reason (text)         : NEW 
+mail         / mail.notification        / failure_reason (text)         : NEW
 mail         / mail.notification        / failure_type (selection)      : NEW selection_keys: ['BOUNCE', 'RECIPIENT', 'SMTP', 'UNKNOWN']
 mail         / mail.notification        / mail_id (many2one)            : NEW relation: mail.mail
 mail         / mail.shortcode           / shortcode_type (selection)    : DEL required: required, selection_keys: ['image', 'text'], req_default: function
-mail         / mail.shortcode           / unicode_source (char)         : DEL 
+mail         / mail.shortcode           / unicode_source (char)         : DEL
 mail         / mail.test                / __last_update (datetime)      : module is now 'test_mail' ('mail')
 mail         / mail.test                / _inherits (False)             : module is now 'test_mail' ('mail')
 mail         / mail.test                / alias_contact (selection)     : module is now 'test_mail' ('mail')
@@ -66,7 +66,7 @@ mail         / mail.test                / message_channel_ids (many2many): modul
 mail         / mail.test                / message_follower_ids (one2many): module is now 'test_mail' ('mail')
 mail         / mail.test                / message_ids (one2many)        : module is now 'test_mail' ('mail')
 mail         / mail.test                / message_is_follower (boolean) : module is now 'test_mail' ('mail')
-mail         / mail.test                / message_last_post (datetime)  : DEL 
+mail         / mail.test                / message_last_post (datetime)  : DEL
 mail         / mail.test                / message_needaction (boolean)  : module is now 'test_mail' ('mail')
 mail         / mail.test                / message_needaction_counter (integer): module is now 'test_mail' ('mail')
 mail         / mail.test                / message_partner_ids (many2many): module is now 'test_mail' ('mail')
@@ -74,27 +74,27 @@ mail         / mail.test                / message_unread (boolean)      : module
 mail         / mail.test                / message_unread_counter (integer): module is now 'test_mail' ('mail')
 mail         / mail.test                / name (char)                   : module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / __last_update (datetime)      : module is now 'test_mail' ('mail')
-mail         / mail.test.simple         / description (text)            : DEL 
+mail         / mail.test.simple         / description (text)            : DEL
 mail         / mail.test.simple         / display_name (char)           : module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / email_from (char)             : module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / message_channel_ids (many2many): module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / message_follower_ids (one2many): module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / message_ids (one2many)        : module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / message_is_follower (boolean) : module is now 'test_mail' ('mail')
-mail         / mail.test.simple         / message_last_post (datetime)  : DEL 
+mail         / mail.test.simple         / message_last_post (datetime)  : DEL
 mail         / mail.test.simple         / message_needaction (boolean)  : module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / message_needaction_counter (integer): module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / message_partner_ids (many2many): module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / message_unread (boolean)      : module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / message_unread_counter (integer): module is now 'test_mail' ('mail')
 mail         / mail.test.simple         / name (char)                   : module is now 'test_mail' ('mail')
-mail         / mail.tracking.value      / track_sequence (integer)      : NEW 
+mail         / mail.tracking.value      / track_sequence (integer)      : NEW
 mail         / res.partner              / activity_date_deadline (date) : not related anymore
 mail         / res.partner              / activity_date_deadline (date) : not stored anymore
 mail         / res.partner              / activity_date_deadline (date) : now a function
-mail         / res.partner              / message_last_post (datetime)  : DEL 
+mail         / res.partner              / message_last_post (datetime)  : DEL
 mail         / res.partner              / message_main_attachment_id (many2one): NEW relation: ir.attachment
-mail         / res.partner              / opt_out (boolean)             : DEL 
+mail         / res.partner              / opt_out (boolean)             : DEL
 mail         / res.users                / moderation_channel_ids (many2many): NEW relation: mail.channel
 ---XML records in module 'mail'---
 NEW ir.actions.act_window: base.action_partner_customer_form

--- a/addons/maintenance/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/maintenance/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -4,20 +4,20 @@ maintenance  / maintenance.equipment    / activity_date_deadline (date) : not st
 maintenance  / maintenance.equipment    / activity_date_deadline (date) : now a function
 maintenance  / maintenance.equipment    / company_id (many2one)         : NEW relation: res.company
 maintenance  / maintenance.equipment    / effective_date (date)         : NEW required: required, req_default: function
-maintenance  / maintenance.equipment    / message_last_post (datetime)  : DEL 
+maintenance  / maintenance.equipment    / message_last_post (datetime)  : DEL
 maintenance  / maintenance.equipment    / message_main_attachment_id (many2one): NEW relation: ir.attachment
 maintenance  / maintenance.equipment    / warranty (date)               : was renamed to warranty_date [nothing to do]
 maintenance  / maintenance.equipment.category / company_id (many2one)         : NEW relation: res.company
-maintenance  / maintenance.equipment.category / message_last_post (datetime)  : DEL 
+maintenance  / maintenance.equipment.category / message_last_post (datetime)  : DEL
 maintenance  / maintenance.equipment.category / message_main_attachment_id (many2one): NEW relation: ir.attachment
 maintenance  / maintenance.request      / activity_date_deadline (date) : not related anymore
 maintenance  / maintenance.request      / activity_date_deadline (date) : not stored anymore
 maintenance  / maintenance.request      / activity_date_deadline (date) : now a function
 maintenance  / maintenance.request      / company_id (many2one)         : NEW relation: res.company
-maintenance  / maintenance.request      / message_last_post (datetime)  : DEL 
+maintenance  / maintenance.request      / message_last_post (datetime)  : DEL
 maintenance  / maintenance.request      / message_main_attachment_id (many2one): NEW relation: ir.attachment
 maintenance  / maintenance.request      / technician_user_id (many2one) : was renamed to user_id [nothing to do]
-maintenance  / maintenance.team         / active (boolean)              : NEW 
+maintenance  / maintenance.team         / active (boolean)              : NEW
 maintenance  / maintenance.team         / company_id (many2one)         : NEW relation: res.company
 ---XML records in module 'maintenance'---
 NEW ir.actions.act_window: maintenance.mail_activity_type_action_config_maintenance

--- a/addons/mass_mailing/migrations/12.0.2.0/openupgrade_analysis.txt
+++ b/addons/mass_mailing/migrations/12.0.2.0/openupgrade_analysis.txt
@@ -1,24 +1,24 @@
 ---Fields in module 'mass_mailing'---
-mass_mailing / mail.mail.statistics     / email (char)                  : NEW 
-mass_mailing / mail.mail.statistics     / ignored (datetime)            : NEW 
+mass_mailing / mail.mail.statistics     / email (char)                  : NEW
+mass_mailing / mail.mail.statistics     / ignored (datetime)            : NEW
 mass_mailing / mail.mail.statistics     / state (selection)             : selection_keys is now '['bounced', 'exception', 'ignored', 'opened', 'outgoing', 'replied', 'sent']' ('['bounced', 'exception', 'opened', 'outgoing', 'replied', 'sent']')
 mass_mailing / mail.mass_mailing        / mail_server_id (many2one)     : NEW relation: ir.mail_server
 mass_mailing / mail.mass_mailing        / user_id (many2one)            : NEW relation: res.users
-mass_mailing / mail.mass_mailing.contact / is_email_valid (boolean)      : NEW 
-mass_mailing / mail.mass_mailing.contact / message_last_post (datetime)  : DEL 
+mass_mailing / mail.mass_mailing.contact / is_email_valid (boolean)      : NEW
+mass_mailing / mail.mass_mailing.contact / message_last_post (datetime)  : DEL
 mass_mailing / mail.mass_mailing.contact / message_main_attachment_id (many2one): NEW relation: ir.attachment
 mass_mailing / mail.mass_mailing.contact / opt_out (boolean)             : not stored anymore
 mass_mailing / mail.mass_mailing.contact / opt_out (boolean)             : now a function
 mass_mailing / mail.mass_mailing.contact / subscription_list_ids (one2many): NEW relation: mail.mass_mailing.list_contact_rel
-mass_mailing / mail.mass_mailing.contact / unsubscription_date (datetime): DEL 
+mass_mailing / mail.mass_mailing.contact / unsubscription_date (datetime): DEL
 mass_mailing / mail.mass_mailing.contact / website_message_ids (one2many): previously in module portal
 mass_mailing / mail.mass_mailing.list   / contact_ids (many2many)       : NEW relation: mail.mass_mailing.contact
-mass_mailing / mail.mass_mailing.list   / is_public (boolean)           : NEW 
+mass_mailing / mail.mass_mailing.list   / is_public (boolean)           : NEW
 mass_mailing / mail.mass_mailing.list   / subscription_contact_ids (one2many): NEW relation: mail.mass_mailing.list_contact_rel
 mass_mailing / mail.mass_mailing.list_contact_rel / contact_id (many2one)         : NEW relation: mail.mass_mailing.contact, required: required
 mass_mailing / mail.mass_mailing.list_contact_rel / list_id (many2one)            : NEW relation: mail.mass_mailing.list, required: required
-mass_mailing / mail.mass_mailing.list_contact_rel / opt_out (boolean)             : NEW 
-mass_mailing / mail.mass_mailing.list_contact_rel / unsubscription_date (datetime): NEW 
+mass_mailing / mail.mass_mailing.list_contact_rel / opt_out (boolean)             : NEW
+mass_mailing / mail.mass_mailing.list_contact_rel / unsubscription_date (datetime): NEW
 mass_mailing / res.company              / social_facebook (char)        : module is now 'social_media' ('mass_mailing')
 mass_mailing / res.company              / social_github (char)          : module is now 'social_media' ('mass_mailing')
 mass_mailing / res.company              / social_googleplus (char)      : module is now 'social_media' ('mass_mailing')

--- a/addons/mrp/migrations/12.0.2.0/openupgrade_analysis.txt
+++ b/addons/mrp/migrations/12.0.2.0/openupgrade_analysis.txt
@@ -1,28 +1,28 @@
 ---Fields in module 'mrp'---
-mrp          / mrp.bom                  / message_last_post (datetime)  : DEL 
+mrp          / mrp.bom                  / message_last_post (datetime)  : DEL
 mrp          / mrp.bom                  / message_main_attachment_id (many2one): NEW relation: ir.attachment
 mrp          / mrp.bom                  / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
 mrp          / mrp.bom.line             / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
 mrp          / mrp.production           / activity_date_deadline (date) : not related anymore
 mrp          / mrp.production           / activity_date_deadline (date) : not stored anymore
 mrp          / mrp.production           / activity_date_deadline (date) : now a function
-mrp          / mrp.production           / message_last_post (datetime)  : DEL 
+mrp          / mrp.production           / message_last_post (datetime)  : DEL
 mrp          / mrp.production           / message_main_attachment_id (many2one): NEW relation: ir.attachment
 mrp          / mrp.production           / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
-mrp          / mrp.production           / product_uom_qty (float)       : NEW 
+mrp          / mrp.production           / product_uom_qty (float)       : NEW
 mrp          / mrp.unbuild              / activity_date_deadline (date) : not related anymore
 mrp          / mrp.unbuild              / activity_date_deadline (date) : not stored anymore
 mrp          / mrp.unbuild              / activity_date_deadline (date) : now a function
-mrp          / mrp.unbuild              / message_last_post (datetime)  : DEL 
+mrp          / mrp.unbuild              / message_last_post (datetime)  : DEL
 mrp          / mrp.unbuild              / message_main_attachment_id (many2one): NEW relation: ir.attachment
 mrp          / mrp.unbuild              / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
-mrp          / mrp.workcenter           / costs_hour (float)            : NEW 
+mrp          / mrp.workcenter           / costs_hour (float)            : NEW
 mrp          / mrp.workcenter           / resource_calendar_id (many2one): is now stored
 mrp          / mrp.workcenter.productivity.loss / loss_id (many2one)            : NEW relation: mrp.workcenter.productivity.loss.type
 mrp          / mrp.workcenter.productivity.loss / loss_type (selection)         : now related
 mrp          / mrp.workcenter.productivity.loss / loss_type (selection)         : selection_keys is now 'function' ('['availability', 'performance', 'productive', 'quality']')
 mrp          / mrp.workcenter.productivity.loss.type / loss_type (selection)         : NEW required: required, selection_keys: ['availability', 'performance', 'productive', 'quality'], req_default: function
-mrp          / mrp.workorder            / message_last_post (datetime)  : DEL 
+mrp          / mrp.workorder            / message_last_post (datetime)  : DEL
 mrp          / mrp.workorder            / message_main_attachment_id (many2one): NEW relation: ir.attachment
 mrp          / mrp.workorder            / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
 mrp          / procurement.rule         / action (False)                : selection_keys is now '['manufacture', 'pull', 'pull_push', 'push']' ('['manufacture', 'move']')

--- a/addons/note/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/note/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -4,7 +4,7 @@ note         / mail.activity.type       / category (False)              : NEW se
 note         / note.note                / activity_date_deadline (date) : not related anymore
 note         / note.note                / activity_date_deadline (date) : not stored anymore
 note         / note.note                / activity_date_deadline (date) : now a function
-note         / note.note                / message_last_post (datetime)  : DEL 
+note         / note.note                / message_last_post (datetime)  : DEL
 note         / note.note                / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'note'---
 NEW ir.ui.view: note.mail_activity_type_view_form

--- a/addons/partner_autocomplete/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/partner_autocomplete/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,9 +1,9 @@
 ---Fields in module 'partner_autocomplete'---
-partner_autocomplete / res.company              / partner_gid (integer)         : NEW 
-partner_autocomplete / res.partner              / additional_info (char)        : NEW 
-partner_autocomplete / res.partner              / partner_gid (integer)         : NEW 
+partner_autocomplete / res.company              / partner_gid (integer)         : NEW
+partner_autocomplete / res.partner              / additional_info (char)        : NEW
+partner_autocomplete / res.partner              / partner_gid (integer)         : NEW
 partner_autocomplete / res.partner.autocomplete.sync / partner_id (many2one)         : NEW relation: res.partner
-partner_autocomplete / res.partner.autocomplete.sync / synched (boolean)             : NEW 
+partner_autocomplete / res.partner.autocomplete.sync / synched (boolean)             : NEW
 ---XML records in module 'partner_autocomplete'---
 NEW ir.cron: partner_autocomplete.ir_cron_partner_autocomplete
 NEW ir.model.access: partner_autocomplete.access_partner_autocomplete_sync_all_all

--- a/addons/payment/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/payment/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,12 +1,12 @@
 ---Fields in module 'payment'---
 payment      / account.invoice          / transaction_ids (many2many)   : NEW relation: payment.transaction
-payment      / payment.acquirer         / qr_code (boolean)             : NEW 
-payment      / payment.transaction      / date (datetime)               : NEW 
-payment      / payment.transaction      / date_validate (datetime)      : DEL 
+payment      / payment.acquirer         / qr_code (boolean)             : NEW
+payment      / payment.transaction      / date (datetime)               : NEW
+payment      / payment.transaction      / date_validate (datetime)      : DEL
 payment      / payment.transaction      / invoice_ids (many2many)       : NEW relation: account.invoice
-payment      / payment.transaction      / is_processed (boolean)        : NEW 
+payment      / payment.transaction      / is_processed (boolean)        : NEW
 payment      / payment.transaction      / payment_id (many2one)         : NEW relation: account.payment
-payment      / payment.transaction      / return_url (char)             : NEW 
+payment      / payment.transaction      / return_url (char)             : NEW
 payment      / payment.transaction      / state (selection)             : selection_keys is now '['authorized', 'cancel', 'done', 'draft', 'error', 'pending']' ('['authorized', 'cancel', 'done', 'draft', 'error', 'pending', 'refunded', 'refunding']')
 payment      / res.company              / payment_acquirer_onboarding_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
 payment      / res.company              / payment_onboarding_payment_method (selection): NEW selection_keys: ['manual', 'other', 'paypal', 'stripe']

--- a/addons/point_of_sale/migrations/12.0.1.0.1/openupgrade_analysis.txt
+++ b/addons/point_of_sale/migrations/12.0.1.0.1/openupgrade_analysis.txt
@@ -1,28 +1,27 @@
 ---Fields in module 'point_of_sale'---
-point_of_sale / digest.digest            / kpi_pos_total (boolean)       : NEW 
-point_of_sale / pos.config               / group_pricelist_item (boolean): DEL 
-point_of_sale / pos.config               / group_sale_pricelist (boolean): DEL 
-point_of_sale / pos.config               / iface_invoicing (boolean)     : DEL 
-point_of_sale / pos.config               / module_account (boolean)      : NEW 
-point_of_sale / pos.order                / amount_paid (float)           : not a function anymore
+point_of_sale / digest.digest            / kpi_pos_total (boolean)       : NEW
+point_of_sale / pos.config               / group_pricelist_item (boolean): DEL
+point_of_sale / pos.config               / group_sale_pricelist (boolean): DEL
+point_of_sale / pos.config               / iface_invoicing (boolean)     : DEL
+point_of_sale / pos.config               / module_account (boolean)      : NEW
 point_of_sale / pos.order                / amount_paid (float)           : is now stored
+point_of_sale / pos.order                / amount_paid (float)           : not a function anymore
 point_of_sale / pos.order                / amount_paid (float)           : now required
-point_of_sale / pos.order                / amount_return (float)         : not a function anymore
 point_of_sale / pos.order                / amount_return (float)         : is now stored
+point_of_sale / pos.order                / amount_return (float)         : not a function anymore
 point_of_sale / pos.order                / amount_return (float)         : now required
-point_of_sale / pos.order                / amount_tax (float)            : not a function anymore
 point_of_sale / pos.order                / amount_tax (float)            : is now stored
+point_of_sale / pos.order                / amount_tax (float)            : not a function anymore
 point_of_sale / pos.order                / amount_tax (float)            : now required
-point_of_sale / pos.order                / amount_total (float)          : not a function anymore
 point_of_sale / pos.order                / amount_total (float)          : is now stored
+point_of_sale / pos.order                / amount_total (float)          : not a function anymore
 point_of_sale / pos.order                / amount_total (float)          : now required
-point_of_sale / pos.order.line           / price_subtotal (float)        : not a function anymore
 point_of_sale / pos.order.line           / price_subtotal (float)        : is now stored
+point_of_sale / pos.order.line           / price_subtotal (float)        : not a function anymore
 point_of_sale / pos.order.line           / price_subtotal (float)        : now required
-point_of_sale / pos.order.line           / price_subtotal_incl (float)   : not a function anymore
 point_of_sale / pos.order.line           / price_subtotal_incl (float)   : is now stored
+point_of_sale / pos.order.line           / price_subtotal_incl (float)   : not a function anymore
 point_of_sale / pos.order.line           / price_subtotal_incl (float)   : now required
-point_of_sale / uom.category             / is_pos_groupable (boolean)    : NEW 
 ---XML records in module 'point_of_sale'---
 NEW digest.digest: digest.digest_digest_default (noupdate)
 NEW ir.actions.act_window: point_of_sale.action_pos_configuration
@@ -33,10 +32,11 @@ DEL ir.model.access: point_of_sale.access_product_uom_manager
 NEW ir.ui.menu: point_of_sale.menu_point_of_sale_customer
 NEW ir.ui.menu: point_of_sale.menu_pos_global_settings
 NEW ir.ui.view: point_of_sale.digest_digest_view_form
+NEW ir.ui.view: point_of_sale.pos_assets_backend
 NEW ir.ui.view: point_of_sale.res_config_settings_view_form
 NEW ir.ui.view: point_of_sale.res_users_view_form
 DEL ir.ui.view: point_of_sale.res_users_form_view
 DEL ir.ui.view: point_of_sale.view_pos_discount
 NEW product.category: point_of_sale.product_category_pos (noupdate)
-DEL product.uom.categ: product.product_uom_categ_unit (noupdate)
-NEW uom.category: uom.product_uom_categ_unit (noupdate)
+DEL product.uom.categ: product.product_uom_categ_unit [renamed to point_of_sale module] (noupdate)
+NEW uom.category: uom.product_uom_categ_unit [renamed from point_of_sale module] (noupdate)

--- a/addons/pos_sale/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/pos_sale/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,3 +1,3 @@
 ---Fields in module 'pos_sale'---
-pos_sale     / pos.order                / currency_rate (float)         : NEW 
+pos_sale     / pos.order                / currency_rate (float)         : NEW
 ---XML records in module 'pos_sale'---

--- a/addons/product/migrations/12.0.1.2/openupgrade_analysis.txt
+++ b/addons/product/migrations/12.0.1.2/openupgrade_analysis.txt
@@ -6,14 +6,14 @@ product      / product.attribute        / create_variant (boolean)      : type i
 product      / product.attribute.price  / value_id (many2one)           : DEL relation: product.attribute.value, required: required
 product      / product.attribute.value  / price_ids (one2many)          : DEL relation: product.attribute.price
 product      / product.attribute.value  / product_ids (many2many)       : DEL relation: product.product
-product      / product.category         / parent_left (integer)         : DEL 
-product      / product.category         / parent_path (char)            : NEW 
-product      / product.category         / parent_right (integer)        : DEL 
+product      / product.category         / parent_left (integer)         : DEL
+product      / product.category         / parent_path (char)            : NEW
+product      / product.category         / parent_right (integer)        : DEL
 product      / product.product          / activity_date_deadline (date) : not related anymore
 product      / product.product          / activity_date_deadline (date) : not stored anymore
 product      / product.product          / activity_date_deadline (date) : now a function
 product      / product.product          / attribute_line_ids (one2many) : relation is now 'product.template.attribute.line' ('product.attribute.line')
-product      / product.product          / message_last_post (datetime)  : DEL 
+product      / product.product          / message_last_post (datetime)  : DEL
 product      / product.product          / message_main_attachment_id (many2one): NEW relation: ir.attachment
 product      / product.product          / uom_id (many2one)             : relation is now 'uom.uom' ('product.uom')
 product      / product.product          / uom_po_id (many2one)          : relation is now 'uom.uom' ('product.uom')
@@ -22,7 +22,7 @@ product      / product.template         / activity_date_deadline (date) : not re
 product      / product.template         / activity_date_deadline (date) : not stored anymore
 product      / product.template         / activity_date_deadline (date) : now a function
 product      / product.template         / attribute_line_ids (one2many) : relation is now 'product.template.attribute.line' ('product.attribute.line')
-product      / product.template         / message_last_post (datetime)  : DEL 
+product      / product.template         / message_last_post (datetime)  : DEL
 product      / product.template         / message_main_attachment_id (many2one): NEW relation: ir.attachment
 product      / product.template         / uom_id (many2one)             : relation is now 'uom.uom' ('product.uom')
 product      / product.template         / uom_po_id (many2one)          : relation is now 'uom.uom' ('product.uom')
@@ -41,6 +41,9 @@ product      / product.uom              / factor_inv (float)            : module
 product      / product.uom              / name (char)                   : module is now 'uom' ('product')
 product      / product.uom              / rounding (float)              : module is now 'uom' ('product')
 product      / product.uom              / uom_type (selection)          : module is now 'uom' ('product')
+product      / product.uom.categ        / __last_update (datetime)      : module is now 'uom' ('product')
+product      / product.uom.categ        / display_name (char)           : module is now 'uom' ('product')
+product      / product.uom.categ        / name (char)                   : module is now 'uom' ('product')
 ---XML records in module 'product'---
 DEL ir.actions.act_window: product.product_uom_categ_form_action
 DEL ir.actions.act_window: product.product_uom_form_action
@@ -83,29 +86,29 @@ DEL ir.ui.view: product.product_uom_categ_form_view
 DEL ir.ui.view: product.product_uom_form_view
 DEL ir.ui.view: product.product_uom_tree_view
 NEW product.category: product.cat_expense (noupdate)
-DEL product.uom: product.product_uom_cm (noupdate)
-DEL product.uom: product.product_uom_day (noupdate)
-DEL product.uom: product.product_uom_dozen (noupdate)
-DEL product.uom: product.product_uom_floz (noupdate)
-DEL product.uom: product.product_uom_foot (noupdate)
-DEL product.uom: product.product_uom_gal (noupdate)
-DEL product.uom: product.product_uom_gram (noupdate)
-DEL product.uom: product.product_uom_hour (noupdate)
-DEL product.uom: product.product_uom_inch (noupdate)
-DEL product.uom: product.product_uom_kgm (noupdate)
-DEL product.uom: product.product_uom_km (noupdate)
-DEL product.uom: product.product_uom_lb (noupdate)
-DEL product.uom: product.product_uom_litre (noupdate)
-DEL product.uom: product.product_uom_meter (noupdate)
-DEL product.uom: product.product_uom_mile (noupdate)
-DEL product.uom: product.product_uom_oz (noupdate)
-DEL product.uom: product.product_uom_qt (noupdate)
-DEL product.uom: product.product_uom_ton (noupdate)
-DEL product.uom: product.product_uom_unit (noupdate)
-DEL product.uom.categ: product.product_uom_categ_kgm (noupdate)
-DEL product.uom.categ: product.product_uom_categ_unit (noupdate)
-DEL product.uom.categ: product.product_uom_categ_vol (noupdate)
-DEL product.uom.categ: product.uom_categ_length (noupdate)
-DEL product.uom.categ: product.uom_categ_wtime (noupdate)
+DEL product.uom: product.product_uom_cm [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_day [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_dozen [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_floz [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_foot [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_gal [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_gram [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_hour [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_inch [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_kgm [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_km [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_lb [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_litre [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_meter [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_mile [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_oz [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_qt [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_ton [renamed to uom module] (noupdate)
+DEL product.uom: product.product_uom_unit [renamed to uom module] (noupdate)
+DEL product.uom.categ: product.product_uom_categ_kgm [renamed to uom module] (noupdate)
+DEL product.uom.categ: product.product_uom_categ_unit [renamed to uom module] (noupdate)
+DEL product.uom.categ: product.product_uom_categ_vol [renamed to uom module] (noupdate)
+DEL product.uom.categ: product.uom_categ_length [renamed to uom module] (noupdate)
+DEL product.uom.categ: product.uom_categ_wtime [renamed to uom module] (noupdate)
 DEL res.groups: product.group_uom
 DEL res.request.link: product.req_link_product (noupdate)

--- a/addons/project/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/project/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -3,22 +3,22 @@ project      / account.analytic.account / company_uom_id (many2one)     : module
 project      / account.analytic.account / company_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
 project      / account.analytic.account / project_count (integer)       : module is now 'hr_timesheet' ('project')
 project      / account.analytic.account / project_ids (one2many)        : module is now 'hr_timesheet' ('project')
-project      / digest.digest            / kpi_project_task_opened (boolean): NEW 
-project      / project.project          / access_token (char)           : NEW 
+project      / digest.digest            / kpi_project_task_opened (boolean): NEW
+project      / project.project          / access_token (char)           : NEW
 project      / project.project          / analytic_account_id (many2one): module is now 'hr_timesheet' ('project')
-project      / project.project          / company_id (many2one)         : not related anymore
 project      / project.project          / company_id (many2one)         : is now stored
-project      / project.project          / message_last_post (datetime)  : DEL 
+project      / project.project          / company_id (many2one)         : not related anymore
+project      / project.project          / message_last_post (datetime)  : DEL
 project      / project.project          / message_main_attachment_id (many2one): NEW relation: ir.attachment
-project      / project.project          / name (char)                   : not related anymore
 project      / project.project          / name (char)                   : is now stored
-project      / project.project          / partner_id (many2one)         : not related anymore
+project      / project.project          / name (char)                   : not related anymore
 project      / project.project          / partner_id (many2one)         : is now stored
-project      / project.task             / access_token (char)           : NEW 
+project      / project.project          / partner_id (many2one)         : not related anymore
+project      / project.task             / access_token (char)           : NEW
 project      / project.task             / activity_date_deadline (date) : not related anymore
 project      / project.task             / activity_date_deadline (date) : not stored anymore
 project      / project.task             / activity_date_deadline (date) : now a function
-project      / project.task             / message_last_post (datetime)  : DEL 
+project      / project.task             / message_last_post (datetime)  : DEL
 project      / project.task             / message_main_attachment_id (many2one): NEW relation: ir.attachment
 project      / project.task             / remaining_hours (float)       : module is now 'hr_timesheet' ('project')
 project      / project.task             / remaining_hours (float)       : now a function
@@ -89,7 +89,7 @@ NEW mail.template: project.rating_project_request_email_template (noupdate)
 DEL mail.template: project.mail_template_data_module_install_project (noupdate)
 DEL mail.template: rating_project.rating_project_request_email_template
 DEL project.task: project.project_task_data_8 (noupdate)
-DEL res.company: base.main_company (noupdate)
+DEL res.company: base.main_company [potentially moved to web module] (noupdate)
 NEW res.groups: project.group_project_rating
 DEL res.groups: project.group_time_work_estimation_tasks
 DEL res.request.link: project.req_link_project (noupdate)

--- a/addons/purchase/migrations/12.0.1.2/openupgrade_analysis.txt
+++ b/addons/purchase/migrations/12.0.1.2/openupgrade_analysis.txt
@@ -2,7 +2,7 @@
 purchase     / account.invoice          / vendor_bill_purchase_id (many2one): NEW relation: purchase.bill.union
 purchase     / procurement.rule         / action (False)                : module is now 'purchase_stock' ('purchase')
 purchase     / procurement.rule         / action (False)                : selection_keys is now '['buy', 'manufacture', 'pull', 'pull_push', 'push']' ('['buy', 'manufacture', 'move']')
-purchase     / purchase.order           / access_token (char)           : NEW 
+purchase     / purchase.order           / access_token (char)           : NEW
 purchase     / purchase.order           / activity_date_deadline (date) : not related anymore
 purchase     / purchase.order           / activity_date_deadline (date) : not stored anymore
 purchase     / purchase.order           / activity_date_deadline (date) : now a function
@@ -10,7 +10,7 @@ purchase     / purchase.order           / default_location_dest_id_usage (select
 purchase     / purchase.order           / group_id (many2one)           : module is now 'purchase_stock' ('purchase')
 purchase     / purchase.order           / incoterm_id (many2one)        : relation is now 'account.incoterms' ('stock.incoterms')
 purchase     / purchase.order           / is_shipped (boolean)          : module is now 'purchase_stock' ('purchase')
-purchase     / purchase.order           / message_last_post (datetime)  : DEL 
+purchase     / purchase.order           / message_last_post (datetime)  : DEL
 purchase     / purchase.order           / message_main_attachment_id (many2one): NEW relation: ir.attachment
 purchase     / purchase.order           / picking_count (integer)       : module is now 'purchase_stock' ('purchase')
 purchase     / purchase.order           / picking_ids (many2many)       : module is now 'purchase_stock' ('purchase')
@@ -20,7 +20,7 @@ purchase     / purchase.order.line      / move_dest_ids (one2many)      : module
 purchase     / purchase.order.line      / move_ids (one2many)           : module is now 'purchase_stock' ('purchase')
 purchase     / purchase.order.line      / orderpoint_id (many2one)      : module is now 'purchase_stock' ('purchase')
 purchase     / purchase.order.line      / product_uom (many2one)        : relation is now 'uom.uom' ('product.uom')
-purchase     / purchase.order.line      / product_uom_qty (float)       : NEW 
+purchase     / purchase.order.line      / product_uom_qty (float)       : NEW
 purchase     / purchase.order.line      / qty_received (float)          : not a function anymore
 purchase     / stock.move               / created_purchase_line_id (many2one): module is now 'purchase_stock' ('purchase')
 purchase     / stock.move               / purchase_line_id (many2one)   : module is now 'purchase_stock' ('purchase')

--- a/addons/purchase_requisition/migrations/12.0.0.1/openupgrade_analysis.txt
+++ b/addons/purchase_requisition/migrations/12.0.0.1/openupgrade_analysis.txt
@@ -2,7 +2,7 @@
 purchase_requisition / product.supplierinfo     / purchase_requisition_line_id (many2one): NEW relation: purchase.requisition.line
 purchase_requisition / purchase.requisition     / account_analytic_id (many2one): DEL relation: account.analytic.account
 purchase_requisition / purchase.requisition     / currency_id (many2one)        : NEW relation: res.currency, required: required, req_default: function
-purchase_requisition / purchase.requisition     / message_last_post (datetime)  : DEL 
+purchase_requisition / purchase.requisition     / message_last_post (datetime)  : DEL
 purchase_requisition / purchase.requisition     / message_main_attachment_id (many2one): NEW relation: ir.attachment
 purchase_requisition / purchase.requisition     / state (selection)             : selection_keys is now '['cancel', 'done', 'draft', 'in_progress', 'ongoing', 'open']' ('['cancel', 'done', 'draft', 'in_progress', 'open']')
 purchase_requisition / purchase.requisition.line / analytic_tag_ids (many2many)  : NEW relation: account.analytic.tag

--- a/addons/repair/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/repair/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -4,7 +4,7 @@ mrp_repair   / mrp.repair               / activity_date_deadline (date) : not st
 mrp_repair   / mrp.repair               / activity_date_deadline (date) : now a function
 mrp_repair   / mrp.repair               / fees_lines (one2many)         : relation is now 'repair.fee' ('mrp.repair.fee')
 mrp_repair   / mrp.repair               / location_dest_id (many2one)   : DEL relation: stock.location, required: required
-mrp_repair   / mrp.repair               / message_last_post (datetime)  : DEL 
+mrp_repair   / mrp.repair               / message_last_post (datetime)  : DEL
 mrp_repair   / mrp.repair               / operations (one2many)         : relation is now 'repair.line' ('mrp.repair.line')
 mrp_repair   / mrp.repair               / product_uom (many2one)        : relation is now 'uom.uom' ('product.uom')
 mrp_repair   / mrp.repair.fee           / name (char)                   : type is now 'text' ('char')

--- a/addons/resource/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/resource/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'resource'---
-resource     / resource.calendar        / hours_per_day (float)         : NEW 
+resource     / resource.calendar        / hours_per_day (float)         : NEW
 resource     / resource.calendar        / tz (selection)                : NEW required: required, selection_keys: function, req_default: function
 resource     / resource.calendar.attendance / day_period (selection)        : NEW required: required, selection_keys: ['afternoon', 'morning'], req_default: function
 resource     / resource.calendar.leaves / time_type (selection)         : NEW selection_keys: ['leave', 'other']

--- a/addons/sale/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/sale/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -1,22 +1,22 @@
 ---Fields in module 'sale'---
 sale         / account.invoice.line     / layout_category_id (many2one) : DEL relation: sale.layout_category
-sale         / account.invoice.line     / layout_category_sequence (integer): DEL 
+sale         / account.invoice.line     / layout_category_sequence (integer): DEL
 sale         / crm.team                 / dashboard_graph_model (False) : selection_keys is now '['account.invoice.report', 'crm.lead', 'sale.report']' ('['account.invoice.report', 'crm.opportunity.report', 'sale.report']')
 sale         / payment.acquirer         / so_reference_type (selection) : NEW selection_keys: ['partner', 'so_name']
 sale         / payment.transaction      / sale_order_ids (many2many)    : NEW relation: sale.order
 sale         / product.attribute        / type (selection)              : previously in module website_sale
 sale         / product.attribute.custom.value / attribute_value_id (many2one) : NEW relation: product.attribute.value
-sale         / product.attribute.custom.value / custom_value (char)           : NEW 
+sale         / product.attribute.custom.value / custom_value (char)           : NEW
 sale         / product.attribute.custom.value / sale_order_line_id (many2one) : NEW relation: sale.order.line
 sale         / product.attribute.value  / html_color (char)             : previously in module website_sale
-sale         / product.attribute.value  / is_custom (boolean)           : NEW 
+sale         / product.attribute.value  / is_custom (boolean)           : NEW
 sale         / product.product          / optional_product_ids (many2many): previously in module website_sale_options
 sale         / product.product          / sales_count (integer)         : type is now 'float' ('integer')
 sale         / product.template         / optional_product_ids (many2many): previously in module website_sale_options
 sale         / product.template         / sales_count (integer)         : type is now 'float' ('integer')
-sale         / res.company              / portal_confirmation_pay (boolean): NEW 
-sale         / res.company              / portal_confirmation_sign (boolean): NEW 
-sale         / res.company              / quotation_validity_days (integer): NEW 
+sale         / res.company              / portal_confirmation_pay (boolean): NEW
+sale         / res.company              / portal_confirmation_sign (boolean): NEW
+sale         / res.company              / quotation_validity_days (integer): NEW
 sale         / res.company              / sale_onboarding_order_confirmation_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
 sale         / res.company              / sale_onboarding_payment_method (selection): NEW selection_keys: ['digital_signature', 'manual', 'other', 'paypal', 'stripe']
 sale         / res.company              / sale_onboarding_sample_quotation_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
@@ -25,33 +25,32 @@ sale         / sale.order               / activity_date_deadline (date) : not re
 sale         / sale.order               / activity_date_deadline (date) : not stored anymore
 sale         / sale.order               / activity_date_deadline (date) : now a function
 sale         / sale.order               / amount_undiscounted (float)   : previously in module website_quote
-sale         / sale.order               / currency_rate (float)         : NEW 
-sale         / sale.order               / message_last_post (datetime)  : DEL 
+sale         / sale.order               / currency_rate (float)         : NEW
+sale         / sale.order               / message_last_post (datetime)  : DEL
 sale         / sale.order               / message_main_attachment_id (many2one): NEW relation: ir.attachment
-sale         / sale.order               / reference (char)              : NEW 
-sale         / sale.order               / require_signature (boolean)   : NEW 
+sale         / sale.order               / reference (char)              : NEW
+sale         / sale.order               / require_signature (boolean)   : NEW
 sale         / sale.order               / signature (binary)            : NEW attachment: True
-sale         / sale.order               / signed_by (char)              : NEW 
+sale         / sale.order               / signed_by (char)              : NEW
 sale         / sale.order               / transaction_ids (many2many)   : NEW relation: payment.transaction
-sale         / sale.order.line          / amt_invoiced (float)          : DEL 
-sale         / sale.order.line          / amt_to_invoice (float)        : DEL 
+sale         / sale.order.line          / amt_invoiced (float)          : DEL
+sale         / sale.order.line          / amt_to_invoice (float)        : DEL
 sale         / sale.order.line          / analytic_line_ids (one2many)  : NEW relation: account.analytic.line
 sale         / sale.order.line          / display_type (selection)      : NEW selection_keys: ['line_note', 'line_section']
-sale         / sale.order.line          / is_expense (boolean)          : NEW 
+sale         / sale.order.line          / is_expense (boolean)          : NEW
 sale         / sale.order.line          / layout_category_id (many2one) : DEL relation: sale.layout_category
-sale         / sale.order.line          / layout_category_sequence (integer): DEL 
+sale         / sale.order.line          / layout_category_sequence (integer): DEL
 sale         / sale.order.line          / product_custom_attribute_value_ids (one2many): NEW relation: product.attribute.custom.value
 sale         / sale.order.line          / product_no_variant_attribute_value_ids (many2many): NEW relation: product.template.attribute.value
 sale         / sale.order.line          / product_uom (many2one)        : relation is now 'uom.uom' ('product.uom')
 sale         / sale.order.line          / qty_delivered (float)         : now a function
-sale         / sale.order.line          / qty_delivered_manual (float)  : NEW 
+sale         / sale.order.line          / qty_delivered_manual (float)  : NEW
 sale         / sale.order.line          / qty_delivered_method (selection): NEW selection_keys: ['analytic', 'manual']
-sale         / sale.order.line          / untaxed_amount_invoiced (float): NEW 
-sale         / sale.order.line          / untaxed_amount_to_invoice (float): NEW 
-sale_order_dates / sale.order               / commitment_date (datetime)    : not stored anymore
-sale_order_dates / sale.order               / commitment_date (datetime)    : was renamed to expected_date [nothing to do]
+sale         / sale.order.line          / untaxed_amount_invoiced (float): NEW
+sale         / sale.order.line          / untaxed_amount_to_invoice (float): NEW
+sale_order_dates / sale.order               / commitment_date (datetime)    : not a function anymore
 sale_order_dates / sale.order               / effective_date (date)         : module is now 'sale_stock' ('sale_order_dates')
-sale_order_dates / sale.order               / requested_date (datetime)     : was renamed to commitment_date [nothing to do]
+sale_order_dates / sale.order               / requested_date (datetime)     : DEL
 sale_payment / payment.transaction      / sale_order_id (many2one)      : DEL relation: sale.order
 sale_payment / sale.order               / payment_acquirer_id (many2one): DEL relation: payment.acquirer
 sale_payment / sale.order               / payment_tx_id (many2one)      : DEL relation: payment.transaction
@@ -164,9 +163,9 @@ DEL ir.ui.view: sale_payment.sale_order_view_form
 NEW mail.activity.type: sale.mail_act_sale_upsell (noupdate)
 DEL mail.template: sale.mail_template_data_notification_email_sale_order (noupdate)
 NEW res.groups: sale.group_sale_order_dates
-DEL res.groups: base.group_portal
-DEL res.groups: base.group_public
-DEL res.groups: base.group_user (noupdate)
+DEL res.groups: base.group_portal [moved to account module]
+DEL res.groups: base.group_public [moved to account module]
+DEL res.groups: base.group_user [moved to account module] (noupdate)
 DEL res.groups: sale.group_analytic_accounting
 DEL res.groups: sale.group_sale_layout
 DEL res.groups: sale.group_show_price_subtotal

--- a/addons/sale_management/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/sale_management/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'sale_management'---
-sale_management / digest.digest            / kpi_all_sale_total (boolean)  : NEW 
+sale_management / digest.digest            / kpi_all_sale_total (boolean)  : NEW
 sale_management / sale.order               / sale_order_option_ids (one2many): NEW relation: sale.order.option
 sale_management / sale.order               / sale_order_template_id (many2one): NEW relation: sale.order.template
 sale_management / sale.order.line          / sale_order_option_ids (one2many): NEW relation: sale.order.option
@@ -14,7 +14,7 @@ sale_management / sale.order.option        / product_id (many2one)         : pre
 sale_management / sale.order.option        / quantity (float)              : previously in module website_quote
 sale_management / sale.order.option        / sequence (integer)            : previously in module website_quote
 sale_management / sale.order.option        / uom_id (many2one)             : previously in module website_quote
-sale_management / sale.order.template      / require_signature (boolean)   : NEW 
+sale_management / sale.order.template      / require_signature (boolean)   : NEW
 sale_management / sale.order.template      / sale_order_template_line_ids (one2many): NEW relation: sale.order.template.line
 sale_management / sale.order.template      / sale_order_template_option_ids (one2many): NEW relation: sale.order.template.option
 sale_management / sale.order.template.line / display_type (selection)      : NEW selection_keys: ['line_note', 'line_section']
@@ -46,7 +46,7 @@ sale_management / sale.quote.template      / note (text)                   : pre
 sale_management / sale.quote.template      / number_of_days (integer)      : previously in module website_quote
 ---XML records in module 'sale_management'---
 NEW digest.digest: digest.digest_digest_default (noupdate)
-NEW ir.actions.act_window: sale.action_quotations
+NEW ir.actions.act_window: sale.action_quotations [moved from sale_quotation_builder module]
 NEW ir.actions.act_window: sale_management.sale_order_template_action
 NEW ir.model.access: sale_management.access_sale_order_option
 NEW ir.model.access: sale_management.access_sale_order_option_all

--- a/addons/sale_purchase/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/sale_purchase/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'sale_purchase'---
-sale_purchase / product.template         / service_to_purchase (boolean) : NEW 
+sale_purchase / product.template         / service_to_purchase (boolean) : NEW
 sale_purchase / purchase.order.line      / sale_line_id (many2one)       : previously in module stock_dropshipping
 sale_purchase / purchase.order.line      / sale_order_id (many2one)      : NEW relation: sale.order
 sale_purchase / sale.order.line          / purchase_line_ids (one2many)  : previously in module stock_dropshipping

--- a/addons/sale_quotation_builder/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/sale_quotation_builder/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,11 +1,11 @@
 ---Fields in module 'sale_quotation_builder'---
-sale_quotation_builder / product.template         / quotation_only_description (html): NEW 
+sale_quotation_builder / product.template         / quotation_only_description (html): NEW
 website_quote / product.product          / website_description (html)    : module is now 'website_sale' ('website_quote')
-website_quote / product.template         / quote_description (html)      : DEL 
+website_quote / product.template         / quote_description (html)      : DEL
 website_quote / product.template         / website_description (html)    : module is now 'website_sale' ('website_quote')
 website_quote / sale.order               / amount_undiscounted (float)   : module is now 'sale' ('website_quote')
 website_quote / sale.order               / options (one2many)            : DEL relation: sale.order.option
-website_quote / sale.order               / quote_viewed (boolean)        : DEL 
+website_quote / sale.order               / quote_viewed (boolean)        : DEL
 website_quote / sale.order               / require_payment (selection)   : selection_keys is now 'False' ('[0, 1]')
 website_quote / sale.order               / require_payment (selection)   : type is now 'boolean' ('selection')
 website_quote / sale.order               / template_id (many2one)        : DEL relation: sale.quote.template
@@ -59,7 +59,7 @@ website_quote / sale.quote.template      / quote_line (one2many)         : DEL r
 website_quote / sale.quote.template      / require_payment (selection)   : selection_keys is now 'False' ('[0, 1]')
 website_quote / sale.quote.template      / require_payment (selection)   : type is now 'boolean' ('selection')
 ---XML records in module 'sale_quotation_builder'---
-DEL ir.actions.act_window: sale.action_quotations
+DEL ir.actions.act_window: sale.action_quotations [moved to sale_management module]
 DEL ir.actions.act_window: website_quote.action_sale_quotation_template
 DEL ir.actions.report: website_quote.report_web_quote
 DEL ir.model.access: website_quote.access_sale_order_option

--- a/addons/sale_timesheet/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/sale_timesheet/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,6 +1,6 @@
 ---Fields in module 'sale_timesheet'---
 sale_timesheet / account.analytic.line    / timesheet_invoice_type (selection): now a function
-sale_timesheet / account.analytic.line    / timesheet_revenue (float)     : DEL 
+sale_timesheet / account.analytic.line    / timesheet_revenue (float)     : DEL
 sale_timesheet / hr.employee              / currency_id (many2one)        : module is now 'hr_timesheet' ('sale_timesheet')
 sale_timesheet / hr.employee              / timesheet_cost (float)        : module is now 'hr_timesheet' ('sale_timesheet')
 sale_timesheet / product.template         / project_template_id (many2one): NEW relation: project.project

--- a/addons/sales_team/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/sales_team/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,4 +1,4 @@
 ---Fields in module 'sales_team'---
-sales_team   / crm.team                 / message_last_post (datetime)  : DEL 
+sales_team   / crm.team                 / message_last_post (datetime)  : DEL
 sales_team   / crm.team                 / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'sales_team'---

--- a/addons/snailmail/migrations/12.0.0.1/openupgrade_analysis.txt
+++ b/addons/snailmail/migrations/12.0.0.1/openupgrade_analysis.txt
@@ -1,11 +1,11 @@
 ---Fields in module 'snailmail'---
-snailmail    / res.company              / snailmail_color (boolean)     : NEW 
-snailmail    / res.company              / snailmail_duplex (boolean)    : NEW 
+snailmail    / res.company              / snailmail_color (boolean)     : NEW
+snailmail    / res.company              / snailmail_duplex (boolean)    : NEW
 snailmail    / snailmail.letter         / attachment_id (many2one)      : NEW relation: ir.attachment
-snailmail    / snailmail.letter         / color (boolean)               : NEW 
+snailmail    / snailmail.letter         / color (boolean)               : NEW
 snailmail    / snailmail.letter         / company_id (many2one)         : NEW relation: res.company, required: required, req_default: function
-snailmail    / snailmail.letter         / duplex (boolean)              : NEW 
-snailmail    / snailmail.letter         / info_msg (char)               : NEW 
+snailmail    / snailmail.letter         / duplex (boolean)              : NEW
+snailmail    / snailmail.letter         / info_msg (char)               : NEW
 snailmail    / snailmail.letter         / model (char)                  : NEW required: required
 snailmail    / snailmail.letter         / partner_id (many2one)         : NEW relation: res.partner, required: required
 snailmail    / snailmail.letter         / report_template (many2one)    : NEW relation: ir.actions.report

--- a/addons/snailmail_account/migrations/12.0.0.1/openupgrade_analysis.txt
+++ b/addons/snailmail_account/migrations/12.0.0.1/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'snailmail_account'---
-snailmail_account / res.company              / invoice_is_snailmail (boolean): NEW 
+snailmail_account / res.company              / invoice_is_snailmail (boolean): NEW
 ---XML records in module 'snailmail_account'---
 NEW ir.ui.view: snailmail_account.account_invoice_send_inherit_account_wizard_form
 NEW ir.ui.view: snailmail_account.res_config_settings_view_form

--- a/addons/social_media/migrations/12.0.0.1/openupgrade_analysis.txt
+++ b/addons/social_media/migrations/12.0.0.1/openupgrade_analysis.txt
@@ -2,7 +2,7 @@
 social_media / res.company              / social_facebook (char)        : previously in module mass_mailing
 social_media / res.company              / social_github (char)          : previously in module mass_mailing
 social_media / res.company              / social_googleplus (char)      : previously in module mass_mailing
-social_media / res.company              / social_instagram (char)       : NEW 
+social_media / res.company              / social_instagram (char)       : NEW
 social_media / res.company              / social_linkedin (char)        : previously in module mass_mailing
 social_media / res.company              / social_twitter (char)         : previously in module mass_mailing
 social_media / res.company              / social_youtube (char)         : previously in module mass_mailing

--- a/addons/stock/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/stock/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -8,23 +8,23 @@ stock        / stock.incoterms          / active (boolean)              : module
 stock        / stock.incoterms          / code (char)                   : module is now 'account' ('stock')
 stock        / stock.incoterms          / display_name (char)           : module is now 'account' ('stock')
 stock        / stock.incoterms          / name (char)                   : module is now 'account' ('stock')
-stock        / stock.inventory.line     / location_name (char)          : DEL 
-stock        / stock.inventory.line     / prodlot_name (char)           : DEL 
-stock        / stock.inventory.line     / product_code (char)           : DEL 
-stock        / stock.inventory.line     / product_name (char)           : DEL 
+stock        / stock.inventory.line     / location_name (char)          : DEL
+stock        / stock.inventory.line     / prodlot_name (char)           : DEL
+stock        / stock.inventory.line     / product_code (char)           : DEL
+stock        / stock.inventory.line     / product_name (char)           : DEL
 stock        / stock.inventory.line     / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
-stock        / stock.location           / parent_left (integer)         : DEL 
-stock        / stock.location           / parent_path (char)            : NEW 
-stock        / stock.location           / parent_right (integer)        : DEL 
+stock        / stock.location           / parent_left (integer)         : DEL
+stock        / stock.location           / parent_path (char)            : NEW
+stock        / stock.location           / parent_right (integer)        : DEL
 stock        / stock.location.route     / pull_ids (one2many)           : DEL relation: procurement.rule
 stock        / stock.location.route     / push_ids (one2many)           : DEL relation: stock.location.path
 stock        / stock.location.route     / rule_ids (one2many)           : NEW relation: stock.rule
-stock        / stock.move               / ordered_qty (float)           : DEL 
+stock        / stock.move               / ordered_qty (float)           : DEL
 stock        / stock.move               / package_level_id (many2one)   : NEW relation: stock.package_level
 stock        / stock.move               / product_uom (many2one)        : relation is now 'uom.uom' ('product.uom')
 stock        / stock.move               / push_rule_id (many2one)       : DEL relation: stock.location.path
 stock        / stock.move               / rule_id (many2one)            : relation is now 'stock.rule' ('procurement.rule')
-stock        / stock.move.line          / ordered_qty (float)           : DEL 
+stock        / stock.move.line          / ordered_qty (float)           : DEL
 stock        / stock.move.line          / package_level_id (many2one)   : NEW relation: stock.package_level
 stock        / stock.move.line          / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
 stock        / stock.package_level      / location_dest_id (many2one)   : NEW relation: stock.location
@@ -36,17 +36,17 @@ stock        / stock.picking            / activity_date_deadline (date) : not re
 stock        / stock.picking            / activity_date_deadline (date) : not stored anymore
 stock        / stock.picking            / activity_date_deadline (date) : now a function
 stock        / stock.picking            / backorder_ids (one2many)      : NEW relation: stock.picking
-stock        / stock.picking            / immediate_transfer (boolean)  : NEW 
-stock        / stock.picking            / message_last_post (datetime)  : DEL 
+stock        / stock.picking            / immediate_transfer (boolean)  : NEW
+stock        / stock.picking            / message_last_post (datetime)  : DEL
 stock        / stock.picking            / message_main_attachment_id (many2one): NEW relation: ir.attachment
 stock        / stock.picking            / move_ids_without_package (one2many): NEW relation: stock.move
 stock        / stock.picking            / move_line_ids_without_package (one2many): NEW relation: stock.move.line
 stock        / stock.picking            / package_level_ids (one2many)  : NEW relation: stock.package_level
 stock        / stock.picking            / package_level_ids_details (one2many): NEW relation: stock.package_level
-stock        / stock.picking.type       / barcode (char)                : NEW 
+stock        / stock.picking.type       / barcode (char)                : NEW
 stock        / stock.picking.type       / barcode_nomenclature_id (many2one): DEL relation: barcode.nomenclature
 stock        / stock.production.lot     / activity_ids (one2many)       : NEW relation: mail.activity
-stock        / stock.production.lot     / message_last_post (datetime)  : DEL 
+stock        / stock.production.lot     / message_last_post (datetime)  : DEL
 stock        / stock.production.lot     / message_main_attachment_id (many2one): NEW relation: ir.attachment
 stock        / stock.production.lot     / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
 stock        / stock.quant              / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom')
@@ -135,19 +135,19 @@ DEL ir.ui.view: stock.view_procurement_rule_tree
 DEL ir.ui.view: stock.view_quant_package_picking_tree
 NEW res.groups: stock.group_lot_on_delivery_slip
 DEL res.request.link: stock.req_link_tracking (noupdate)
-DEL stock.incoterms: stock.incoterm_CFR
-DEL stock.incoterms: stock.incoterm_CIF
-DEL stock.incoterms: stock.incoterm_CIP
-DEL stock.incoterms: stock.incoterm_CPT
-DEL stock.incoterms: stock.incoterm_DAF
-DEL stock.incoterms: stock.incoterm_DAP
-DEL stock.incoterms: stock.incoterm_DAT
-DEL stock.incoterms: stock.incoterm_DDP
-DEL stock.incoterms: stock.incoterm_DDU
-DEL stock.incoterms: stock.incoterm_DEQ
-DEL stock.incoterms: stock.incoterm_DES
-DEL stock.incoterms: stock.incoterm_EXW
-DEL stock.incoterms: stock.incoterm_FAS
-DEL stock.incoterms: stock.incoterm_FCA
-DEL stock.incoterms: stock.incoterm_FOB
+DEL stock.incoterms: stock.incoterm_CFR [renamed to account module]
+DEL stock.incoterms: stock.incoterm_CIF [renamed to account module]
+DEL stock.incoterms: stock.incoterm_CIP [renamed to account module]
+DEL stock.incoterms: stock.incoterm_CPT [renamed to account module]
+DEL stock.incoterms: stock.incoterm_DAF [renamed to account module]
+DEL stock.incoterms: stock.incoterm_DAP [renamed to account module]
+DEL stock.incoterms: stock.incoterm_DAT [renamed to account module]
+DEL stock.incoterms: stock.incoterm_DDP [renamed to account module]
+DEL stock.incoterms: stock.incoterm_DDU [renamed to account module]
+DEL stock.incoterms: stock.incoterm_DEQ [renamed to account module]
+DEL stock.incoterms: stock.incoterm_DES [renamed to account module]
+DEL stock.incoterms: stock.incoterm_EXW [renamed to account module]
+DEL stock.incoterms: stock.incoterm_FAS [renamed to account module]
+DEL stock.incoterms: stock.incoterm_FCA [renamed to account module]
+DEL stock.incoterms: stock.incoterm_FOB [renamed to account module]
 DEL web.planner: stock.planner_inventory

--- a/addons/stock_landed_costs/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/stock_landed_costs/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'stock_landed_costs'---
-stock_landed_costs / stock.landed.cost        / message_last_post (datetime)  : DEL 
+stock_landed_costs / stock.landed.cost        / message_last_post (datetime)  : DEL
 stock_landed_costs / stock.landed.cost        / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'stock_landed_costs'---
 NEW ir.ui.view: stock_landed_costs.stock_landed_cost_view_kanban

--- a/addons/stock_picking_batch/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/stock_picking_batch/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'stock_picking_batch'---
-stock_picking_batch / stock.picking.batch      / message_last_post (datetime)  : DEL 
+stock_picking_batch / stock.picking.batch      / message_last_post (datetime)  : DEL
 stock_picking_batch / stock.picking.batch      / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'stock_picking_batch'---
 NEW ir.actions.report: stock_picking_batch.action_report_picking_batch

--- a/addons/survey/migrations/12.0.3.0/openupgrade_analysis.txt
+++ b/addons/survey/migrations/12.0.3.0/openupgrade_analysis.txt
@@ -2,7 +2,7 @@
 survey       / survey.survey            / activity_date_deadline (date) : not related anymore
 survey       / survey.survey            / activity_date_deadline (date) : not stored anymore
 survey       / survey.survey            / activity_date_deadline (date) : now a function
-survey       / survey.survey            / message_last_post (datetime)  : DEL 
+survey       / survey.survey            / message_last_post (datetime)  : DEL
 survey       / survey.survey            / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'survey'---
 DEL ir.actions.act_window: survey.action_partner_survey_mail

--- a/addons/test_mail/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/test_mail/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -26,23 +26,23 @@ test_mail    / mail.test                / message_unread (boolean)      : previo
 test_mail    / mail.test                / message_unread_counter (integer): previously in module mail
 test_mail    / mail.test                / name (char)                   : previously in module mail
 test_mail    / mail.test                / website_message_ids (one2many): previously in module portal
-test_mail    / mail.test.activity       / active (boolean)              : NEW 
+test_mail    / mail.test.activity       / active (boolean)              : NEW
 test_mail    / mail.test.activity       / activity_ids (one2many)       : NEW relation: mail.activity
-test_mail    / mail.test.activity       / email_from (char)             : NEW 
+test_mail    / mail.test.activity       / email_from (char)             : NEW
 test_mail    / mail.test.activity       / message_follower_ids (one2many): NEW relation: mail.followers
 test_mail    / mail.test.activity       / message_ids (one2many)        : NEW relation: mail.message
 test_mail    / mail.test.activity       / message_main_attachment_id (many2one): NEW relation: ir.attachment
-test_mail    / mail.test.activity       / name (char)                   : NEW 
+test_mail    / mail.test.activity       / name (char)                   : NEW
 test_mail    / mail.test.activity       / website_message_ids (one2many): NEW relation: mail.message
-test_mail    / mail.test.full           / count (integer)               : NEW 
+test_mail    / mail.test.full           / count (integer)               : NEW
 test_mail    / mail.test.full           / customer_id (many2one)        : NEW relation: res.partner
-test_mail    / mail.test.full           / datetime (datetime)           : NEW 
-test_mail    / mail.test.full           / email_from (char)             : NEW 
+test_mail    / mail.test.full           / datetime (datetime)           : NEW
+test_mail    / mail.test.full           / email_from (char)             : NEW
 test_mail    / mail.test.full           / mail_template (many2one)      : NEW relation: mail.template
 test_mail    / mail.test.full           / message_follower_ids (one2many): NEW relation: mail.followers
 test_mail    / mail.test.full           / message_ids (one2many)        : NEW relation: mail.message
 test_mail    / mail.test.full           / message_main_attachment_id (many2one): NEW relation: ir.attachment
-test_mail    / mail.test.full           / name (char)                   : NEW 
+test_mail    / mail.test.full           / name (char)                   : NEW
 test_mail    / mail.test.full           / umbrella_id (many2one)        : NEW relation: mail.test
 test_mail    / mail.test.full           / user_id (many2one)            : NEW relation: res.users
 test_mail    / mail.test.full           / website_message_ids (one2many): NEW relation: mail.message
@@ -61,11 +61,12 @@ test_mail    / mail.test.simple         / message_unread (boolean)      : previo
 test_mail    / mail.test.simple         / message_unread_counter (integer): previously in module mail
 test_mail    / mail.test.simple         / name (char)                   : previously in module mail
 test_mail    / mail.test.simple         / website_message_ids (one2many): previously in module portal
-test_mail    / mail.test.track          / email_from (char)             : NEW 
+test_mail    / mail.test.track          / company_id (many2one)         : NEW relation: res.company
+test_mail    / mail.test.track          / email_from (char)             : NEW
 test_mail    / mail.test.track          / message_follower_ids (one2many): NEW relation: mail.followers
 test_mail    / mail.test.track          / message_ids (one2many)        : NEW relation: mail.message
 test_mail    / mail.test.track          / message_main_attachment_id (many2one): NEW relation: ir.attachment
-test_mail    / mail.test.track          / name (char)                   : NEW 
+test_mail    / mail.test.track          / name (char)                   : NEW
 test_mail    / mail.test.track          / umbrella_id (many2one)        : NEW relation: mail.test
 test_mail    / mail.test.track          / user_id (many2one)            : NEW relation: res.users
 test_mail    / mail.test.track          / website_message_ids (one2many): NEW relation: mail.message

--- a/addons/test_mass_mailing/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/test_mass_mailing/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,15 +1,15 @@
 ---Fields in module 'test_mass_mailing'---
-test_mass_mailing / mass.mail.test           / email_from (char)             : NEW 
+test_mass_mailing / mass.mail.test           / email_from (char)             : NEW
 test_mass_mailing / mass.mail.test           / message_follower_ids (one2many): NEW relation: mail.followers
 test_mass_mailing / mass.mail.test           / message_ids (one2many)        : NEW relation: mail.message
 test_mass_mailing / mass.mail.test           / message_main_attachment_id (many2one): NEW relation: ir.attachment
-test_mass_mailing / mass.mail.test           / name (char)                   : NEW 
+test_mass_mailing / mass.mail.test           / name (char)                   : NEW
 test_mass_mailing / mass.mail.test           / website_message_ids (one2many): NEW relation: mail.message
-test_mass_mailing / mass.mail.test.bl        / email_from (char)             : NEW 
+test_mass_mailing / mass.mail.test.bl        / email_from (char)             : NEW
 test_mass_mailing / mass.mail.test.bl        / message_follower_ids (one2many): NEW relation: mail.followers
 test_mass_mailing / mass.mail.test.bl        / message_ids (one2many)        : NEW relation: mail.message
 test_mass_mailing / mass.mail.test.bl        / message_main_attachment_id (many2one): NEW relation: ir.attachment
-test_mass_mailing / mass.mail.test.bl        / name (char)                   : NEW 
+test_mass_mailing / mass.mail.test.bl        / name (char)                   : NEW
 test_mass_mailing / mass.mail.test.bl        / umbrella_id (many2one)        : NEW relation: mail.test
 test_mass_mailing / mass.mail.test.bl        / user_id (many2one)            : NEW relation: res.users
 test_mass_mailing / mass.mail.test.bl        / website_message_ids (one2many): NEW relation: mail.message

--- a/addons/test_website/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/test_website/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,0 +1,8 @@
+---Fields in module 'test_website'---
+---XML records in module 'test_website'---
+NEW ir.ui.view: test_website.assets_frontend
+NEW ir.ui.view: test_website.test_page_view (noupdate)
+NEW ir.ui.view: test_website.test_view (noupdate)
+NEW ir.ui.view: test_website.test_view_child_broken (noupdate)
+NEW ir.ui.view: test_website.test_view_to_be_t_called (noupdate)
+NEW website.page: test_website.test_page (noupdate)

--- a/addons/uom/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/uom/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -8,6 +8,9 @@ uom          / product.uom              / factor_inv (float)            : previo
 uom          / product.uom              / name (char)                   : previously in module product
 uom          / product.uom              / rounding (float)              : previously in module product
 uom          / product.uom              / uom_type (selection)          : previously in module product
+uom          / product.uom.categ        / __last_update (datetime)      : previously in module product
+uom          / product.uom.categ        / display_name (char)           : previously in module product
+uom          / product.uom.categ        / name (char)                   : previously in module product
 uom          / uom.category             / measure_type (selection)      : NEW selection_keys: ['length', 'time', 'unit', 'volume', 'weight']
 uom          / uom.uom                  / measure_type (selection)      : NEW selection_keys: function
 ---XML records in module 'uom'---
@@ -21,27 +24,27 @@ NEW ir.ui.view: uom.product_uom_categ_form_view
 NEW ir.ui.view: uom.product_uom_form_view
 NEW ir.ui.view: uom.product_uom_tree_view
 NEW res.groups: uom.group_uom
-NEW uom.category: uom.product_uom_categ_kgm (noupdate)
-NEW uom.category: uom.product_uom_categ_unit (noupdate)
-NEW uom.category: uom.product_uom_categ_vol (noupdate)
-NEW uom.category: uom.uom_categ_length (noupdate)
-NEW uom.category: uom.uom_categ_wtime (noupdate)
-NEW uom.uom: uom.product_uom_cm (noupdate)
-NEW uom.uom: uom.product_uom_day (noupdate)
-NEW uom.uom: uom.product_uom_dozen (noupdate)
-NEW uom.uom: uom.product_uom_floz (noupdate)
-NEW uom.uom: uom.product_uom_foot (noupdate)
-NEW uom.uom: uom.product_uom_gal (noupdate)
-NEW uom.uom: uom.product_uom_gram (noupdate)
-NEW uom.uom: uom.product_uom_hour (noupdate)
-NEW uom.uom: uom.product_uom_inch (noupdate)
-NEW uom.uom: uom.product_uom_kgm (noupdate)
-NEW uom.uom: uom.product_uom_km (noupdate)
-NEW uom.uom: uom.product_uom_lb (noupdate)
-NEW uom.uom: uom.product_uom_litre (noupdate)
-NEW uom.uom: uom.product_uom_meter (noupdate)
-NEW uom.uom: uom.product_uom_mile (noupdate)
-NEW uom.uom: uom.product_uom_oz (noupdate)
-NEW uom.uom: uom.product_uom_qt (noupdate)
-NEW uom.uom: uom.product_uom_ton (noupdate)
-NEW uom.uom: uom.product_uom_unit (noupdate)
+NEW uom.category: uom.product_uom_categ_kgm [renamed from product module] (noupdate)
+NEW uom.category: uom.product_uom_categ_unit [renamed from product module] (noupdate)
+NEW uom.category: uom.product_uom_categ_vol [renamed from product module] (noupdate)
+NEW uom.category: uom.uom_categ_length [renamed from product module] (noupdate)
+NEW uom.category: uom.uom_categ_wtime [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_cm [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_day [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_dozen [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_floz [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_foot [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_gal [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_gram [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_hour [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_inch [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_kgm [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_km [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_lb [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_litre [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_meter [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_mile [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_oz [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_qt [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_ton [renamed from product module] (noupdate)
+NEW uom.uom: uom.product_uom_unit [renamed from product module] (noupdate)

--- a/addons/web/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/web/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,6 +1,6 @@
 ---Fields in module 'web'---
-web          / report.layout            / image (char)                  : NEW 
-web          / report.layout            / pdf (char)                    : NEW 
+web          / report.layout            / image (char)                  : NEW
+web          / report.layout            / pdf (char)                    : NEW
 web          / report.layout            / view_id (many2one)            : NEW relation: ir.ui.view, required: required
 ---XML records in module 'web'---
 DEL ir.actions.act_window: web_planner.web_planner_action
@@ -35,4 +35,4 @@ NEW report.layout: web.report_layout_background
 NEW report.layout: web.report_layout_boxed
 NEW report.layout: web.report_layout_clean
 NEW report.layout: web.report_layout_standard
-NEW res.company: base.main_company (noupdate)
+NEW res.company: base.main_company [potentially moved from project module] (noupdate)

--- a/addons/website/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,38 +1,38 @@
 ---Fields in module 'website'---
-website      / ir.attachment            / key (char)                    : NEW 
+website      / ir.attachment            / key (char)                    : NEW
 website      / ir.attachment            / website_id (many2one)         : NEW relation: website
-website      / ir.ui.view               / page_ids (one2many)           : not a function anymore
 website      / ir.ui.view               / page_ids (one2many)           : is now stored
-website      / ir.ui.view               / website_meta_og_img (char)    : NEW 
+website      / ir.ui.view               / page_ids (one2many)           : not a function anymore
+website      / ir.ui.view               / website_meta_og_img (char)    : NEW
 website      / res.partner              / website_id (many2one)         : NEW relation: website
 website      / res.users                / website_id (many2one)         : NEW relation: website
 website      / website                  / auth_signup_uninvited (selection): NEW selection_keys: ['b2b', 'b2c']
 website      / website                  / company_id (many2one)         : now required, default = function
 website      / website                  / country_group_ids (many2many) : NEW relation: res.country.group
-website      / website                  / google_maps_api_key (char)    : NEW 
+website      / website                  / google_maps_api_key (char)    : NEW
 website      / website                  / name (char)                   : now required
 website      / website                  / social_default_image (binary) : NEW attachment: True
-website      / website                  / social_facebook (char)        : not related anymore
 website      / website                  / social_facebook (char)        : is now stored
-website      / website                  / social_github (char)          : not related anymore
+website      / website                  / social_facebook (char)        : not related anymore
 website      / website                  / social_github (char)          : is now stored
-website      / website                  / social_googleplus (char)      : not related anymore
+website      / website                  / social_github (char)          : not related anymore
 website      / website                  / social_googleplus (char)      : is now stored
-website      / website                  / social_instagram (char)       : NEW 
-website      / website                  / social_linkedin (char)        : not related anymore
+website      / website                  / social_googleplus (char)      : not related anymore
+website      / website                  / social_instagram (char)       : NEW
 website      / website                  / social_linkedin (char)        : is now stored
-website      / website                  / social_twitter (char)         : not related anymore
+website      / website                  / social_linkedin (char)        : not related anymore
 website      / website                  / social_twitter (char)         : is now stored
-website      / website                  / social_youtube (char)         : not related anymore
+website      / website                  / social_twitter (char)         : not related anymore
 website      / website                  / social_youtube (char)         : is now stored
-website      / website                  / specific_user_account (boolean): NEW 
+website      / website                  / social_youtube (char)         : not related anymore
+website      / website                  / specific_user_account (boolean): NEW
 website      / website                  / theme_id (many2one)           : NEW relation: ir.module.module
-website      / website.menu             / parent_left (integer)         : DEL 
-website      / website.menu             / parent_path (char)            : NEW 
-website      / website.menu             / parent_right (integer)        : DEL 
-website      / website.page             / header_color (char)           : NEW 
-website      / website.page             / header_overlay (boolean)      : NEW 
-website      / website.page             / is_published (boolean)        : NEW 
+website      / website.menu             / parent_left (integer)         : DEL
+website      / website.menu             / parent_path (char)            : NEW
+website      / website.menu             / parent_right (integer)        : DEL
+website      / website.page             / header_color (char)           : NEW
+website      / website.page             / header_overlay (boolean)      : NEW
+website      / website.page             / is_published (boolean)        : NEW
 website      / website.page             / website_id (many2one)         : is now stored
 website      / website.page             / website_ids (many2many)       : DEL relation: website
 website      / website.page             / website_published (boolean)   : not stored anymore
@@ -71,6 +71,7 @@ NEW ir.ui.view: website._assets_frontend_helpers
 NEW ir.ui.view: website._assets_primary_variables
 NEW ir.ui.view: website._assets_secondary_variables
 NEW ir.ui.view: website.affix_top_menu
+NEW ir.ui.view: website.assets_common
 NEW ir.ui.view: website.assets_frontend_compatibility_for_12_0
 NEW ir.ui.view: website.brand_promotion
 NEW ir.ui.view: website.default_scss

--- a/addons/website_blog/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_blog/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,19 +1,19 @@
 ---Fields in module 'website_blog'---
-website_blog / blog.blog                / message_last_post (datetime)  : DEL 
+website_blog / blog.blog                / message_last_post (datetime)  : DEL
 website_blog / blog.blog                / message_main_attachment_id (many2one): NEW relation: ir.attachment
 website_blog / blog.blog                / website_id (many2one)         : NEW relation: website
-website_blog / blog.blog                / website_meta_og_img (char)    : NEW 
-website_blog / blog.post                / is_published (boolean)        : NEW 
-website_blog / blog.post                / message_last_post (datetime)  : DEL 
+website_blog / blog.blog                / website_meta_og_img (char)    : NEW
+website_blog / blog.post                / is_published (boolean)        : NEW
+website_blog / blog.post                / message_last_post (datetime)  : DEL
 website_blog / blog.post                / message_main_attachment_id (many2one): NEW relation: ir.attachment
-website_blog / blog.post                / website_meta_og_img (char)    : NEW 
+website_blog / blog.post                / website_meta_og_img (char)    : NEW
 website_blog / blog.post                / website_published (boolean)   : not stored anymore
 website_blog / blog.post                / website_published (boolean)   : now a function
 website_blog / blog.tag                 / category_id (many2one)        : NEW relation: blog.tag.category
-website_blog / blog.tag                 / website_meta_og_img (char)    : NEW 
+website_blog / blog.tag                 / website_meta_og_img (char)    : NEW
 website_blog / blog.tag.category        / name (char)                   : NEW required: required
 website_blog / blog.tag.category        / tag_ids (one2many)            : NEW relation: blog.tag
-website_blog / mail.message             / path (char)                   : DEL 
+website_blog / mail.message             / path (char)                   : DEL
 ---XML records in module 'website_blog'---
 NEW ir.actions.act_window: website_blog.action_tag_category
 NEW ir.model.access: website_blog.blog_tag_category

--- a/addons/website_crm_partner_assign/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_crm_partner_assign/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'website_crm_partner_assign'---
-website_crm_partner_assign / res.partner.grade        / is_published (boolean)        : NEW 
+website_crm_partner_assign / res.partner.grade        / is_published (boolean)        : NEW
 website_crm_partner_assign / res.partner.grade        / website_published (boolean)   : not stored anymore
 website_crm_partner_assign / res.partner.grade        / website_published (boolean)   : now related
 ---XML records in module 'website_crm_partner_assign'---

--- a/addons/website_customer/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_customer/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'website_customer'---
-website_customer / res.partner.tag          / is_published (boolean)        : NEW 
+website_customer / res.partner.tag          / is_published (boolean)        : NEW
 website_customer / res.partner.tag          / website_published (boolean)   : not stored anymore
 website_customer / res.partner.tag          / website_published (boolean)   : now related
 ---XML records in module 'website_customer'---

--- a/addons/website_event/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_event/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,8 +1,8 @@
 ---Fields in module 'website_event'---
-website_event / event.event              / is_published (boolean)        : NEW 
+website_event / event.event              / is_published (boolean)        : NEW
 website_event / event.event              / website_id (many2one)         : NEW relation: website
 website_event / event.event              / website_menu (boolean)        : not a function anymore
-website_event / event.event              / website_meta_og_img (char)    : NEW 
+website_event / event.event              / website_meta_og_img (char)    : NEW
 website_event / event.event              / website_published (boolean)   : not stored anymore
 website_event / event.event              / website_published (boolean)   : now a function
 ---XML records in module 'website_event'---

--- a/addons/website_event_track/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_event_track/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,17 +1,17 @@
 ---Fields in module 'website_event_track'---
 website_event_track / event.event              / track_menu_ids (one2many)     : NEW relation: website.event.menu
 website_event_track / event.event              / track_proposal_menu_ids (one2many): NEW relation: website.event.menu
-website_event_track / event.event              / website_track (boolean)       : not a function anymore
 website_event_track / event.event              / website_track (boolean)       : is now stored
-website_event_track / event.event              / website_track_proposal (boolean): not a function anymore
+website_event_track / event.event              / website_track (boolean)       : not a function anymore
 website_event_track / event.event              / website_track_proposal (boolean): is now stored
+website_event_track / event.event              / website_track_proposal (boolean): not a function anymore
 website_event_track / event.track              / activity_date_deadline (date) : not related anymore
 website_event_track / event.track              / activity_date_deadline (date) : not stored anymore
 website_event_track / event.track              / activity_date_deadline (date) : now a function
-website_event_track / event.track              / is_published (boolean)        : NEW 
-website_event_track / event.track              / message_last_post (datetime)  : DEL 
+website_event_track / event.track              / is_published (boolean)        : NEW
+website_event_track / event.track              / message_last_post (datetime)  : DEL
 website_event_track / event.track              / message_main_attachment_id (many2one): NEW relation: ir.attachment
-website_event_track / event.track              / website_meta_og_img (char)    : NEW 
+website_event_track / event.track              / website_meta_og_img (char)    : NEW
 website_event_track / event.track              / website_published (boolean)   : not stored anymore
 website_event_track / event.track              / website_published (boolean)   : now related
 website_event_track / website.event.menu       / event_id (many2one)           : NEW relation: event.event

--- a/addons/website_forum/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_forum/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,14 +1,14 @@
 ---Fields in module 'website_forum'---
-website_forum / forum.forum              / message_last_post (datetime)  : DEL 
+website_forum / forum.forum              / message_last_post (datetime)  : DEL
 website_forum / forum.forum              / message_main_attachment_id (many2one): NEW relation: ir.attachment
 website_forum / forum.forum              / website_id (many2one)         : NEW relation: website
-website_forum / forum.forum              / website_meta_og_img (char)    : NEW 
-website_forum / forum.post               / message_last_post (datetime)  : DEL 
+website_forum / forum.forum              / website_meta_og_img (char)    : NEW
+website_forum / forum.post               / message_last_post (datetime)  : DEL
 website_forum / forum.post               / message_main_attachment_id (many2one): NEW relation: ir.attachment
-website_forum / forum.post               / website_meta_og_img (char)    : NEW 
-website_forum / forum.tag                / message_last_post (datetime)  : DEL 
+website_forum / forum.post               / website_meta_og_img (char)    : NEW
+website_forum / forum.tag                / message_last_post (datetime)  : DEL
 website_forum / forum.tag                / message_main_attachment_id (many2one): NEW relation: ir.attachment
-website_forum / forum.tag                / website_meta_og_img (char)    : NEW 
+website_forum / forum.tag                / website_meta_og_img (char)    : NEW
 ---XML records in module 'website_forum'---
 NEW ir.ui.menu: website_forum.menu_forum_global
 NEW ir.ui.menu: website_forum.menu_forum_tag_global

--- a/addons/website_hr/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_hr/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'website_hr'---
-website_hr   / hr.employee              / is_published (boolean)        : NEW 
+website_hr   / hr.employee              / is_published (boolean)        : NEW
 website_hr   / hr.employee              / website_id (many2one)         : NEW relation: website
 website_hr   / hr.employee              / website_published (boolean)   : not stored anymore
 website_hr   / hr.employee              / website_published (boolean)   : now a function

--- a/addons/website_hr_recruitment/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_hr_recruitment/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,7 +1,7 @@
 ---Fields in module 'website_hr_recruitment'---
-website_hr_recruitment / hr.job                   / is_published (boolean)        : NEW 
+website_hr_recruitment / hr.job                   / is_published (boolean)        : NEW
 website_hr_recruitment / hr.job                   / website_id (many2one)         : NEW relation: website
-website_hr_recruitment / hr.job                   / website_meta_og_img (char)    : NEW 
+website_hr_recruitment / hr.job                   / website_meta_og_img (char)    : NEW
 website_hr_recruitment / hr.job                   / website_published (boolean)   : not stored anymore
 website_hr_recruitment / hr.job                   / website_published (boolean)   : now a function
 ---XML records in module 'website_hr_recruitment'---

--- a/addons/website_livechat/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_livechat/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'website_livechat'---
-website_livechat / im_livechat.channel      / is_published (boolean)        : NEW 
+website_livechat / im_livechat.channel      / is_published (boolean)        : NEW
 website_livechat / im_livechat.channel      / website_published (boolean)   : not stored anymore
 website_livechat / im_livechat.channel      / website_published (boolean)   : now related
 ---XML records in module 'website_livechat'---

--- a/addons/website_partner/migrations/12.0.0.1/openupgrade_analysis.txt
+++ b/addons/website_partner/migrations/12.0.0.1/openupgrade_analysis.txt
@@ -1,6 +1,6 @@
 ---Fields in module 'website_partner'---
-website_partner / res.partner              / is_published (boolean)        : NEW 
-website_partner / res.partner              / website_meta_og_img (char)    : NEW 
+website_partner / res.partner              / is_published (boolean)        : NEW
+website_partner / res.partner              / website_meta_og_img (char)    : NEW
 website_partner / res.partner              / website_published (boolean)   : not stored anymore
 website_partner / res.partner              / website_published (boolean)   : now related
 ---XML records in module 'website_partner'---

--- a/addons/website_sale/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_sale/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,24 +1,24 @@
 ---Fields in module 'website_sale'---
 website_sale / account.invoice          / website_id (many2one)         : NEW relation: website
-website_sale / digest.digest            / kpi_website_sale_total (boolean): NEW 
+website_sale / digest.digest            / kpi_website_sale_total (boolean): NEW
 website_sale / product.attribute        / type (selection)              : module is now 'sale' ('website_sale')
 website_sale / product.attribute        / type (selection)              : now required, default = function
 website_sale / product.attribute.value  / html_color (char)             : module is now 'sale' ('website_sale')
 website_sale / product.product          / website_description (html)    : previously in module website_quote
 website_sale / product.public.category  / website_id (many2one)         : NEW relation: website
-website_sale / product.public.category  / website_meta_og_img (char)    : NEW 
-website_sale / product.template         / is_published (boolean)        : NEW 
+website_sale / product.public.category  / website_meta_og_img (char)    : NEW
+website_sale / product.template         / is_published (boolean)        : NEW
 website_sale / product.template         / website_description (html)    : previously in module website_quote
 website_sale / product.template         / website_id (many2one)         : NEW relation: website
-website_sale / product.template         / website_meta_og_img (char)    : NEW 
+website_sale / product.template         / website_meta_og_img (char)    : NEW
 website_sale / product.template         / website_published (boolean)   : not stored anymore
 website_sale / product.template         / website_published (boolean)   : now a function
 website_sale / res.company              / website_sale_onboarding_payment_acquirer_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
 website_sale / res.partner              / last_website_so_id (many2one) : not stored anymore
 website_sale / res.partner              / last_website_so_id (many2one) : now a function
-website_sale / sale.order               / can_directly_mark_as_paid (boolean): DEL 
+website_sale / sale.order               / can_directly_mark_as_paid (boolean): DEL
 website_sale / sale.order               / website_id (many2one)         : NEW relation: website
-website_sale / website                  / cart_abandoned_delay (float)  : NEW 
+website_sale / website                  / cart_abandoned_delay (float)  : NEW
 website_sale / website                  / cart_recovery_mail_template_id (many2one): NEW relation: mail.template
 website_sale_options / product.product          / optional_product_ids (many2many): module is now 'sale' ('website_sale_options')
 website_sale_options / product.template         / optional_product_ids (many2many): module is now 'sale' ('website_sale_options')

--- a/addons/website_sale_delivery/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_sale_delivery/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,5 +1,5 @@
 ---Fields in module 'website_sale_delivery'---
-website_sale_delivery / delivery.carrier         / is_published (boolean)        : NEW 
+website_sale_delivery / delivery.carrier         / is_published (boolean)        : NEW
 website_sale_delivery / delivery.carrier         / website_id (many2one)         : NEW relation: website
 website_sale_delivery / delivery.carrier         / website_published (boolean)   : not stored anymore
 website_sale_delivery / delivery.carrier         / website_published (boolean)   : now a function

--- a/addons/website_sale_wishlist/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_sale_wishlist/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,3 +1,3 @@
 ---Fields in module 'website_sale_wishlist'---
-website_sale_wishlist / product.wishlist         / session (char)                : DEL 
+website_sale_wishlist / product.wishlist         / session (char)                : DEL
 ---XML records in module 'website_sale_wishlist'---

--- a/addons/website_slides/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_slides/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -1,18 +1,18 @@
 ---Fields in module 'website_slides'---
-website_slides / slide.channel            / is_published (boolean)        : NEW 
-website_slides / slide.channel            / message_last_post (datetime)  : DEL 
+website_slides / slide.channel            / is_published (boolean)        : NEW
+website_slides / slide.channel            / message_last_post (datetime)  : DEL
 website_slides / slide.channel            / message_main_attachment_id (many2one): NEW relation: ir.attachment
 website_slides / slide.channel            / website_id (many2one)         : NEW relation: website
-website_slides / slide.channel            / website_meta_og_img (char)    : NEW 
+website_slides / slide.channel            / website_meta_og_img (char)    : NEW
 website_slides / slide.channel            / website_published (boolean)   : not stored anymore
 website_slides / slide.channel            / website_published (boolean)   : now a function
-website_slides / slide.slide              / is_published (boolean)        : NEW 
-website_slides / slide.slide              / message_last_post (datetime)  : DEL 
+website_slides / slide.slide              / is_published (boolean)        : NEW
+website_slides / slide.slide              / message_last_post (datetime)  : DEL
 website_slides / slide.slide              / message_main_attachment_id (many2one): NEW relation: ir.attachment
-website_slides / slide.slide              / website_meta_og_img (char)    : NEW 
+website_slides / slide.slide              / website_meta_og_img (char)    : NEW
 website_slides / slide.slide              / website_published (boolean)   : not stored anymore
 website_slides / slide.slide              / website_published (boolean)   : now related
-website_slides / website                  / website_slide_google_app_key (char): NEW 
+website_slides / website                  / website_slide_google_app_key (char): NEW
 ---XML records in module 'website_slides'---
 DEL ir.config_parameter: website_slides.google_app_key (noupdate)
 NEW ir.ui.menu: website_slides.menu_action_ir_slide_category_global

--- a/addons/website_theme_install/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/website_theme_install/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -4,28 +4,28 @@ website_theme_install / ir.ui.view               / theme_template_id (many2one) 
 website_theme_install / theme.ir.attachment      / copy_ids (one2many)           : NEW relation: ir.attachment
 website_theme_install / theme.ir.attachment      / key (char)                    : NEW required: required
 website_theme_install / theme.ir.attachment      / name (char)                   : NEW required: required
-website_theme_install / theme.ir.attachment      / url (char)                    : NEW 
-website_theme_install / theme.ir.ui.view         / active (boolean)              : NEW 
-website_theme_install / theme.ir.ui.view         / arch (text)                   : NEW 
-website_theme_install / theme.ir.ui.view         / arch_fs (char)                : NEW 
+website_theme_install / theme.ir.attachment      / url (char)                    : NEW
+website_theme_install / theme.ir.ui.view         / active (boolean)              : NEW
+website_theme_install / theme.ir.ui.view         / arch (text)                   : NEW
+website_theme_install / theme.ir.ui.view         / arch_fs (char)                : NEW
 website_theme_install / theme.ir.ui.view         / copy_ids (one2many)           : NEW relation: ir.ui.view
-website_theme_install / theme.ir.ui.view         / inherit_id (reference)        : NEW 
-website_theme_install / theme.ir.ui.view         / key (char)                    : NEW 
+website_theme_install / theme.ir.ui.view         / inherit_id (reference)        : NEW
+website_theme_install / theme.ir.ui.view         / key (char)                    : NEW
 website_theme_install / theme.ir.ui.view         / mode (selection)              : NEW selection_keys: ['extension', 'primary']
 website_theme_install / theme.ir.ui.view         / name (char)                   : NEW required: required
 website_theme_install / theme.ir.ui.view         / priority (integer)            : NEW required: required, req_default: function
-website_theme_install / theme.ir.ui.view         / type (char)                   : NEW 
+website_theme_install / theme.ir.ui.view         / type (char)                   : NEW
 website_theme_install / theme.website.menu       / copy_ids (one2many)           : NEW relation: website.menu
 website_theme_install / theme.website.menu       / name (char)                   : NEW required: required
-website_theme_install / theme.website.menu       / new_window (boolean)          : NEW 
+website_theme_install / theme.website.menu       / new_window (boolean)          : NEW
 website_theme_install / theme.website.menu       / page_id (many2one)            : NEW relation: theme.website.page
 website_theme_install / theme.website.menu       / parent_id (many2one)          : NEW relation: theme.website.menu
-website_theme_install / theme.website.menu       / sequence (integer)            : NEW 
-website_theme_install / theme.website.menu       / url (char)                    : NEW 
+website_theme_install / theme.website.menu       / sequence (integer)            : NEW
+website_theme_install / theme.website.menu       / url (char)                    : NEW
 website_theme_install / theme.website.page       / copy_ids (one2many)           : NEW relation: website.page
-website_theme_install / theme.website.page       / url (char)                    : NEW 
+website_theme_install / theme.website.page       / url (char)                    : NEW
 website_theme_install / theme.website.page       / view_id (many2one)            : NEW relation: theme.ir.ui.view, required: required
-website_theme_install / theme.website.page       / website_indexed (boolean)     : NEW 
+website_theme_install / theme.website.page       / website_indexed (boolean)     : NEW
 website_theme_install / website.menu             / theme_template_id (many2one)  : NEW relation: theme.website.menu
 website_theme_install / website.page             / theme_template_id (many2one)  : NEW relation: theme.website.page
 ---XML records in module 'website_theme_install'---

--- a/odoo/addons/base/migrations/12.0.1.3/openupgrade_analysis.txt
+++ b/odoo/addons/base/migrations/12.0.1.3/openupgrade_analysis.txt
@@ -1,33 +1,33 @@
 ---Fields in module 'base'---
-auth_crypt   / res.users                / password_crypt (char)         : DEL 
+auth_crypt   / res.users                / password_crypt (char)         : DEL
 base         / ir.actions.report        / report_type (selection)       : selection_keys is now '['qweb-html', 'qweb-pdf', 'qweb-text']' ('['qweb-html', 'qweb-pdf']')
-base         / ir.attachment            / active (boolean)              : NEW 
-base         / ir.attachment            / res_model_name (char)         : NEW 
+base         / ir.attachment            / active (boolean)              : NEW
+base         / ir.attachment            / res_model_name (char)         : NEW
 base         / ir.attachment            / thumbnail (binary)            : NEW attachment: True
 base         / ir.model                 / rule_ids (one2many)           : NEW relation: ir.rule
 base         / ir.model.fields          / copy (boolean)                : was renamed to copied [nothing to do]
 base         / ir.model.fields          / related_field_id (many2one)   : NEW relation: ir.model.fields
 base         / ir.model.fields          / relation_field_id (many2one)  : NEW relation: ir.model.fields
-base         / ir.module.module         / to_buy (boolean)              : NEW 
+base         / ir.module.module         / to_buy (boolean)              : NEW
 base         / ir.server.object.lines   / type (selection)              : selection_keys is now '['equation', 'reference', 'value']' ('['equation', 'value']')
 base         / ir.translation           / type (selection)              : selection_keys is now '['code', 'constraint', 'model', 'model_terms', 'selection', 'sql_constraint']' ('['code', 'constraint', 'field', 'help', 'model', 'report', 'selection', 'sql_constraint', 'view']')
-base         / ir.ui.menu               / parent_left (integer)         : DEL 
-base         / ir.ui.menu               / parent_path (char)            : NEW 
-base         / ir.ui.menu               / parent_right (integer)        : DEL 
+base         / ir.ui.menu               / parent_left (integer)         : DEL
+base         / ir.ui.menu               / parent_path (char)            : NEW
+base         / ir.ui.menu               / parent_right (integer)        : DEL
 base         / res.company              / base_onboarding_company_state (selection): NEW selection_keys: ['done', 'just_done', 'not_done']
 base         / res.company              / external_report_layout (selection): DEL selection_keys: ['background', 'boxed', 'clean', 'standard']
 base         / res.company              / external_report_layout_id (many2one): NEW relation: ir.ui.view
 base         / res.currency             / decimal_places (integer)      : is now stored
-base         / res.groups               / is_portal (boolean)           : DEL 
+base         / res.groups               / is_portal (boolean)           : DEL
 base         / res.lang                 / week_start (selection)        : NEW required: required, selection_keys: [1, 2, 3, 4, 5, 6, 7], req_default: function
 base         / res.partner              / commercial_partner_country_id (many2one): DEL relation: res.country
-base         / res.partner.bank         / acc_holder_name (char)        : NEW 
+base         / res.partner.bank         / acc_holder_name (char)        : NEW
 base         / res.partner.bank         / acc_type (char)               : selection_keys is now 'function' ('False')
 base         / res.partner.bank         / acc_type (char)               : type is now 'selection' ('char')
 base         / res.partner.bank         / partner_id (many2one)         : now required
-base         / res.partner.category     / parent_left (integer)         : DEL 
-base         / res.partner.category     / parent_path (char)            : NEW 
-base         / res.partner.category     / parent_right (integer)        : DEL 
+base         / res.partner.category     / parent_left (integer)         : DEL
+base         / res.partner.category     / parent_path (char)            : NEW
+base         / res.partner.category     / parent_right (integer)        : DEL
 base         / res.users                / password (char)               : not stored anymore
 base         / res.users                / password (char)               : now a function
 ---XML records in module 'base'---
@@ -79,6 +79,8 @@ DEL ir.ui.view: base.action_view_company_form_link_2_currencies
 DEL ir.ui.view: base.res_request_link-view
 DEL ir.ui.view: base.res_request_link_search_view
 DEL ir.ui.view: base.res_request_link_tree-view
+NEW res.lang: base.lang_ar
+NEW res.lang: base.lang_bn_IN
 NEW res.lang: base.lang_en_CA
 NEW res.partner: base.partner_admin (noupdate)
 DEL res.request.link: base.req_link_partner (noupdate)

--- a/odoo/addons/base/migrations/12.0.1.3/openupgrade_general_log.txt
+++ b/odoo/addons/base/migrations/12.0.1.3/openupgrade_general_log.txt
@@ -1,12 +1,12 @@
 ---Fields in module 'general'---
-# 7353 fields matched,
+# 7352 fields matched,
 # Direct match: 6966
-# Found in other module: 152
+# Found in other module: 155
 # Found with different name: 0
 # Found with different type: 2
-# In obsolete models: 233
-# New columns: 1313
-# Not matched: 244
+# In obsolete models: 229
+# New columns: 1346
+# Not matched: 246
 new model account.analytic.distribution
 new model account.analytic.group
 new model account.fiscal.year
@@ -26,6 +26,7 @@ new model fleet.vehicle.assignation.log
 new model hr.leave
 new model hr.leave.allocation
 new model hr.leave.type
+new model l10n_it.ddt
 new model mail.blacklist
 new model mail.mass_mailing.list_contact_rel
 new model mail.moderation
@@ -83,7 +84,7 @@ obsolete model procurement.rule (renamed to stock.rule)
 obsolete model product.attribute.line (renamed to product.template.attribute.line)
 obsolete model product.attribute.price (renamed to product.template.attribute.value)
 obsolete model product.uom (renamed to uom.uom)
-obsolete model product.uom.categ
+obsolete model product.uom.categ (renamed to uom.category)
 obsolete model report.intrastat.code
 obsolete model res.request.link
 obsolete model sale.layout_category
@@ -94,284 +95,6 @@ obsolete model stock.incoterms (renamed to account.incoterms)
 obsolete model stock.location.path
 obsolete model web.planner
 ---XML records in module 'general'---
-ERROR: module not in list of installed modules:
----Fields in module 'auth_crypt'---
----XML records in module 'auth_crypt'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'web_planner'---
----XML records in module 'web_planner'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'anonymization'---
----XML records in module 'anonymization'---
-DEL ir.actions.act_window: anonymization.action_ir_model_fields_anonymization_history_tree
-DEL ir.actions.act_window: anonymization.action_ir_model_fields_anonymization_tree
-DEL ir.actions.act_window: anonymization.action_ir_model_fields_anonymize_wizard
-DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_group_system
-DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_history_group_system
-DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_history_user
-DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_migration_fix
-DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_user
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_analytic_line_amount
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_amount_tax
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_amount_total
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_amount_untaxed
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_line_price_subtotal
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_line_price_unit
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_residual
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_tax_amount
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_move_line_amount_currency
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_move_line_credit
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_move_line_debit
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_product_name
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_purchase_order_amount_tax
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_purchase_order_amount_total
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_purchase_order_amount_untaxed
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_purchase_order_line_price_unit
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_city
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_code
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_display_name
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_email
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_mobile
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_name
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_phone
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_street
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_street2
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_zip
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_users_signature
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_amount_tax
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_amount_total
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_amount_untaxed
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_line_discount
-DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_line_price_unit
-DEL ir.ui.menu: anonymization.menu_administration_anonymization
-DEL ir.ui.menu: anonymization.menu_administration_anonymization_fields
-DEL ir.ui.menu: anonymization.menu_administration_anonymization_history
-DEL ir.ui.menu: anonymization.menu_administration_anonymization_wizard
-DEL ir.ui.view: anonymization.view_ir_model_fields_anonymization_form
-DEL ir.ui.view: anonymization.view_ir_model_fields_anonymization_history_form
-DEL ir.ui.view: anonymization.view_ir_model_fields_anonymization_history_tree
-DEL ir.ui.view: anonymization.view_ir_model_fields_anonymization_tree
-DEL ir.ui.view: anonymization.view_ir_model_fields_anonymize_wizard_form
-DEL ir.ui.view: anonymization.view_ir_model_fields_nonymization_kanban
-ERROR: module not in list of installed modules:
----Fields in module 'rating_project'---
----XML records in module 'rating_project'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'sale_order_dates'---
----XML records in module 'sale_order_dates'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'product_extended'---
----XML records in module 'product_extended'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'account_asset'---
-account_asset / account.invoice.line     / asset_category_id (many2one)  : DEL relation: account.asset.category
-account_asset / account.invoice.line     / asset_end_date (date)         : DEL 
-account_asset / account.invoice.line     / asset_mrr (float)             : DEL 
-account_asset / account.invoice.line     / asset_start_date (date)       : DEL 
-account_asset / account.move             / asset_depreciation_ids (one2many): DEL relation: account.asset.depreciation.line
-account_asset / product.template         / asset_category_id (many2one)  : DEL relation: account.asset.category
-account_asset / product.template         / deferred_revenue_category_id (many2one): DEL relation: account.asset.category
----XML records in module 'account_asset'---
-DEL ir.actions.act_window: account_asset.action_account_asset_asset_form
-DEL ir.actions.act_window: account_asset.action_account_asset_asset_list_normal_purchase
-DEL ir.actions.act_window: account_asset.action_asset_asset_report
-DEL ir.actions.act_window: account_asset.action_asset_depreciation_confirmation_wizard
-DEL ir.actions.act_window: account_asset.action_asset_modify
-DEL ir.cron: account_asset.account_asset_cron
-DEL ir.model.access: account_asset.access_account_asset_asset
-DEL ir.model.access: account_asset.access_account_asset_asset_invoicing_payment
-DEL ir.model.access: account_asset.access_account_asset_asset_manager
-DEL ir.model.access: account_asset.access_account_asset_category
-DEL ir.model.access: account_asset.access_account_asset_category_invoicing_payment
-DEL ir.model.access: account_asset.access_account_asset_category_manager
-DEL ir.model.access: account_asset.access_account_asset_depreciation_line
-DEL ir.model.access: account_asset.access_account_asset_depreciation_line_invoicing_payment
-DEL ir.model.access: account_asset.access_account_asset_depreciation_line_manager
-DEL ir.model.access: account_asset.access_asset_asset_report
-DEL ir.model.access: account_asset.access_asset_asset_report_manager
-DEL ir.rule: account_asset.account_asset_asset_multi_company_rule (noupdate)
-DEL ir.rule: account_asset.account_asset_category_multi_company_rule (noupdate)
-DEL ir.ui.menu: account_asset.menu_action_account_asset_asset_form
-DEL ir.ui.menu: account_asset.menu_action_account_asset_asset_list_normal_purchase
-DEL ir.ui.menu: account_asset.menu_action_asset_asset_report
-DEL ir.ui.menu: account_asset.menu_asset_depreciation_confirmation_wizard
-DEL ir.ui.menu: account_asset.menu_finance_config_assets
-DEL ir.ui.view: account_asset.action_account_asset_report_graph
-DEL ir.ui.view: account_asset.action_account_asset_report_pivot
-DEL ir.ui.view: account_asset.asset_modify_form
-DEL ir.ui.view: account_asset.assets_backend
-DEL ir.ui.view: account_asset.qunit_suite
-DEL ir.ui.view: account_asset.res_config_settings_view_form
-DEL ir.ui.view: account_asset.view_account_asset_asset_category_kanban
-DEL ir.ui.view: account_asset.view_account_asset_asset_form
-DEL ir.ui.view: account_asset.view_account_asset_asset_kanban
-DEL ir.ui.view: account_asset.view_account_asset_asset_purchase_tree
-DEL ir.ui.view: account_asset.view_account_asset_category_form
-DEL ir.ui.view: account_asset.view_account_asset_category_search
-DEL ir.ui.view: account_asset.view_account_asset_category_tree
-DEL ir.ui.view: account_asset.view_account_asset_search
-DEL ir.ui.view: account_asset.view_asset_asset_report_search
-DEL ir.ui.view: account_asset.view_asset_depreciation_confirmation_wizard
-DEL ir.ui.view: account_asset.view_invoice_asset_category
-DEL ir.ui.view: account_asset.view_product_template_form_inherit
-ERROR: module not in list of installed modules:
----Fields in module 'account_budget'---
-account_budget / account.analytic.account / crossovered_budget_line (one2many): DEL relation: crossovered.budget.lines
----XML records in module 'account_budget'---
-DEL ir.actions.act_window: account_budget.act_account_analytic_account_cb_lines
-DEL ir.actions.act_window: account_budget.act_crossovered_budget_lines_view
-DEL ir.actions.act_window: account_budget.act_crossovered_budget_view
-DEL ir.actions.act_window: account_budget.open_budget_post_form
-DEL ir.model.access: account_budget.access_account_budget_post
-DEL ir.model.access: account_budget.access_account_budget_post_accountant
-DEL ir.model.access: account_budget.access_budget
-DEL ir.model.access: account_budget.access_crossovered_budget
-DEL ir.model.access: account_budget.access_crossovered_budget_accountant
-DEL ir.model.access: account_budget.access_crossovered_budget_lines_accountant
-DEL ir.rule: account_budget.budget_comp_rule (noupdate)
-DEL ir.rule: account_budget.budget_lines_comp_rule (noupdate)
-DEL ir.rule: account_budget.budget_post_comp_rule (noupdate)
-DEL ir.ui.menu: account_budget.menu_act_crossovered_budget_lines_view
-DEL ir.ui.menu: account_budget.menu_act_crossovered_budget_view
-DEL ir.ui.menu: account_budget.menu_budget_post_form
-DEL ir.ui.view: account_budget.crossovered_budget_view_form
-DEL ir.ui.view: account_budget.crossovered_budget_view_tree
-DEL ir.ui.view: account_budget.res_config_settings_view_form
-DEL ir.ui.view: account_budget.view_account_analytic_account_form_inherit_budget
-DEL ir.ui.view: account_budget.view_budget_post_form
-DEL ir.ui.view: account_budget.view_budget_post_search
-DEL ir.ui.view: account_budget.view_budget_post_tree
-DEL ir.ui.view: account_budget.view_crossovered_budget_kanban
-DEL ir.ui.view: account_budget.view_crossovered_budget_line_form
-DEL ir.ui.view: account_budget.view_crossovered_budget_line_search
-DEL ir.ui.view: account_budget.view_crossovered_budget_line_tree
-DEL ir.ui.view: account_budget.view_crossovered_budget_search
-DEL res.users: base.user_root (noupdate)
-ERROR: module not in list of installed modules:
----Fields in module 'account_invoicing'---
----XML records in module 'account_invoicing'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'website_quote'---
----XML records in module 'website_quote'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'website_sale_options'---
----XML records in module 'website_sale_options'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'website_forum_doc'---
-website_forum_doc / forum.post               / color (integer)               : DEL 
-website_forum_doc / forum.post               / documentation_stage_id (many2one): DEL relation: forum.documentation.stage
-website_forum_doc / forum.post               / documentation_toc_id (many2one): DEL relation: forum.documentation.toc
----XML records in module 'website_forum_doc'---
-DEL forum.documentation.stage: website_forum_doc.stage_draft (noupdate)
-DEL forum.documentation.stage: website_forum_doc.stage_ideas (noupdate)
-DEL forum.documentation.stage: website_forum_doc.stage_publish (noupdate)
-DEL forum.documentation.stage: website_forum_doc.stage_review (noupdate)
-DEL ir.actions.act_url: website_forum_doc.action_open_documentation
-DEL ir.actions.act_window: website_forum_doc.action_documentation_toc
-DEL ir.actions.act_window: website_forum_doc.action_forum_doc_post
-DEL ir.actions.todo: base.open_menu
-DEL ir.model.access: website_forum_doc.all_documentation_toc
-DEL ir.model.access: website_forum_doc.users_documentation_stage
-DEL ir.model.access: website_forum_doc.users_documentation_stage_all
-DEL ir.model.access: website_forum_doc.users_documentation_toc
-DEL ir.ui.menu: website_forum_doc.menu_documentation
-DEL ir.ui.menu: website_forum_doc.menu_forum_doc_posts
-DEL ir.ui.view: website_forum_doc.assets_frontend
-DEL ir.ui.view: website_forum_doc.breadcrumb
-DEL ir.ui.view: website_forum_doc.documentation
-DEL ir.ui.view: website_forum_doc.documentation_post
-DEL ir.ui.view: website_forum_doc.forum_question_doc
-DEL ir.ui.view: website_forum_doc.header_footer_custom
-DEL ir.ui.view: website_forum_doc.promote_question
-DEL ir.ui.view: website_forum_doc.toc
-DEL ir.ui.view: website_forum_doc.view_documentation_toc_list
-DEL ir.ui.view: website_forum_doc.view_forum_post_doc_form
-DEL ir.ui.view: website_forum_doc.view_forum_post_doc_list
-DEL ir.ui.view: website_forum_doc.view_forum_post_kanban
-DEL website.menu: website_forum_doc.menu_questions (noupdate)
-ERROR: module not in list of installed modules:
----Fields in module 'website_sale_stock_options'---
----XML records in module 'website_sale_stock_options'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'base_vat_autocomplete'---
----XML records in module 'base_vat_autocomplete'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'mrp_repair'---
----XML records in module 'mrp_repair'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'account_cash_basis_base_account'---
----XML records in module 'account_cash_basis_base_account'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'sale_payment'---
----XML records in module 'sale_payment'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'website_rating_project'---
----XML records in module 'website_rating_project'---
----nothing has changed in this module--
-ERROR: module not in list of installed modules:
----Fields in module 'report_intrastat'---
-report_intrastat / product.template         / intrastat_id (many2one)       : DEL relation: report.intrastat.code
-report_intrastat / res.country              / intrastat (boolean)           : DEL 
----XML records in module 'report_intrastat'---
-DEL ir.actions.act_window: report_intrastat.action_report_intrastat_code_tree
-DEL ir.actions.act_window: report_intrastat.action_report_intrastat_tree_all
-DEL ir.actions.report: report_intrastat.account_intrastatinvoices
-DEL ir.model.access: report_intrastat.access_report_intrastat
-DEL ir.model.access: report_intrastat.access_report_intrastat_code
-DEL ir.model.access: report_intrastat.access_report_intrastat_code_purchase_manager
-DEL ir.model.access: report_intrastat.access_report_intrastat_code_sale_manager
-DEL ir.model.access: report_intrastat.access_report_intrastat_code_stock_manager
-DEL ir.rule: report_intrastat.invoice_analysis_comp_rule
-DEL ir.ui.menu: report_intrastat.menu_report_intrastat_all
-DEL ir.ui.menu: report_intrastat.menu_report_intrastat_code
-DEL ir.ui.view: report_intrastat.product_template_form_view
-DEL ir.ui.view: report_intrastat.report_intrastatinvoice
-DEL ir.ui.view: report_intrastat.report_intrastatinvoice_document
-DEL ir.ui.view: report_intrastat.view_country_form
-DEL ir.ui.view: report_intrastat.view_country_tree
-DEL ir.ui.view: report_intrastat.view_report_intrastat_code_form
-DEL ir.ui.view: report_intrastat.view_report_intrastat_code_tree
-DEL ir.ui.view: report_intrastat.view_report_intrastat_kanban
-DEL ir.ui.view: report_intrastat.view_report_intrastat_search
-DEL ir.ui.view: report_intrastat.view_report_intrastat_tree
-DEL res.country: base.at (noupdate)
-DEL res.country: base.be (noupdate)
-DEL res.country: base.cy (noupdate)
-DEL res.country: base.cz (noupdate)
-DEL res.country: base.de (noupdate)
-DEL res.country: base.dk (noupdate)
-DEL res.country: base.ee (noupdate)
-DEL res.country: base.es (noupdate)
-DEL res.country: base.fi (noupdate)
-DEL res.country: base.fr (noupdate)
-DEL res.country: base.gr (noupdate)
-DEL res.country: base.hu (noupdate)
-DEL res.country: base.ie (noupdate)
-DEL res.country: base.it (noupdate)
-DEL res.country: base.lt (noupdate)
-DEL res.country: base.lu (noupdate)
-DEL res.country: base.lv (noupdate)
-DEL res.country: base.mt (noupdate)
-DEL res.country: base.nl (noupdate)
-DEL res.country: base.pl (noupdate)
-DEL res.country: base.pt (noupdate)
-DEL res.country: base.se (noupdate)
-DEL res.country: base.si (noupdate)
-DEL res.country: base.sk (noupdate)
-DEL res.country: base.uk (noupdate)
 ERROR: module not in list of installed modules:
 ---Fields in module 'pos_data_drinks'---
 ---XML records in module 'pos_data_drinks'---
@@ -440,6 +163,289 @@ DEL product.product: pos_data_drinks.tuborg (noupdate)
 DEL product.product: pos_data_drinks.water (noupdate)
 DEL product.product: pos_data_drinks.white_russian (noupdate)
 DEL product.product: pos_data_drinks.white_wine (noupdate)
+ERROR: module not in list of installed modules:
+---Fields in module 'account_cash_basis_base_account'---
+---XML records in module 'account_cash_basis_base_account'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'l10n_be_intrastat_2019'---
+l10n_be_intrastat_2019 / account.invoice.line     / intrastat_product_origin_country_id (many2one): DEL relation: res.country
+---XML records in module 'l10n_be_intrastat_2019'---
+DEL ir.ui.view: l10n_be_intrastat_2019.invoice_line_be_intrastat_data_form
+ERROR: module not in list of installed modules:
+---Fields in module 'mrp_repair'---
+---XML records in module 'mrp_repair'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'account_invoicing'---
+---XML records in module 'account_invoicing'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'auth_crypt'---
+---XML records in module 'auth_crypt'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'rating_project'---
+---XML records in module 'rating_project'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'sale_payment'---
+---XML records in module 'sale_payment'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'account_budget'---
+account_budget / account.analytic.account / crossovered_budget_line (one2many): DEL relation: crossovered.budget.lines
+---XML records in module 'account_budget'---
+DEL ir.actions.act_window: account_budget.act_account_analytic_account_cb_lines
+DEL ir.actions.act_window: account_budget.act_crossovered_budget_lines_view
+DEL ir.actions.act_window: account_budget.act_crossovered_budget_view
+DEL ir.actions.act_window: account_budget.open_budget_post_form
+DEL ir.model.access: account_budget.access_account_budget_post
+DEL ir.model.access: account_budget.access_account_budget_post_accountant
+DEL ir.model.access: account_budget.access_budget
+DEL ir.model.access: account_budget.access_crossovered_budget
+DEL ir.model.access: account_budget.access_crossovered_budget_accountant
+DEL ir.model.access: account_budget.access_crossovered_budget_lines_accountant
+DEL ir.rule: account_budget.budget_comp_rule (noupdate)
+DEL ir.rule: account_budget.budget_lines_comp_rule (noupdate)
+DEL ir.rule: account_budget.budget_post_comp_rule (noupdate)
+DEL ir.ui.menu: account_budget.menu_act_crossovered_budget_lines_view
+DEL ir.ui.menu: account_budget.menu_act_crossovered_budget_view
+DEL ir.ui.menu: account_budget.menu_budget_post_form
+DEL ir.ui.view: account_budget.crossovered_budget_view_form
+DEL ir.ui.view: account_budget.crossovered_budget_view_tree
+DEL ir.ui.view: account_budget.res_config_settings_view_form
+DEL ir.ui.view: account_budget.view_account_analytic_account_form_inherit_budget
+DEL ir.ui.view: account_budget.view_budget_post_form
+DEL ir.ui.view: account_budget.view_budget_post_search
+DEL ir.ui.view: account_budget.view_budget_post_tree
+DEL ir.ui.view: account_budget.view_crossovered_budget_kanban
+DEL ir.ui.view: account_budget.view_crossovered_budget_line_form
+DEL ir.ui.view: account_budget.view_crossovered_budget_line_search
+DEL ir.ui.view: account_budget.view_crossovered_budget_line_tree
+DEL ir.ui.view: account_budget.view_crossovered_budget_search
+DEL res.users: base.user_root (noupdate)
+ERROR: module not in list of installed modules:
+---Fields in module 'sale_order_dates'---
+---XML records in module 'sale_order_dates'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'website_quote'---
+---XML records in module 'website_quote'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'product_extended'---
+---XML records in module 'product_extended'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'website_rating_project'---
+---XML records in module 'website_rating_project'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'website_forum_doc'---
+website_forum_doc / forum.post               / color (integer)               : DEL
+website_forum_doc / forum.post               / documentation_stage_id (many2one): DEL relation: forum.documentation.stage
+website_forum_doc / forum.post               / documentation_toc_id (many2one): DEL relation: forum.documentation.toc
+---XML records in module 'website_forum_doc'---
+DEL forum.documentation.stage: website_forum_doc.stage_draft (noupdate)
+DEL forum.documentation.stage: website_forum_doc.stage_ideas (noupdate)
+DEL forum.documentation.stage: website_forum_doc.stage_publish (noupdate)
+DEL forum.documentation.stage: website_forum_doc.stage_review (noupdate)
+DEL ir.actions.act_url: website_forum_doc.action_open_documentation
+DEL ir.actions.act_window: website_forum_doc.action_documentation_toc
+DEL ir.actions.act_window: website_forum_doc.action_forum_doc_post
+DEL ir.actions.todo: base.open_menu
+DEL ir.model.access: website_forum_doc.all_documentation_toc
+DEL ir.model.access: website_forum_doc.users_documentation_stage
+DEL ir.model.access: website_forum_doc.users_documentation_stage_all
+DEL ir.model.access: website_forum_doc.users_documentation_toc
+DEL ir.ui.menu: website_forum_doc.menu_documentation
+DEL ir.ui.menu: website_forum_doc.menu_forum_doc_posts
+DEL ir.ui.view: website_forum_doc.assets_frontend
+DEL ir.ui.view: website_forum_doc.breadcrumb
+DEL ir.ui.view: website_forum_doc.documentation
+DEL ir.ui.view: website_forum_doc.documentation_post
+DEL ir.ui.view: website_forum_doc.forum_question_doc
+DEL ir.ui.view: website_forum_doc.header_footer_custom
+DEL ir.ui.view: website_forum_doc.promote_question
+DEL ir.ui.view: website_forum_doc.toc
+DEL ir.ui.view: website_forum_doc.view_documentation_toc_list
+DEL ir.ui.view: website_forum_doc.view_forum_post_doc_form
+DEL ir.ui.view: website_forum_doc.view_forum_post_doc_list
+DEL ir.ui.view: website_forum_doc.view_forum_post_kanban
+DEL website.menu: website_forum_doc.menu_questions (noupdate)
+ERROR: module not in list of installed modules:
+---Fields in module 'report_intrastat'---
+report_intrastat / product.template         / intrastat_id (many2one)       : DEL relation: report.intrastat.code
+report_intrastat / res.country              / intrastat (boolean)           : DEL
+---XML records in module 'report_intrastat'---
+DEL ir.actions.act_window: report_intrastat.action_report_intrastat_code_tree
+DEL ir.actions.act_window: report_intrastat.action_report_intrastat_tree_all
+DEL ir.actions.report: report_intrastat.account_intrastatinvoices
+DEL ir.model.access: report_intrastat.access_report_intrastat
+DEL ir.model.access: report_intrastat.access_report_intrastat_code
+DEL ir.model.access: report_intrastat.access_report_intrastat_code_purchase_manager
+DEL ir.model.access: report_intrastat.access_report_intrastat_code_sale_manager
+DEL ir.model.access: report_intrastat.access_report_intrastat_code_stock_manager
+DEL ir.rule: report_intrastat.invoice_analysis_comp_rule
+DEL ir.ui.menu: report_intrastat.menu_report_intrastat_all
+DEL ir.ui.menu: report_intrastat.menu_report_intrastat_code
+DEL ir.ui.view: report_intrastat.product_template_form_view
+DEL ir.ui.view: report_intrastat.report_intrastatinvoice
+DEL ir.ui.view: report_intrastat.report_intrastatinvoice_document
+DEL ir.ui.view: report_intrastat.view_country_form
+DEL ir.ui.view: report_intrastat.view_country_tree
+DEL ir.ui.view: report_intrastat.view_report_intrastat_code_form
+DEL ir.ui.view: report_intrastat.view_report_intrastat_code_tree
+DEL ir.ui.view: report_intrastat.view_report_intrastat_kanban
+DEL ir.ui.view: report_intrastat.view_report_intrastat_search
+DEL ir.ui.view: report_intrastat.view_report_intrastat_tree
+DEL res.country: base.at (noupdate)
+DEL res.country: base.be (noupdate)
+DEL res.country: base.cy (noupdate)
+DEL res.country: base.cz (noupdate)
+DEL res.country: base.de (noupdate)
+DEL res.country: base.dk (noupdate)
+DEL res.country: base.ee (noupdate)
+DEL res.country: base.es (noupdate)
+DEL res.country: base.fi (noupdate)
+DEL res.country: base.fr (noupdate)
+DEL res.country: base.gr (noupdate)
+DEL res.country: base.hu (noupdate)
+DEL res.country: base.ie (noupdate)
+DEL res.country: base.it (noupdate)
+DEL res.country: base.lt (noupdate)
+DEL res.country: base.lu (noupdate)
+DEL res.country: base.lv (noupdate)
+DEL res.country: base.mt (noupdate)
+DEL res.country: base.nl (noupdate)
+DEL res.country: base.pl (noupdate)
+DEL res.country: base.pt (noupdate)
+DEL res.country: base.se (noupdate)
+DEL res.country: base.si (noupdate)
+DEL res.country: base.sk (noupdate)
+DEL res.country: base.uk (noupdate)
+ERROR: module not in list of installed modules:
+---Fields in module 'anonymization'---
+---XML records in module 'anonymization'---
+DEL ir.actions.act_window: anonymization.action_ir_model_fields_anonymization_history_tree
+DEL ir.actions.act_window: anonymization.action_ir_model_fields_anonymization_tree
+DEL ir.actions.act_window: anonymization.action_ir_model_fields_anonymize_wizard
+DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_group_system
+DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_history_group_system
+DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_history_user
+DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_migration_fix
+DEL ir.model.access: anonymization.access_ir_model_fields_anonymization_user
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_analytic_line_amount
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_amount_tax
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_amount_total
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_amount_untaxed
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_line_price_subtotal
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_line_price_unit
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_residual
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_invoice_tax_amount
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_move_line_amount_currency
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_move_line_credit
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_account_move_line_debit
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_product_name
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_purchase_order_amount_tax
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_purchase_order_amount_total
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_purchase_order_amount_untaxed
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_purchase_order_line_price_unit
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_city
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_code
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_display_name
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_email
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_mobile
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_name
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_phone
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_street
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_street2
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_partner_zip
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_res_users_signature
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_amount_tax
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_amount_total
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_amount_untaxed
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_line_discount
+DEL ir.model.fields.anonymization: anonymization.anonymization_field_sale_order_line_price_unit
+DEL ir.ui.menu: anonymization.menu_administration_anonymization
+DEL ir.ui.menu: anonymization.menu_administration_anonymization_fields
+DEL ir.ui.menu: anonymization.menu_administration_anonymization_history
+DEL ir.ui.menu: anonymization.menu_administration_anonymization_wizard
+DEL ir.ui.view: anonymization.view_ir_model_fields_anonymization_form
+DEL ir.ui.view: anonymization.view_ir_model_fields_anonymization_history_form
+DEL ir.ui.view: anonymization.view_ir_model_fields_anonymization_history_tree
+DEL ir.ui.view: anonymization.view_ir_model_fields_anonymization_tree
+DEL ir.ui.view: anonymization.view_ir_model_fields_anonymize_wizard_form
+DEL ir.ui.view: anonymization.view_ir_model_fields_nonymization_kanban
+ERROR: module not in list of installed modules:
+---Fields in module 'website_sale_options'---
+---XML records in module 'website_sale_options'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'web_planner'---
+---XML records in module 'web_planner'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'website_sale_stock_options'---
+---XML records in module 'website_sale_stock_options'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'base_vat_autocomplete'---
+---XML records in module 'base_vat_autocomplete'---
+---nothing has changed in this module--
+ERROR: module not in list of installed modules:
+---Fields in module 'account_asset'---
+account_asset / account.invoice.line     / asset_category_id (many2one)  : DEL relation: account.asset.category
+account_asset / account.invoice.line     / asset_end_date (date)         : DEL
+account_asset / account.invoice.line     / asset_mrr (float)             : DEL
+account_asset / account.invoice.line     / asset_start_date (date)       : DEL
+account_asset / account.move             / asset_depreciation_ids (one2many): DEL relation: account.asset.depreciation.line
+account_asset / product.template         / asset_category_id (many2one)  : DEL relation: account.asset.category
+account_asset / product.template         / deferred_revenue_category_id (many2one): DEL relation: account.asset.category
+---XML records in module 'account_asset'---
+DEL ir.actions.act_window: account_asset.action_account_asset_asset_form
+DEL ir.actions.act_window: account_asset.action_account_asset_asset_list_normal_purchase
+DEL ir.actions.act_window: account_asset.action_asset_asset_report
+DEL ir.actions.act_window: account_asset.action_asset_depreciation_confirmation_wizard
+DEL ir.actions.act_window: account_asset.action_asset_modify
+DEL ir.cron: account_asset.account_asset_cron
+DEL ir.model.access: account_asset.access_account_asset_asset
+DEL ir.model.access: account_asset.access_account_asset_asset_invoicing_payment
+DEL ir.model.access: account_asset.access_account_asset_asset_manager
+DEL ir.model.access: account_asset.access_account_asset_category
+DEL ir.model.access: account_asset.access_account_asset_category_invoicing_payment
+DEL ir.model.access: account_asset.access_account_asset_category_manager
+DEL ir.model.access: account_asset.access_account_asset_depreciation_line
+DEL ir.model.access: account_asset.access_account_asset_depreciation_line_invoicing_payment
+DEL ir.model.access: account_asset.access_account_asset_depreciation_line_manager
+DEL ir.model.access: account_asset.access_asset_asset_report
+DEL ir.model.access: account_asset.access_asset_asset_report_manager
+DEL ir.rule: account_asset.account_asset_asset_multi_company_rule (noupdate)
+DEL ir.rule: account_asset.account_asset_category_multi_company_rule (noupdate)
+DEL ir.ui.menu: account_asset.menu_action_account_asset_asset_form
+DEL ir.ui.menu: account_asset.menu_action_account_asset_asset_list_normal_purchase
+DEL ir.ui.menu: account_asset.menu_action_asset_asset_report
+DEL ir.ui.menu: account_asset.menu_asset_depreciation_confirmation_wizard
+DEL ir.ui.menu: account_asset.menu_finance_config_assets
+DEL ir.ui.view: account_asset.action_account_asset_report_graph
+DEL ir.ui.view: account_asset.action_account_asset_report_pivot
+DEL ir.ui.view: account_asset.asset_modify_form
+DEL ir.ui.view: account_asset.assets_backend
+DEL ir.ui.view: account_asset.qunit_suite
+DEL ir.ui.view: account_asset.res_config_settings_view_form
+DEL ir.ui.view: account_asset.view_account_asset_asset_category_kanban
+DEL ir.ui.view: account_asset.view_account_asset_asset_form
+DEL ir.ui.view: account_asset.view_account_asset_asset_kanban
+DEL ir.ui.view: account_asset.view_account_asset_asset_purchase_tree
+DEL ir.ui.view: account_asset.view_account_asset_category_form
+DEL ir.ui.view: account_asset.view_account_asset_category_search
+DEL ir.ui.view: account_asset.view_account_asset_category_tree
+DEL ir.ui.view: account_asset.view_account_asset_search
+DEL ir.ui.view: account_asset.view_asset_asset_report_search
+DEL ir.ui.view: account_asset.view_asset_depreciation_confirmation_wizard
+DEL ir.ui.view: account_asset.view_invoice_asset_category
+DEL ir.ui.view: account_asset.view_product_template_form_inherit
 ERROR: module not in list of installed modules:
 ---Fields in module 'l10n_be_intrastat'---
 l10n_be_intrastat / account.invoice          / incoterm_id (many2one)        : module is now 'account' ('l10n_be_intrastat')

--- a/odoo/addons/openupgrade_records/lib/compare.py
+++ b/odoo/addons/openupgrade_records/lib/compare.py
@@ -235,10 +235,13 @@ def compare_sets(old_records, new_records):
             continue
         if column['mode'] == 'create':
             column['mode'] = ''
+        extra_message = ", ".join(
+            [k + ': ' + str(column[k]) for k in printkeys if column[k]]
+        )
+        if extra_message:
+            extra_message = " " + extra_message
         fieldprint(
-            column, '', '', "DEL " + ", ".join(
-                [k + ': ' + str(column[k]) for k in printkeys if column[k]]
-                ), reprs)
+            column, '', '', "DEL" + extra_message, reprs)
 
     for column in new_records:
         # we do not care about newly added non stored function fields
@@ -247,10 +250,13 @@ def compare_sets(old_records, new_records):
             continue
         if column['mode'] == 'create':
             column['mode'] = ''
+        extra_message = ", ".join(
+            [k + ': ' + str(column[k]) for k in printkeys if column[k]]
+        )
+        if extra_message:
+            extra_message = " " + extra_message
         fieldprint(
-            column, '', '', "NEW " + ", ".join(
-                [k + ': ' + str(column[k]) for k in printkeys if column[k]]
-                ), reprs)
+            column, '', '', "NEW" + extra_message, reprs)
 
     for line in [
             "# %d fields matched," % (origlen - len(old_records)),

--- a/odoo/addons/openupgrade_records/models/analysis_wizard.py
+++ b/odoo/addons/openupgrade_records/models/analysis_wizard.py
@@ -65,7 +65,8 @@ class AnalysisWizard(models.TransientModel):
         res = compare.compare_sets(remote_records, local_records)
 
         # Retrieve xml id representations and compare
-        flds = ['module', 'model', 'name', 'noupdate']
+        flds = ['module', 'model', 'name', 'noupdate',
+                'prefix', 'suffix', 'original_module']
         local_xml_records = [
             dict([(field, record[field]) for field in flds])
             for record in local_record_obj.search([('type', '=', 'xmlid')])]

--- a/odoo/addons/openupgrade_records/models/openupgrade_record.py
+++ b/odoo/addons/openupgrade_records/models/openupgrade_record.py
@@ -38,6 +38,20 @@ class Record(models.Model):
             'openupgrade.attribute', 'record_id',
             readonly=True)
     noupdate = fields.Boolean(readonly=True)
+    prefix = fields.Char(readonly=True, compute='_compute_prefix_and_suffix')
+    suffix = fields.Char(readonly=True, compute='_compute_prefix_and_suffix')
+    original_module = fields.Char(
+        readonly=True, compute='_compute_original_module')
+
+    @api.depends('name')
+    def _compute_prefix_and_suffix(self):
+        for rec in self:
+            rec.prefix, rec.suffix = rec.name.split('.', 1)
+
+    @api.depends('model')
+    def _compute_original_module(self):
+        for rec in self:
+            rec.original_module = self.env[rec.model]._original_module
 
     @api.model
     def field_dump(self):

--- a/odoo/addons/openupgrade_records/models/openupgrade_record.py
+++ b/odoo/addons/openupgrade_records/models/openupgrade_record.py
@@ -38,10 +38,9 @@ class Record(models.Model):
             'openupgrade.attribute', 'record_id',
             readonly=True)
     noupdate = fields.Boolean(readonly=True)
-    prefix = fields.Char(readonly=True, compute='_compute_prefix_and_suffix')
-    suffix = fields.Char(readonly=True, compute='_compute_prefix_and_suffix')
-    original_module = fields.Char(
-        readonly=True, compute='_compute_original_module')
+    prefix = fields.Char(compute='_compute_prefix_and_suffix')
+    suffix = fields.Char(compute='_compute_prefix_and_suffix')
+    original_module = fields.Char(compute='_compute_original_module')
 
     @api.depends('name')
     def _compute_prefix_and_suffix(self):

--- a/odoo/addons/test_performance/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/odoo/addons/test_performance/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -5,7 +5,7 @@ test_performance / test_performance.mail    / message_channel_ids (many2many): m
 test_performance / test_performance.mail    / message_follower_ids (one2many): module is now 'test_mail' ('test_performance')
 test_performance / test_performance.mail    / message_ids (one2many)        : module is now 'test_mail' ('test_performance')
 test_performance / test_performance.mail    / message_is_follower (boolean) : module is now 'test_mail' ('test_performance')
-test_performance / test_performance.mail    / message_last_post (datetime)  : DEL 
+test_performance / test_performance.mail    / message_last_post (datetime)  : DEL
 test_performance / test_performance.mail    / message_needaction (boolean)  : module is now 'test_mail' ('test_performance')
 test_performance / test_performance.mail    / message_needaction_counter (integer): module is now 'test_mail' ('test_performance')
 test_performance / test_performance.mail    / message_partner_ids (many2many): module is now 'test_mail' ('test_performance')


### PR DESCRIPTION
This PR includes 3 things:

 - Detect moved or renamed xmlids in different modules
 - Remove the sickening trailing spaces in the reports
 - New analysis to observe how affect his changes

The `openupgrade_analysis.txt` of `account` module gives a good example of the changes introduced.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr