### PR TITLE
[FIX] website: Fix menu & page structure migration

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -160,7 +160,14 @@ class View(models.Model):
                     view.with_context(website_id=website.id).write({'name': view.name})
 
         specific_views = self.env['ir.ui.view']
-        if self and self.pool._init:
+
+        # OpenUpgrade: force a False condition to never enter this code block.
+        # This is needed because the update process could correctly unlink
+        # website-agnostic views, but we don't want the website-specific
+        # equivalents to be removed during the migration.
+        if False and self and self.pool._init:
+        # OpenUpgrade: end of modification
+
             for view in self:
                 specific_views += view._get_specific_views()
 


### PR DESCRIPTION
- Do not remove the views that have been COW'd in the pre-migration. An odoo code patch needed for that.
- The migration field is now TEXT and stores a JSON with menu info.
- Create pages in pre-migration, since in post-migration they might have disappeared and, after some tests, we were gonna need them anyway.
- Update/recreate website-specific menu items correctly.
- Fix https://github.com/OCA/OpenUpgrade/pull/1923 by respecting `noupdate=1` status of homepage record until the end of the pre-migration. This way, the BS4 migration and website-specification process work as expected.





--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa