### PR TITLE
[FIX] account/sale_timesheet: Renamed ir.rule XML-ID changed in between v12

### DIFF
--- a/addons/account/migrations/12.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/12.0.1.1/openupgrade_analysis_work.txt
@@ -395,6 +395,9 @@ NEW res.groups: account.group_show_line_subtotals_tax_excluded
 NEW res.groups: account.group_show_line_subtotals_tax_included
 # DONE: pre-migration: renamed groups from sale module
 
+NEW ir.rule: account.account_analytic_line_rule_billing_user
+# DONE: pre-migration: Renamed from sale_timesheet module
+
 NEW res.groups: base.group_portal
 NEW res.groups: base.group_public
 NEW res.groups: base.group_user (noupdate)

--- a/addons/account/migrations/12.0.1.1/pre-migration.py
+++ b/addons/account/migrations/12.0.1.1/pre-migration.py
@@ -54,6 +54,8 @@ xmlid_renames = [
      'account.group_show_line_subtotals_tax_excluded'),
     ('sale.group_show_price_total',
      'account.group_show_line_subtotals_tax_included'),
+    ('sale_timesheet.account_analytic_line_rule_billing_user',
+     'account.account_analytic_line_rule_billing_user'),
 ]
 
 

--- a/addons/sale_timesheet/migrations/12.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/sale_timesheet/migrations/12.0.1.0/openupgrade_analysis_work.txt
@@ -55,3 +55,6 @@ NEW ir.ui.view: sale_timesheet.qunit_suite
 DEL ir.ui.view: sale_timesheet.hr_timesheet_employee_extd_form
 DEL ir.ui.view: sale_timesheet.product_template_search_view_sale_timesheet
 # NOTHING TO DO
+
+DEL ir.rule: sale_timesheet.account_analytic_line_rule_billing_user (noupdate)
+# DONE: Renamed in account module


### PR DESCRIPTION
It was changed in https://github.com/odoo/odoo/pull/31661, after the first analysis.

cc @Tecnativa