### PR TITLE
[12.0][MIG] Avoid 'account.move.line.reconcile' error

### DIFF
--- a/addons/account/migrations/12.0.1.1/end-migration.py
+++ b/addons/account/migrations/12.0.1.1/end-migration.py
@@ -1,0 +1,20 @@
+# Copyright 2018 Othmane Ghandi <https://github.com/OthmaneGhandi>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def remove_action_window(env):
+    """Remove action windows that may cause error: for now action_view_account_move_line_reconcile"""
+    openupgrade.logged_query(
+    	env.cr, 
+        """DELETE FROM ir_act_window
+        	WHERE res_model = 'account.move.line.reconcile'
+        """)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    remove_action_window(env)
+
+
+


### PR DESCRIPTION
Current behavior before PR:
You got an error when trying to open Journal Items, related to "'account.move.line.reconcile'" action view
=> The action view should be deleted et the end of the migration 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
