### PR TITLE
[12.0][MIG]Avoid account_id non null constraint

### DIFF
--- a/addons/account/migrations/12.0.1.1/pre-migration.py
+++ b/addons/account/migrations/12.0.1.1/pre-migration.py
@@ -83,6 +83,11 @@ def fill_account_invoice_line_sections(cr):
     )
     openupgrade.logged_query(
         cr, """
+        ALTER TABLE account_invoice_line ALTER COLUMN account_id DROP not null
+        """,
+    )
+    openupgrade.logged_query(
+        cr, """
         INSERT INTO account_invoice_line (invoice_id, layout_category_id,
             sequence, name, price_unit, quantity, display_type,
             create_uid, create_date, write_uid, write_date)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

**Current behavior before PR:**

In account pre-migration.py when we try to insert sections in "account_invoice_line" we got : "account_id" non null constraint, because in V11 the field is always required 

**Desired behavior after PR is merged:**
we drop not null constraint from account_id field --> after that the modules in V12 will be loaded and the constraint will be set correctly as defined (depends on display_type)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
