### PR TITLE
[12.0][FIX] mail: assure mimetype exists

### DIFF
--- a/addons/mail/migrations/12.0.1.0/end-migration.py
+++ b/addons/mail/migrations/12.0.1.0/end-migration.py
@@ -52,9 +52,9 @@ def fill_mail_thread_message_main_attachment_id(env):
             all_attachments = attachs.get(record.id, attachment_obj)
             if all_attachments:
                 prioritary_attachments = all_attachments.filtered(
-                    lambda x: x.mimetype.endswith('pdf')
+                    lambda x: x.mimetype and x.mimetype.endswith('pdf')
                 ) or all_attachments.filtered(
-                    lambda x: x.mimetype.startswith('image')
+                    lambda x: x.mimetype and x.mimetype.startswith('image')
                 ) or all_attachments
                 record.write({'message_main_attachment_id':
                               prioritary_attachments[0].id})


### PR DESCRIPTION
If mimetype is False, it breaks when trying to call endswith.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr