### PR TITLE
[IMP] project: Avoid subtask project constraint

### DIFF
--- a/addons/project/migrations/11.0.1.1/pre-migration.py
+++ b/addons/project/migrations/11.0.1.1/pre-migration.py
@@ -27,9 +27,29 @@ def move_fields_from_module(env):
     )
 
 
+def avoid_subproject_constraint(env):
+    """On v11, there's a new constraint that prevents that a subtask belongs to
+    a project different from the one defined in parent project as subproject,
+    so for avoiding this constraint, we empty the subproject in the parent
+    project in these cases.
+    """
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE project_project pp
+        SET subtask_project_id = NULL
+        FROM project_task pt,
+            project_task pt_parent
+        WHERE pt.parent_id = pt_parent.id
+            AND pt_parent.project_id = pp.id
+            AND pp.subtask_project_id IS NOT NULL
+            AND pt.project_id != pp.subtask_project_id""",
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     move_fields_from_module(env)
+    avoid_subproject_constraint(env)
     openupgrade.rename_xmlids(env.cr, renamed_xml_ids)
     openupgrade.delete_records_safely_by_xml_id(env, [
         'project.portal_issue_rule',  # Comes from website_project_issue


### PR DESCRIPTION
On v11, there's a new constraint that prevents that a subtask belongs to a project different from the one defined in parent project as subproject, so for avoiding this constraint, we empty the subproject in the parent
project in these cases.

Closes #1789

@Tecnativa