### PR TITLE
[FIX] base: Preserve system user email

### DIFF
--- a/odoo/addons/base/migrations/12.0.1.3/end-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/end-migration.py
@@ -58,8 +58,9 @@ def fork_off_system_user(env):
     )
     user_root.write({
         'partner_id': partner_root.id,
-        'email': 'root@example.com',
+        'email': partner_admin.email,
     })
+    partner_admin.email = False
     env.cr.execute(
         """ UPDATE ir_model_data SET res_id = %s
         WHERE module = 'base' AND name = 'user_admin'""", (user_admin.id,))


### PR DESCRIPTION
After this migration, all system emails are sent by `__system__` instead of `admin`, so `__system__` should keep its email address to avoid altering the experience of users receiving emails.

The side effect will be that admin user will have no email address, which is not cool, so after migrating you should either update admin's email or remove him.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa TT19494