### PR TITLE
event_registration_mass_mailing: it is no longer needed

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -23,6 +23,7 @@ merged_modules = {
     'auth_crypt': 'base',
     'account_cash_basis_base_account': 'account',
     'account_invoicing': 'account',
+    'event_registration_mass_mailing': 'mass_mailing_event',
     'rating_project': 'project',
     'sale_order_dates': 'sale',
     'sale_payment': 'sale',


### PR DESCRIPTION

event_registration_mass_mailing: it is no longer needed
Add it to `merged_modules` dictionary

Cc @Tecnativa

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
