### PR TITLE
[ADD] account_asset-> account_asset_management (renamed models)

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -81,4 +81,8 @@ renamed_models = {
     'sale.quote.template': 'sale.order.template',
     'stock.incoterms': 'account.incoterms',
     # 'stock.location.path': 'stock.rule', handled in 'stock'
+    # OCA/account-financial-tools
+    'account.asset.asset': 'account.asset',
+    'account.asset.depreciation.line': 'account.asset.line',
+    'account.asset.category': 'account.asset.profile',
 }


### PR DESCRIPTION
Although this change does nothing, it helps in the openupgrade_records analysis. Then, if @apps2grow redo the analysis with this, the new resulting analysis in https://github.com/OCA/account-financial-tools/pull/873 will be more understandable.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr