### PR TITLE
[IMP] Do not remove many2many tables

### DIFF
--- a/openerp/addons/base/ir/ir_model.py
+++ b/openerp/addons/base/ir/ir_model.py
@@ -634,6 +634,11 @@ class ir_model_relation(Model):
 
         # drop m2m relation tables
         for table in to_drop_table:
+            # OpenUpgrade: do not run the new table cleanup
+            openupgrade.message(
+                cr, 'Unknown', False, False,
+                "Not dropping the many2many table %s", table)
+            continue
             cr.execute('DROP TABLE %s CASCADE'% table,)
             _logger.info('Dropped table %s', table)
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
OpenUpgrade has blocks that prevent tables and columns to be dropped, but it's not doing that for tables created for many2many fields.

I'm wondering if this is intentional or just never reported :thinking: 
Btw, if approved, this should be forward-ported and probably backported aswell.


**Desired behavior after PR is merged:**
Many2many rel tables should not be dropped

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
