### PR TITLE
[9.0] crm: assign activity to leads that has action

### DIFF
--- a/addons/crm/migrations/9.0.1.0/post-migration.py
+++ b/addons/crm/migrations/9.0.1.0/post-migration.py
@@ -44,12 +44,20 @@ def migrate_phonecalls(env):
         record.message_post(
             body=body, subject=phonecall['name'] or 'Phone call',
             subtype_id=activity.subtype_id.id)
-
+        
+def assign_crm_activity(env):
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE crm_lead SET next_activity_id = %s
+        WHERE title_action IS NOT NULL or date_action IS NOT NULL
+        """, (env.ref('crm.crm_activity_data_meeting').id,)
+    )
 
 @openupgrade.migrate()
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     migrate_phonecalls(env)
+    assign_crm_activity(env)
     openupgrade.load_data(
         cr, 'crm', 'migrations/9.0.1.0/noupdate_changes.xml',
     )

--- a/addons/crm/migrations/9.0.1.0/post-migration.py
+++ b/addons/crm/migrations/9.0.1.0/post-migration.py
@@ -44,7 +44,8 @@ def migrate_phonecalls(env):
         record.message_post(
             body=body, subject=phonecall['name'] or 'Phone call',
             subtype_id=activity.subtype_id.id)
-        
+
+
 def assign_crm_activity(env):
     openupgrade.logged_query(
         env.cr, """
@@ -52,6 +53,7 @@ def assign_crm_activity(env):
         WHERE title_action IS NOT NULL or date_action IS NOT NULL
         """, (env.ref('crm.crm_activity_data_meeting').id,)
     )
+
 
 @openupgrade.migrate()
 def migrate(cr, version):


### PR DESCRIPTION
If it's not assign, issue comes in the v11 activity migration to `mail_activity` if there is no `next_activity_id` it skips such records https://github.com/OCA/OpenUpgrade/blob/11.0/addons/crm/migrations/11.0.1.0/post-migration.py#L78




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
