### PR TITLE
[11.0][MIG] web_widget_datepicker_options -> web

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -102,6 +102,7 @@ merged_modules = {
     'stock_picking_transfer_lot_autoassign': 'stock_pack_operation_auto_fill',
     # OCA/web
     'web_sheet_full_width': 'web_responsive',
+    'web_widget_datepicker_options': 'web',
     'web_widget_domain_v11': 'web',
     # OCA/website
     'website_seo_redirection': 'website',


### PR DESCRIPTION
The module was merged `web`, as https://github.com/OCA/web/commit/67793c90e4f452f11af1f362c5176ca3aed7987f explains.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr