### PR TITLE
[12.0][IMP] project: Move fill_project_project_inherits_values to pre

### DIFF
--- a/addons/project/migrations/12.0.1.1/post-migration.py
+++ b/addons/project/migrations/12.0.1.1/post-migration.py
@@ -2,23 +2,10 @@
 # Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
-from psycopg2.extensions import AsIs
-
-
-def fill_project_project_inherits_values(cr):
-    openupgrade.logged_query(
-        cr, """UPDATE project_project pp
-        SET name = aaa.name, partner_id = aaa.partner_id,
-            company_id = aaa.company_id
-        FROM account_analytic_account aaa
-        WHERE pp.%s = aaa.id
-        """, (AsIs(openupgrade.get_legacy_name('analytic_account_id')), ),
-    )
 
 
 @openupgrade.migrate()
 def migrate(env, version):
-    fill_project_project_inherits_values(env.cr)
     openupgrade.load_data(
         env.cr, 'project', 'migrations/12.0.1.1/noupdate_changes.xml',
         mode='init_no_create')

--- a/addons/project/migrations/12.0.1.1/pre-migration.py
+++ b/addons/project/migrations/12.0.1.1/pre-migration.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Eficent <http://www.eficent.com>
+# Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+from psycopg2 import sql
 
 column_copies = {
     'project_project': [
@@ -28,7 +30,29 @@ def compute_project_task_rating_last_value(env):
         )
 
 
+def fill_project_project_inherits_values(env):
+    """Do this on pre-migration for avoiding temporary error on null names."""
+    # Fields already exists, so we only need to add SQL columns
+    openupgrade.logged_query(
+        env.cr, """ALTER TABLE project_project
+            ADD COLUMN name VARCHAR,
+            ADD COLUMN partner_id int4,
+            ADD COLUMN company_id int4""")
+    openupgrade.logged_query(
+        env.cr, sql.SQL(
+            """UPDATE project_project pp
+            SET name = aaa.name, partner_id = aaa.partner_id,
+                company_id = aaa.company_id
+            FROM account_analytic_account aaa
+            WHERE pp.{} = aaa.id"""
+        ).format(
+            sql.Identifier('analytic_account_id'),
+        )
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    fill_project_project_inherits_values(env)
     openupgrade.copy_columns(env.cr, column_copies)
     compute_project_task_rating_last_value(env)


### PR DESCRIPTION
We do this for avoiding the error that appears in the log:
```
odoo.sql_db: bad query: b'ALTER TABLE "project_project" ALTER COLUMN "name" SET NOT NULL'
ERROR: column "name" contains null values
```

Althought that error is temporary, and the constraint is added on a second update of the module, it's better to avoid the annoying error in the log when you check it, and also for having the constraint applied immediately if needed.

cc @Tecnativa