### PR TITLE
[8.0] stock: process all done moves before assigned moves

### DIFF
--- a/addons/stock/migrations/8.0.1.1/post-migration.py
+++ b/addons/stock/migrations/8.0.1.1/post-migration.py
@@ -929,13 +929,14 @@ def migrate_stock_qty(cr, registry):
 
     with api.Environment.manage():
         env = api.Environment(cr, SUPERUSER_ID, {})
-        moves = env['stock.move'].search(
-            [('state', 'in', ['assigned', 'done'])], order="date")
-        for move in moves:
-            if move.state == 'assigned':
-                _move_assign(env, move)
-            else:
-                _move_done(env, move)
+        done_moves = env['stock.move'].search(
+            [('state', '=', 'done')], order="date")
+        for done_move in done_moves:
+            _move_done(env, done_move)
+        assigned_moves = env['stock.move'].search(
+            [('state', '=', 'assigned')], order="date")
+        for assigned_move in assigned_moves:
+            _move_assign(env, assigned_move)
 
 
 def migrate_stock_production_lot(cr, registry):


### PR DESCRIPTION
I'm in the process of migrating a DB with lots of stock moves (about 160 000) from v7 to v12.
I made a test migration in April 2019, and migration from v7 to v8 was working fine.
I made the "real" migration this week-end with up-to-date code (to get the latest fixes/improvements): I started v7 to v8 migration on Friday evening, but it was still running on Monday morning after 55h of processing... so I had to stop it and post-pone the migration to another day. Looking at the logs, it was inside the method migrate_stock_qty() (https://github.com/OCA/OpenUpgrade/blob/8.0/addons/stock/migrations/8.0.1.1/post-migration.py#L922) for about 54h and was still in there when I stopped it.
As this migration from v7 to v8 was working fine in April 2019, I had a look at the commits in between. One change from @pedrobaeza caught my attention: this commit https://github.com/OCA/OpenUpgrade/blob/8.0/addons/stock/migrations/8.0.1.1/post-migration.py#L922 which was the consequence of this bug report https://github.com/OCA/OpenUpgrade/issues/1783
It seems like a very minor and obvious fix. But it seems strange to find such an obvious fix in v7 to v8 migration in 2019, such a long time after v8 release !
My idea was that I may be impacted by an infinite loop caused by this change ; so I added logs in the methods _move_assign() and _move_done() to confirm this.
But, when reading the source code of this 2 methods, I felt that there may be a logic error in the code: I think that we must process all done moves BEFORE processing the assigned moves, because the assign moves reserve quants generated by the processing of done moves. And, with the current code, done and assigned moves are processed "at the same time" (only ordered by "date"). With the code before the fix introduced by @pedrobaeza on April 4, the _move_assigned() method was not called because of the syntax error ('assign' instead of 'assigned').
I launched a new test migration yesterday afternoon from v7 to v8 (on the same DB as my failed migration of this WE) with the code change of this PR plus some logs. I was expecting to "see" the infinite loop, but it successfully ran until the end after 11h of processing. My interpretation of this is that my code change fixed the infinite loop... but it may be a bit optimistic !

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
