### PR TITLE
[9.0][IMP] fix tax amount migration for taxes

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -1222,6 +1222,7 @@ def migrate(env, version):
             atp.amount as amount
         FROM account_tax at
         JOIN account_tax atp ON at.parent_id = atp.id
+        WHERE atp.amount_type = 'percent'
     ) AS subquery
     WHERE query.id = subquery.id
     """)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: amount in childs tax are in % of parent tax in 8.0, while in 9.0 are in fixed amount

Current behavior before PR: tax amount are in % if they are children of another tax

Desired behavior after PR is merged: tax amount are in correct fixed amount if they are children of another tax




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
