### PR TITLE
[11.0][FIX] project.issue : add the issues unrelated to projects

### DIFF
--- a/addons/project/migrations/11.0.1.1/post-migration.py
+++ b/addons/project/migrations/11.0.1.1/post-migration.py
@@ -128,9 +128,8 @@ def convert_issues(env):
                 WHEN pi.priority='2' THEN '1'
                 ELSE pi.priority
             END
-        FROM project_issue pi,
-            project_project pp
-        WHERE pi.project_id = pp.id
+        FROM project_issue pi
+            LEFT JOIN project_project pp ON pp.id = pi.project_id
         """, {
             'project_column': AsIs(issue_project_column),
             'issue_column': AsIs(origin_issue_column),


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
When migrating the issues and transform them to tasks => the issues that are not related to projects are not taking into account

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
