### PR TITLE
[12.0][MIG] In Sale : avoid 'product_id' & 'product_uom' non null constraint

### DIFF
--- a/addons/sale/migrations/12.0.1.1/pre-migration.py
+++ b/addons/sale/migrations/12.0.1.1/pre-migration.py
@@ -51,11 +51,16 @@ def fill_sale_order_line_sections(cr):
     )
     openupgrade.logged_query(
         cr, """
+        ALTER TABLE sale_order_line ALTER COLUMN product_uom DROP not null
+        """,
+    )
+    openupgrade.logged_query(
+        cr, """
         INSERT INTO sale_order_line (order_id, layout_category_id,
-            sequence, name, price_unit, product_uom, product_uom_qty, customer_lead,
+            sequence, name, price_unit, product_uom_qty, customer_lead,
             display_type, create_uid, create_date, write_uid, write_date)
         SELECT sol.order_id, sol.layout_category_id,
-            min(sol.sequence) -1 as sequence, max(slc.name), 0, 1, 0, 0,
+            min(sol.sequence) -1 as sequence, max(slc.name), 0, 0, 0,
             'line_section', min(sol.create_uid), min(sol.create_date),
             min(sol.write_uid), min(sol.write_date)
         FROM sale_order_line sol

--- a/addons/sale/migrations/12.0.1.1/pre-migration.py
+++ b/addons/sale/migrations/12.0.1.1/pre-migration.py
@@ -46,11 +46,16 @@ def fill_sale_order_line_sections(cr):
     )
     openupgrade.logged_query(
         cr, """
+        ALTER TABLE sale_order_line ALTER COLUMN product_id DROP not null
+        """,
+    )
+    openupgrade.logged_query(
+        cr, """
         INSERT INTO sale_order_line (order_id, layout_category_id,
-            sequence, name, price_unit, product_uom_qty, customer_lead,
+            sequence, name, price_unit, product_uom, product_uom_qty, customer_lead,
             display_type, create_uid, create_date, write_uid, write_date)
         SELECT sol.order_id, sol.layout_category_id,
-            min(sol.sequence) -1 as sequence, max(slc.name), 0, 0, 0,
+            min(sol.sequence) -1 as sequence, max(slc.name), 0, 1, 0, 0,
             'line_section', min(sol.create_uid), min(sol.create_date),
             min(sol.write_uid), min(sol.write_date)
         FROM sale_order_line sol


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

**Current behavior before PR:**
In **Sale pre-migration.py** when we try to insert sections in "sale_order_line" we got : "product_id" & "product_uom" non null constraint, because in V11 those 2 fields is always required

**Desired behavior after PR is merged:**
we drop not null constraint from product_id field & and added a default value for product_uom --> after that the modules in V12 will be loaded and the constraint will be set correctly as defined (depends on display_type)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
