### PR TITLE
[12.0][FIX] stock: push_pull rules broccoly

### DIFF
--- a/addons/stock/migrations/12.0.1.1/post-migration.py
+++ b/addons/stock/migrations/12.0.1.1/post-migration.py
@@ -10,7 +10,7 @@ def map_stock_rule_action(cr):
         cr,
         openupgrade.get_legacy_name('action'),
         'action',
-        [('move', 'pull_push'),
+        [('move', 'pull'),
          ],
         table='stock_rule', write='sql')
 
@@ -100,6 +100,14 @@ def merge_stock_location_path_stock_rule(env):
             env, 'stock.rule',
             [row[1]],
             row[0],
+        )
+    pull_push_rule_ids = tuple(set([r[0] for r in rules_to_merge]))
+    if pull_push_rule_ids:
+        openupgrade.logged_query(
+            env.cr, """
+            UPDATE stock_rule
+            SET action = 'pull_push'
+            WHERE id in %s""", (pull_push_rule_ids, ),
         )
 
 


### PR DESCRIPTION
Rules coming from `procurement.rule` (with old action='move') became 'pull'
Rules coming from `stock.location.path` became 'push'
Rules coming from from both became 'pull_push'

Fixes https://github.com/OCA/OpenUpgrade/issues/1919.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr