### PR TITLE
[FIX] sale: Delete mail template translations

### DIFF
--- a/addons/sale/migrations/12.0.1.1/post-migration.py
+++ b/addons/sale/migrations/12.0.1.1/post-migration.py
@@ -83,6 +83,11 @@ def migrate(env, version):
     fill_sale_order_line_qty_delivered_method(env.cr)
     openupgrade.load_data(
         env.cr, 'sale', 'migrations/12.0.1.1/noupdate_changes.xml')
+    openupgrade.delete_record_translations(
+        env.cr, 'sale', [
+            'email_template_edi_sale',
+        ],
+    )
     openupgrade.delete_records_safely_by_xml_id(
         env, [
             'sale.mail_template_data_notification_email_sale_order',


### PR DESCRIPTION
The record `sale.email_template_edi_sale` is reset as a noupdate change. Its no-updated translations must be reset too.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa