### PR TITLE
[12.0][DOC] account_asset replaced by OCA

### DIFF
--- a/odoo/openupgrade/doc/source/modules110-120.rst
+++ b/odoo/openupgrade/doc/source/modules110-120.rst
@@ -27,7 +27,7 @@ missing in the new release are marked with |del|.
 +--------------------------------------------+-------------------------------------------------+
 |account_analytic_default                    |                                                 |
 +--------------------------------------------+-------------------------------------------------+
-| |del| account_asset                        |                                                 |
+| |del| account_asset                        | Replaced by OCA module [#account_asset]_        |
 +--------------------------------------------+-------------------------------------------------+
 |account_bank_statement_import               | Nothing to do                                   |
 +--------------------------------------------+-------------------------------------------------+
@@ -637,6 +637,10 @@ missing in the new release are marked with |del|.
 +--------------------------------------------+-------------------------------------------------+
 |website_twitter                             |                                                 |
 +--------------------------------------------+-------------------------------------------------+
+
+.. [#account_asset] 'Account Asset' module is replaced by the Odoo Community Association module
+    'Account Asset Management' (not exactly the same but does the same):
+    See : https://github.com/OCA/account-financial-tools/tree/12.0/account_asset_management
 
 OCA modules
 ===========


### PR DESCRIPTION
Fine tunning of https://github.com/OCA/OpenUpgrade/commit/4f1b58559ef590cca00a28adc5dc23aada0bd7be, that adds the documentation for `account_asset`.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr