### PR TITLE
[IMP] Mute warning logs about invalid view

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -358,8 +358,9 @@ actual arch.
                     check = valid_view(view_arch)
                     if not check:
                         raise ValidationError(_('Invalid view %s definition in %s') % (view.name, view.arch_fs))
-                    if check == "Warning":
-                        _logger.warning(_('Invalid view %s definition in %s \n%s'), view.name, view.arch_fs, view.arch)
+                    # OpenUpgrade: Don't show this warning as useless and too much verbose
+                    # if check == "Warning":
+                        # _logger.warning(_('Invalid view %s definition in %s'), view.name, view.arch_fs)
         return True
 
     @api.constrains('type', 'groups_id')

--- a/odoo/tools/view_validation.py
+++ b/odoo/tools/view_validation.py
@@ -17,12 +17,13 @@ def valid_view(arch):
     for pred in _validators[arch.tag]:
 
         # OpenUpgrade: Force warning here as we ignore all view errors.
-        check = pred(arch) or 'warning'
+        check = pred(arch) or 'Warning'
         if not check:
             _logger.error("Invalid XML: %s", pred.__doc__)
             return False
         if check == "Warning":
-            _logger.warning("Invalid XML: %s", pred.__doc__)
+            # OpenUpgrade: Don't show this warning as useless and too much verbose
+            # _logger.warning("Invalid XML: %s", pred.__doc__)
             return "Warning"
     return True
 


### PR DESCRIPTION
This is not helping for anything in the migration process and it's very verbose now on v12, showing full view arch.

cc @Tecnativa