### PR TITLE
[FIX] stock: Mark references as noupdate=1

### DIFF
--- a/addons/stock/migrations/12.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/12.0.1.1/pre-migration.py
@@ -25,12 +25,38 @@ _table_renames = [
 ]
 
 
+def switch_stock_xml_id_noupdate(cr):
+    """Main warehouse references records have an associated XML-ID, that was
+    updated in v11 through a method and maintain as XML noupdate=0 data, so
+    they weren't removed on updates, but now on v12, that XML-IDs are
+    noupdate=1, and no XML data in provided, so on regular update process, they
+    are tried to be removed. We switch them to noupdate=1 for avoiding this
+    problem.
+    """
+    openupgrade.logged_query(
+        cr, """
+        UPDATE ir_model_data
+        SET noupdate = True
+        WHERE module = 'stock'
+        AND name IN %s""", ((
+            'stock_location_stock',
+            'stock_location_company',
+            'stock_location_output',
+            'location_pack_zone',
+            'picking_type_internal',
+            'picking_type_in',
+            'picking_type_out',
+        ), ),
+    )
+
+
 @openupgrade.migrate(use_env=False)
 def migrate(cr, version):
     openupgrade.copy_columns(cr, _column_copies)
     openupgrade.rename_columns(cr, _column_renames)
     openupgrade.rename_models(cr, _model_renames)
     openupgrade.rename_tables(cr, _table_renames)
+    switch_stock_xml_id_noupdate(cr)
     cr.execute(
         """
         ALTER TABLE stock_rule


### PR DESCRIPTION
Main warehouse references records have an associated XML-ID, that was updated in v11 through a method and maintain as XML noupdate=0 data, so they weren't removed on updates, but now on v12, that XML-IDs are noupdate=1, and no XML data in provided, so on regular update process, they are tried to be removed. We switch them to noupdate=1 for avoiding this problem.

Fixes #1925

cc @Tecnativa