### PR TITLE
[12.0][FIX] sale_timesheet: Set qty_delivered_method

### DIFF
--- a/addons/sale/migrations/12.0.1.1/post-migration.py
+++ b/addons/sale/migrations/12.0.1.1/post-migration.py
@@ -51,7 +51,7 @@ def fill_sale_order_line_qty_delivered_method(cr):
             SET qty_delivered_method = 'stock_move'
             FROM product_product pp
             LEFT JOIN product_template pt ON pp.product_tmpl_id = pt.id
-            WHERE sol.product_id = pp.id AND NOT sol.is_expense
+            WHERE sol.product_id = pp.id AND sol.is_expense IS NOT TRUE
                 AND pt.type IN ('consu', 'product')
             """
         )
@@ -62,7 +62,7 @@ def fill_sale_order_line_qty_delivered_method(cr):
         SET qty_delivered_method = 'timesheet'
         FROM product_product pp
         LEFT JOIN product_template pt ON pp.product_tmpl_id = pt.id
-        WHERE sol.product_id = pp.id AND NOT sol.is_expense
+        WHERE sol.product_id = pp.id AND sol.is_expense IS NOT TRUE
             AND pt.type = 'service' AND pt.service_type = 'timesheet'
         """
     )

--- a/addons/sale_timesheet/migrations/12.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/sale_timesheet/migrations/12.0.1.0/openupgrade_analysis_work.txt
@@ -19,8 +19,10 @@ sale_timesheet / project.sale.line.employee.map / sale_line_id (many2one)       
 sale_timesheet / project.task             / billable_type (selection)     : NEW selection_keys: ['employee_rate', 'no', 'task_rate']
 sale_timesheet / project.task             / sale_order_id (many2one)      : NEW relation: sale.order
 sale_timesheet / sale.order.line          / project_id (many2one)         : NEW relation: project.project
-sale_timesheet / sale.order.line          / qty_delivered_method (False)  : NEW selection_keys: ['analytic', 'manual', 'stock_move', 'timesheet'], mode: modify
 # NOTHING TO DO: new features
+
+sale_timesheet / sale.order.line          / qty_delivered_method (False)  : NEW selection_keys: ['analytic', 'manual', 'stock_move', 'timesheet'], mode: modify
+# NOTHING TO DO: Already filled in sale post-migration script
 
 ---XML records in module 'sale_timesheet'---
 NEW ir.actions.act_window: sale_timesheet.project_profitability_report_action


### PR DESCRIPTION
Value 'timesheet' is added by sale_timesheet module, and the field is new on v12 and thus, the sale.order.line records that qualify for it don't have proper value. We fill it by SQL here for avoiding to trigger other dependent computed fields.

cc @Tecnativa