### PR TITLE
[11.0][FIX] MRP consumed materials qty that use tracking

### DIFF
--- a/addons/mrp/migrations/11.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/11.0.2.0/post-migration.py
@@ -75,7 +75,9 @@ def create_stock_move_lines_from_stock_move_lots(env):
             CASE WHEN sm.is_done = TRUE THEN 0
             ELSE sm.product_uom_qty
             END as product_uom_qty,
-            sm.product_uom_qty as qty_done,
+            CASE WHEN sml.lot_id IS NOT NULL THEN sml.quantity_done
+            ELSE sm.product_uom_qty
+            END as qty_done,
             sm.name,
             sm.state,
             current_timestamp,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When a product, inside the bill of material, is using tracking by lot/serial number, the quantity is not correct 

It's quite the same like here #1963 but this is for Bill Of materials stock.move.lines

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
