### PR TITLE
[12.0][FIX] mail_bot: set auto_install to false.

### DIFF
--- a/addons/mail_bot/__manifest__.py
+++ b/addons/mail_bot/__manifest__.py
@@ -11,7 +11,7 @@
     'depends': ['mail'],
     'installable': True,
     'application': False,
-    'auto_install': True,
+    'auto_install': False,
     'data': [
         'views/assets.xml',
         'views/res_users_views.xml',


### PR DESCRIPTION
This module is not adding any core functionality, only an
automatic chat that helps to discover funtionalities. Since it
is a new module in v12 it was always being installed by
openupgrade, this causes some problems with admin user split
done in end-migration of base module (see
https://github.com/OCA/OpenUpgrade/issues/1953).

If after running openupgrade you start you migrated database
with upstream Odoo, mail_bot will be installed but this time
without generating issues in the migrations result.

If we found in the future more ocurrences of the issue mentioned above (quite unlikely) we can reopen it, and find a more robust solution, but for the time being this is the more time-efficient solution due to the small scope of the problem.
