### PR TITLE
[12.0][FIX] iap: Don't be auto-installed if you are not going to use any IAP module

### DIFF
--- a/addons/iap/__manifest__.py
+++ b/addons/iap/__manifest__.py
@@ -19,5 +19,5 @@ This module provides standard tools (account model, context manager and helpers)
     'qweb': [
         'static/src/xml/iap_templates.xml',
     ],
-    'auto_install': True,
+    'auto_install': False,
 }


### PR DESCRIPTION
It will be installed when you have one module that requires it. This way, we avoid the surprise when migrating of having 6 new modules installed after the migration:

* iap
* sms
* calendar_sms
* snailmail
* snailmail_account
* partner_autocomplete

Twin PR for OCB: OCA/OCB#868

cc @Tecnativa