### PR TITLE
[FIX] apriori incorrect rename (product_supplierinfo_for_customer_sale)

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -30,7 +30,6 @@ renamed_modules = {
     'sale_delivery_block': 'sale_stock_picking_blocking',
     'sale_delivery_block_proc_group_by_line':
         'sale_stock_picking_blocking_proc_group_by_line',
-    # 'product_customer_code_sale': 'product_supplierinfo_for_customer_sale',
     # OCA/server-tools:
     'mail_log_messages_to_process': 'mail_log_message_to_process',
     # OCA/stock-logistics-workflow:
@@ -63,6 +62,8 @@ merged_modules = [
     ('mrp_production_unreserve', 'mrp'),
     # OCA/sale-workflow
     ('sale_order_back2draft', 'sale'),
+    ('product_customer_code_sale',
+     'product_supplierinfo_for_customer_sale'),
     # OCA/social
     ('mass_mailing_security_group', 'mass_mailing'),
     # OCA/stock-logistics-workflow

--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -4,7 +4,8 @@ to help the matching process
 
 renamed_modules = {
     # OCA/account-invoice-reporting
-    'account_invoice_group_picking': 'account_invoice_report_grouped_by_picking',
+    'account_invoice_group_picking':
+    'account_invoice_report_grouped_by_picking',
     # OCA/connector
     # Connector module has been unfolded in 2 modules in version 10.0:
     # connector and queue_job. We need to do this to correct upgrade both
@@ -29,7 +30,7 @@ renamed_modules = {
     'sale_delivery_block': 'sale_stock_picking_blocking',
     'sale_delivery_block_proc_group_by_line':
         'sale_stock_picking_blocking_proc_group_by_line',
-    'product_customer_code_sale': 'product_supplierinfo_for_customer_sale',
+    # 'product_customer_code_sale': 'product_supplierinfo_for_customer_sale',
     # OCA/server-tools:
     'mail_log_messages_to_process': 'mail_log_message_to_process',
     # OCA/stock-logistics-workflow:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Openugrapde from 8.0 to 10.0
- during the process 9.0 to 10.0, an error occures
```
IntegrityError: duplicate key value violates unique constraint "name_uniq"
DETAIL:  Key (name)=(product_supplierinfo_for_customer_sale) already exists.
```

This is due to the apriori.py file from openupgrade 10.0 that mentions that the module `product_customer_code_sale` has been renamed into `product_supplierinfo_for_customer_sale`

The problem is that 
- `product_supplierinfo_for_customer_sale` exists in V8, so the module is present in `ir_module_module` table (OCA/product-attribute/8.0) https://github.com/OCA/product-attribute/tree/8.0/product_supplierinfo_for_customer_sale
- `product_customer_code_sale` exists in V8, so the module is also present in `ir_module_module` table. (OCA/sale-workflow/8.0) https://github.com/OCA/sale-workflow/tree/8.0/product_customer_code_sale


I don't know if this is the best solution, but it seems that the current code is not correct, so I disabled the line.

regards.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
