### PR TITLE
[12.0][FIX] account_voucher: assure company_id in old databases

### DIFF
--- a/addons/account_voucher/migrations/12.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/account_voucher/migrations/12.0.1.0/openupgrade_analysis_work.txt
@@ -1,5 +1,8 @@
 ---Fields in module 'account_voucher'---
 account_voucher / account.voucher          / company_id (many2one)         : is now stored
+# DONE: pre-migration: assure it's filled because of _check_company_id method, it's required.
+# In v8 this field was stored and thus, maybe some databases have this column with empty cases.
+
 account_voucher / account.voucher          / currency_id (many2one)        : is now stored
 account_voucher / account.voucher          / message_last_post (datetime)  : DEL
 account_voucher / account.voucher          / message_main_attachment_id (many2one): NEW relation: ir.attachment

--- a/addons/account_voucher/migrations/12.0.1.0/pre-lol.py
+++ b/addons/account_voucher/migrations/12.0.1.0/pre-lol.py
@@ -1,0 +1,24 @@
+# Copyright 2019 Eficent <http://www.eficent.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def assure_company(cr):
+    openupgrade.logged_query(
+        cr, """
+        UPDATE account_voucher av
+        SET company_id = aj.company_id
+        FROM account_journal aj
+        WHERE av.journal_id = aj.id
+            AND av.company_id IS NULL"""
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if openupgrade.column_exists(env.cr, 'account_voucher', 'company_id'):
+        # In odoo v8, the company_id was stored. Thus, maybe some databases
+        # that have been migrating since v8, may still have that column. Thus,
+        # if new records have been created in newer versions, they may have
+        # this field empty.
+        assure_company(env.cr)


### PR DESCRIPTION
In odoo v8, the company_id was stored. Thus, maybe some databases
that have been migrating since v8, may still have that column. Thus,
if new records have been created in newer versions, they may have
this field empty.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr