### PR TITLE
[FIX] mass_mailing: remove mass_mailing_security_group record rules

### DIFF
--- a/addons/mass_mailing/migrations/10.0.2.0/post-migration.py
+++ b/addons/mass_mailing/migrations/10.0.2.0/post-migration.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Tecnativa - Jairo Llopis
+# Copyright 2019 Tecnativa - David Vidal
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
+
+_garbage_records = [
+    "mass_mailing.mass_mailing_marketing_user_access",
+    "mass_mailing.mass_mailing_marketing_manager_access",
+]
 
 
 def convert_campaigns_to_utm(env):
@@ -35,3 +41,6 @@ def migrate(env, version):
     openupgrade.load_data(
         env.cr, 'mass_mailing', 'migrations/10.0.2.0/noupdate_changes.xml',
     )
+    # The OCA module mass_mailing_security_group was merged into mass_mailing
+    # but we need to remove the record rules given by it
+    openupgrade.delete_records_safely_by_xml_id(env, _garbage_records)


### PR DESCRIPTION
The OCA module mass_mailing_security_group was merged into mass_mailing but we need to remove the record rules given by it

cc @Tecnativa

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
