### PR TITLE
[FIX] website_blog: Remove website_blog_mgmt garbage

### DIFF
--- a/addons/website_blog/migrations/10.0.1.0/pre-migration.py
+++ b/addons/website_blog/migrations/10.0.1.0/pre-migration.py
@@ -8,6 +8,9 @@ from openupgradelib import openupgrade
 _field_renames_website_blog_mgmt = [
     ('blog.post', 'blog_post', 'website_publication_date', 'published_date'),
 ]
+_garbage_records = [
+    "website_blog.ir_cron_publish_blog",
+]
 
 
 @openupgrade.migrate(use_env=True)
@@ -16,3 +19,4 @@ def migrate(env, version):
     if openupgrade.column_exists(cr, 'blog_post', 'website_publication_date'):
         # If website_blog_mgmt was installed
         openupgrade.rename_fields(env, _field_renames_website_blog_mgmt)
+    openupgrade.delete_records_safely_by_xml_id(env, _garbage_records)


### PR DESCRIPTION
In https://github.com/OCA/OpenUpgrade/pull/1656 website_blog_mgmt was merged into website_blog.

However, this noupdate record still remains in the database, producing recurring failures like this:

    Traceback (most recent call last):
      File "/opt/odoo/custom/src/odoo/odoo/tools/safe_eval.py", line 350, in safe_eval
        return unsafe_eval(c, globals_dict, locals_dict)
      File "", line 1, in <module>
    AttributeError: 'blog.post' object has no attribute 'cron_publish_posts'

    During handling of the above exception, another exception occurred:

    Traceback (most recent call last):
      File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_cron.py", line 102, in _callback
        self.env['ir.actions.server'].browse(server_action_id).run()
      File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_actions.py", line 569, in run
        res = func(action, eval_context=eval_context)
      File "/opt/odoo/auto/addons/website/models/ir_actions.py", line 57, in run_action_code_multi
        res = super(ServerAction, self).run_action_code_multi(action, eval_context)
      File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_actions.py", line 445, in run_action_code_multi
        safe_eval(action.sudo().code.strip(), eval_context, mode="exec", nocopy=True)  # nocopy allows to return 'action'
      File "/opt/odoo/custom/src/odoo/odoo/tools/safe_eval.py", line 373, in safe_eval
        pycompat.reraise(ValueError, ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr)), exc_info[2])
      File "/opt/odoo/custom/src/odoo/odoo/tools/pycompat.py", line 86, in reraise
        raise value.with_traceback(tb)
      File "/opt/odoo/custom/src/odoo/odoo/tools/safe_eval.py", line 350, in safe_eval
        return unsafe_eval(c, globals_dict, locals_dict)
      File "", line 1, in <module>
    ValueError: <class 'AttributeError'>: "'blog.post' object has no attribute 'cron_publish_posts'" while evaluating
    'model.cron_publish_posts()'

Now it is removed.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa