### PR TITLE
[12.0][FIX] account: transfer_account_code_prefix

### DIFF
--- a/addons/account/migrations/12.0.1.1/post-migration.py
+++ b/addons/account/migrations/12.0.1.1/post-migration.py
@@ -96,7 +96,7 @@ def fill_account_chart_template_account_code_prefix(cr):
     openupgrade.logged_query(
         cr, """
         UPDATE account_chart_template act
-        SET transfer_account_code_prefix = trim(leading '0' from aat.code)
+        SET transfer_account_code_prefix = trim(trailing '0' from aat.code)
         FROM account_account_template aat
         WHERE act.%s = aat.id
         """, (AsIs(openupgrade.get_legacy_name('transfer_account_id')), ),


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

As discussed in https://github.com/OCA/OpenUpgrade/pull/1742: the calculation of the transfer_account_code_prefix makes use of `leading` instead of `trailing`. But `...code_prefix` expects to be the left part of the code, not the right part; the `trailing` seems the correct one.

However in Odoo there are a lot of transfer accounts with prefix codes ending with 0, so the use of `trailing` seems to be not correct in any case.

This PR is the proposal to set `transfer_account_code_prefix` the same as `transfer_account_id.code`. It shouldn't be a problem. And the user can manually adjust it later.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
