### PR TITLE
[12.0][FIX] base: split v11 admin user into system and admin in the post-migration

### DIFF
--- a/odoo/addons/base/migrations/12.0.1.3/end-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/end-migration.py
@@ -1,6 +1,6 @@
 # © 2018 Opener B.V. (stefan@opener.amsterdam)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from openupgradelib import openupgrade, openupgrade_merge_records
+from openupgradelib import openupgrade
 
 
 def update_model_terms_translations(env):
@@ -34,82 +34,6 @@ def update_model_terms_translations(env):
             (tuple(names),))
 
 
-def fork_off_system_user(env):
-    """ Fork user admin off from user system. User admin keeps the original
-    partner, and user system gets a new partner. """
-    user_root = env.ref('base.user_root')
-    partner_admin = env.ref('base.partner_admin')
-    partner_root = env.ref('base.partner_admin').copy({'name': 'System'})
-    login = user_root.login
-    user_root.login = '__system__'
-    user_admin = env.ref('base.user_root').copy({
-        'partner_id': partner_admin.id,
-        'login': login,
-    })
-    # copy old passwords for not losing them on new admin user
-    crypt = openupgrade.column_exists(env.cr, 'res_users', 'password_crypt')
-    set_query = "SET password = ru2.password "
-    if crypt:
-        set_query += ", password_crypt = ru2.password_crypt "
-    env.cr.execute(
-        "UPDATE res_users ru " + set_query +
-        "FROM res_users ru2 WHERE ru2.id = %s AND ru.id = %s",
-        (user_root.id, user_admin.id),
-    )
-    user_root.write({
-        'partner_id': partner_root.id,
-        'email': 'root@example.com',
-    })
-    env.cr.execute(
-        """ UPDATE ir_model_data SET res_id = %s
-        WHERE module = 'base' AND name = 'user_admin'""", (user_admin.id,))
-    env.cr.execute(
-        """ UPDATE ir_model_data SET res_id = %s
-        WHERE module = 'base' AND name = 'partner_root'""", (partner_root.id,))
-    openupgrade.logged_query(
-        env.cr,
-        """ UPDATE ir_model_data SET res_id = %(user_admin)s
-        WHERE model = 'res.users' AND res_id = %(user_root)s
-        AND (module != 'base' OR name != 'user_root') """,
-        {'user_admin': user_admin.id, 'user_root': user_root.id})
-    # Get create_uid and write_uid columns to ignore
-    env.cr.execute(
-        """ SELECT tc.table_name, kcu.column_name
-            FROM information_schema.table_constraints AS tc
-            JOIN information_schema.key_column_usage AS kcu
-                ON tc.constraint_name = kcu.constraint_name
-                AND tc.table_schema = kcu.table_schema
-            JOIN information_schema.constraint_column_usage AS ccu
-                ON ccu.constraint_name = tc.constraint_name
-                AND ccu.table_schema = tc.table_schema
-            WHERE constraint_type = 'FOREIGN KEY'
-            AND ccu.table_name = 'res_users' and ccu.column_name = 'id'
-            AND kcu.column_name IN ('create_uid', 'write_uid')
-        """)
-    exclude_columns = env.cr.fetchall() + [
-        ('ir_cron', 'user_id'), ('res_groups_users_rel', 'uid'),
-        ('res_company_users_rel', 'user_id'),
-    ]
-
-    openupgrade_merge_records.merge_records(
-        env, 'res.users', [user_root.id], user_admin.id,
-        method='sql', delete=False, exclude_columns=exclude_columns)
-    # Circumvent ORM when setting root user inactive, because
-    # "You cannot deactivate the user you're currently logged in as."
-    set_query = "SET active = FALSE, password = NULL"
-    if crypt:
-        set_query += ", password_crypt = NULL"
-    env.cr.execute(
-        "UPDATE res_users " + set_query + " WHERE id = %s",
-        (user_root.id, ),
-    )
-    # Ensure also partner_root is inactive
-    env.cr.execute(
-        """ UPDATE res_partner
-            SET active = FALSE WHERE id = %s """,
-        (partner_root.id,))
-
-
 def fill_res_users_password_from_password_crypt(cr):
     openupgrade.logged_query(
         cr,
@@ -123,6 +47,5 @@ def fill_res_users_password_from_password_crypt(cr):
 @openupgrade.migrate()
 def migrate(env, version):
     update_model_terms_translations(env)
-    fork_off_system_user(env)
     if openupgrade.column_exists(env.cr, 'res_users', 'password_crypt'):
         fill_res_users_password_from_password_crypt(env.cr)

--- a/odoo/addons/base/migrations/12.0.1.3/post-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/post-migration.py
@@ -1,6 +1,6 @@
 # © 2018 Opener B.V. (stefan@opener.amsterdam)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from openupgradelib import openupgrade
+from openupgradelib import openupgrade, openupgrade_merge_records
 
 
 def generate_thumbnails(env):
@@ -32,6 +32,82 @@ def update_res_company_onboarding_company_state(env):
     good_companies.write({'base_onboarding_company_state': 'done'})
 
 
+def fork_off_system_user(env):
+    """ Fork user admin off from user system. User admin keeps the original
+    partner, and user system gets a new partner. """
+    user_root = env.ref('base.user_root')
+    partner_admin = env.ref('base.partner_admin')
+    partner_root = env.ref('base.partner_admin').copy({'name': 'System'})
+    login = user_root.login
+    user_root.login = '__system__'
+    user_admin = env.ref('base.user_root').copy({
+        'partner_id': partner_admin.id,
+        'login': login,
+    })
+    # copy old passwords for not losing them on new admin user
+    crypt = openupgrade.column_exists(env.cr, 'res_users', 'password_crypt')
+    set_query = "SET password = ru2.password "
+    if crypt:
+        set_query += ", password_crypt = ru2.password_crypt "
+    env.cr.execute(
+        "UPDATE res_users ru " + set_query +
+        "FROM res_users ru2 WHERE ru2.id = %s AND ru.id = %s",
+        (user_root.id, user_admin.id),
+    )
+    user_root.write({
+        'partner_id': partner_root.id,
+        'email': 'root@example.com',
+    })
+    env.cr.execute(
+        """ UPDATE ir_model_data SET res_id = %s
+        WHERE module = 'base' AND name = 'user_admin'""", (user_admin.id,))
+    env.cr.execute(
+        """ UPDATE ir_model_data SET res_id = %s
+        WHERE module = 'base' AND name = 'partner_root'""", (partner_root.id,))
+    openupgrade.logged_query(
+        env.cr,
+        """ UPDATE ir_model_data SET res_id = %(user_admin)s
+        WHERE model = 'res.users' AND res_id = %(user_root)s
+        AND (module != 'base' OR name != 'user_root') """,
+        {'user_admin': user_admin.id, 'user_root': user_root.id})
+    # Get create_uid and write_uid columns to ignore
+    env.cr.execute(
+        """ SELECT tc.table_name, kcu.column_name
+            FROM information_schema.table_constraints AS tc
+            JOIN information_schema.key_column_usage AS kcu
+                ON tc.constraint_name = kcu.constraint_name
+                AND tc.table_schema = kcu.table_schema
+            JOIN information_schema.constraint_column_usage AS ccu
+                ON ccu.constraint_name = tc.constraint_name
+                AND ccu.table_schema = tc.table_schema
+            WHERE constraint_type = 'FOREIGN KEY'
+            AND ccu.table_name = 'res_users' and ccu.column_name = 'id'
+            AND kcu.column_name IN ('create_uid', 'write_uid')
+        """)
+    exclude_columns = env.cr.fetchall() + [
+        ('ir_cron', 'user_id'), ('res_groups_users_rel', 'uid'),
+        ('res_company_users_rel', 'user_id'),
+    ]
+
+    openupgrade_merge_records.merge_records(
+        env, 'res.users', [user_root.id], user_admin.id,
+        method='sql', delete=False, exclude_columns=exclude_columns)
+    # Circumvent ORM when setting root user inactive, because
+    # "You cannot deactivate the user you're currently logged in as."
+    set_query = "SET active = FALSE, password = NULL"
+    if crypt:
+        set_query += ", password_crypt = NULL"
+    env.cr.execute(
+        "UPDATE res_users " + set_query + " WHERE id = %s",
+        (user_root.id, ),
+    )
+    # Ensure also partner_root is inactive
+    env.cr.execute(
+        """ UPDATE res_partner
+            SET active = FALSE WHERE id = %s """,
+        (partner_root.id,))
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     env['ir.ui.menu']._parent_store_compute()
@@ -46,3 +122,4 @@ def migrate(env, version):
         UPDATE ir_model_data SET noupdate=True
         WHERE  module='base' AND name='group_user'""",
     )
+    fork_off_system_user(env)


### PR DESCRIPTION
Before this the split was done in the end-migration and any other module modifyting
base.user_root will be modifying the previous v11 admin. After that the split is done
in the end-migration of base and you end up with the modifications meant for the
v12  `__system__` user in the v12 `admin` user.

Description of the issue/feature this PR addresses:
Temptative fix for https://github.com/OCA/OpenUpgrade/issues/1953

@StefanRijnhart does this look good to you? any reason why did this in the end-migration? 

cc @mreficent @pedrobaeza 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
