### PR TITLE
[12.0][FIX] hr_holidays: Avoid trying to repeat followers

### DIFF
--- a/addons/hr_holidays/migrations/12.0.1.5/post-migration.py
+++ b/addons/hr_holidays/migrations/12.0.1.5/post-migration.py
@@ -162,7 +162,7 @@ def subscribe_new_subtypes(env):
             subtype_ids = (new_mt1 + new_mt2).ids
             partner_ids = followers.mapped('partner_id').ids
             Followers._insert_followers(
-                followers[0].res_model, followers.mapped('res_id'),
+                followers[0].res_model, list(set(followers.mapped('res_id'))),
                 partner_ids,
                 dict((pid, subtype_ids) for pid in partner_ids),
                 [], False, check_existing=True, existing_policy='update',


### PR DESCRIPTION
There is a constraint in `mail.followers` for unique `res_id`, `partner_id`, `res_model`.

Thus, we need to ensure we don't repeat the `res_id` to avoid the constraint error.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr