### PR TITLE
[12.0][MIG] hr_employee_seniority

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -16,6 +16,8 @@ renamed_modules = {
     # OCA/crm > OCA/partner-contact
     'crm_deduplicate_acl': 'partner_deduplicate_acl',
     'crm_deduplicate_filter': 'partner_deduplicate_filter',
+    # OCA/hr
+    'hr_employee_seniority': 'hr_employee_service_contract',
 }
 
 merged_modules = {


### PR DESCRIPTION
Migration of `hr_employee_seniority` from OCA/hr. It becomes `hr_employee_service_contract` in 12.0.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
