### PR TITLE
[10.0][MIG] purchase_fiscal_position_update

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -61,6 +61,8 @@ merged_modules = [
     ('website_sale_b2c', 'sale'),  # used groups are in sale
     # OCA/manufacture
     ('mrp_production_unreserve', 'mrp'),
+    # OCA/purchase-workflow
+    ('purchase_fiscal_position_update', 'purchase'),
     # OCA/sale-workflow
     ('sale_order_back2draft', 'sale'),
     ('product_customer_code_sale',


### PR DESCRIPTION
The code of this module was implemented in https://github.com/odoo/odoo/commit/77b68a170d00ca7a3d864ebd18cc2e89c65835b8.

@alexis-via migrated to v10 by error. I don't know if we should delete that module from the v10 repo.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr