### PR TITLE
[12.0] base_partner_merge merged in base.

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -35,6 +35,8 @@ merged_modules = {
     'website_sale_stock_options': 'website_sale_stock',
     # OCA/account-financial-tools
     'account_reversal': 'account',
+    # OCA/partner-contact
+    'base_partner_merge': 'base',
     # OCA/server-auth
     'auth_brute_force': 'base',
     # OCA/web


### PR DESCRIPTION
If you had this module installed it means that you did not have crm
and you wanted the merge partner views, they are now in base module
in v12, so in that situation base_partner_merge is now included in base.

@Eficent


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
