### PR TITLE
[FIX] Bump openupgradelib version dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         'mock',
         'ofxparse',
         'openerp-client-lib==1.1.2',
-        'openupgradelib>=2.0.0',
+        'openupgradelib>=3.0.0',
         'passlib',
         'pillow',  # windows binary http://www.lfd.uci.edu/~gohlke/pythonlibs/
         'psutil',  # windows binary code.google.com/p/psutil/downloads/list


### PR DESCRIPTION
openupgradelib 3.0.0 has commit https://github.com/OCA/openupgradelib/commit/c57ca75c1ba0d2b118808d6d7e6f69398b3334b7 that fixes AttributeError exception

Description of the issue/feature this PR addresses:

Cannot upgrade to database to 12, 'cos old openupgradelib tries to import odoo.tools.yaml_import which does not exist.

Current behavior before PR:
After runing `odoo-bin --update all`
```
Traceback (most recent call last):
  File "/home/noroot/Projects/c12/src/c8/ou12/odoo/service/server.py", line 1063, in load_server_wide_modules
    odoo.modules.module.load_openerp_module(m)
  File "/home/noroot/Projects/c12/src/c8/ou12/odoo/modules/module.py", line 368, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 664, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 634, in _load_backward_compatible
  File "/home/noroot/Projects/c12/src/c8/ou12/odoo/modules/module.py", line 82, in load_module
    exec(open(modfile, 'rb').read(), new_mod.__dict__)
  File "<string>", line 5, in <module>
  File "/home/noroot/Projects/c12/src/c8/ou12/odoo/addons/base/models/__init__.py", line 7, in <module>
    from . import ir_model
  File "/home/noroot/Projects/c12/src/c8/ou12/odoo/addons/base/models/ir_model.py", line 17, in <module>
    from openupgradelib import openupgrade
  File "/home/noroot/Projects/c12/src/c8/ou12/ou12venv/lib/python3.5/site-packages/openupgradelib/openupgrade.py", line 85, in <module>
    yaml_import = tools.yaml_import
AttributeError: module 'odoo.tools' has no attribute 'yaml_import'
```
Desired behavior after PR is merged:

Exception above does not happen (assuming openupgradelib 3.0.0 is installed or installed via `pip install --upgrade git+https://github.com/OCA/openupgradelib.git`). Currently openupgradelib 3.0.0 is NOT published in pypi. You can install it via `pip install --upgrade git+https://github.com/OCA/openupgradelib.git`



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
