### PR TITLE
[12.0][IMP] mail: remove activity_date_deadline column

### DIFF
--- a/addons/mail/migrations/12.0.1.0/end-migration.py
+++ b/addons/mail/migrations/12.0.1.0/end-migration.py
@@ -64,7 +64,18 @@ def fill_mail_thread_message_main_attachment_id(env):
         )
 
 
+def remove_activity_date_deadline_column(env):
+    activity_mixin_models = [k for k in env.registry if issubclass(
+        type(env[k]), type(env['mail.activity.mixin'])) and env[k]._auto]
+    _column_renames = {
+        env[model]._table: [('activity_date_deadline', None)]
+        for model in activity_mixin_models if openupgrade.column_exists(
+            env.cr, env[model]._table, 'activity_date_deadline')}
+    openupgrade.rename_columns(env.cr, _column_renames)
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     fill_mail_tracking_value_track_sequence(env)
     fill_mail_thread_message_main_attachment_id(env)
+    remove_activity_date_deadline_column(env)

--- a/addons/mail/migrations/12.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/mail/migrations/12.0.1.0/openupgrade_analysis_work.txt
@@ -126,6 +126,11 @@ mail         / res.partner              / opt_out (boolean)             : DEL
 mail         / res.users                / moderation_channel_ids (many2many): NEW relation: mail.channel
 # NOTHING TO DO
 
+mail         / mail.activity.mixin      / activity_date_deadline (date) : not related anymore
+mail         / mail.activity.mixin      / activity_date_deadline (date) : not stored anymore
+mail         / mail.activity.mixin      / activity_date_deadline (date) : now a function
+# DONE: end-migration: remove activity_date_deadline column in all tables of models that inherit this mixin
+
 mail         / mail.thread              / message_main_attachment_id (many2one): NEW relation: ir.attachment
 # DONE: end-migration: filled the message_main_attachment_id as _message_post_after_hook method
 


### PR DESCRIPTION
To avoid confusion if someone checks the table later. This field is not stored anymore.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr