### PR TITLE
[12.0][FIX] sale: avoid the automatic compute of qty_delivered_method

### DIFF
--- a/addons/sale/migrations/12.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/sale/migrations/12.0.1.1/openupgrade_analysis_work.txt
@@ -86,6 +86,7 @@ sale         / sale.order.line          / qty_delivered (float)         : now a 
 sale         / sale.order.line          / qty_delivered_manual (float)  : NEW
 sale         / sale.order.line          / qty_delivered_method (selection): NEW selection_keys: ['analytic', 'manual']
 # DONE pre-migration: copied column qty_delivered to qty_delivered_manual
+# DONE: pre-migration: create column qty_delivered_method to avoid the compute
 # DONE: post-migration: filled qty_delivered_method based on conditions
 # DONE: end-migration: recomputed qty_delivered by calling _compute_qty_delivered() in orm
 

--- a/addons/sale/migrations/12.0.1.1/pre-migration.py
+++ b/addons/sale/migrations/12.0.1.1/pre-migration.py
@@ -81,3 +81,7 @@ def migrate(env, version):
         # from sale_order_dates module
         openupgrade.rename_fields(env, _field_renames_order_dates)
     fill_sale_order_line_sections(env.cr)
+    openupgrade.logged_query(
+        env.cr,
+        "ALTER TABLE sale_order_line ADD COLUMN qty_delivered_method varchar",
+    )


### PR DESCRIPTION
The `qty_delivered_method` is filled in the post-migration, so we need to avoid the compute during the module loading.

The compute of this method mark as dirty some other fields, and produce a long and unnecessary chain reaction of other computes.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr