### PR TITLE
[12.0][IMP] openupgrade_records: consider merged models

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -90,9 +90,14 @@ renamed_models = {
     'sale.quote.option': 'sale.order.template.option',
     'sale.quote.template': 'sale.order.template',
     'stock.incoterms': 'account.incoterms',
-    # 'stock.location.path': 'stock.rule', handled in 'stock'
     # OCA/account-financial-tools
     'account.asset.asset': 'account.asset',
     'account.asset.depreciation.line': 'account.asset.line',
     'account.asset.category': 'account.asset.profile',
+}
+
+# only used here for openupgrade_records analysis:
+merged_models = {
+    # Odoo
+    'stock.location.path': 'stock.rule',
 }

--- a/odoo/addons/openupgrade_records/lib/compare.py
+++ b/odoo/addons/openupgrade_records/lib/compare.py
@@ -19,8 +19,13 @@ def module_map(module):
         module, apriori.merged_modules.get(module, module))
 
 
-def model_map(model):
+def model_rename_map(model):
     return apriori.renamed_models.get(model, model)
+
+
+def model_map(model):
+    return apriori.renamed_models.get(
+        model, apriori.merged_models.get(model, model))
 
 
 def inv_model_map(model):
@@ -50,7 +55,7 @@ def compare_records(dict_old, dict_new, fields):
             if module_map(dict_old['module']) != dict_new['module']:
                 return False
         elif field == 'model':
-            if model_map(dict_old['model']) != dict_new['model']:
+            if model_rename_map(dict_old['model']) != dict_new['model']:
                 return False
         elif field == 'other_prefix':
             if dict_old['module'] != dict_old['prefix'] or \


### PR DESCRIPTION
This way, we can keep track also for merged models.

You can check https://github.com/OCA/OpenUpgrade/pull/2017 for what this fix provides. Basically, the 'stock.location.path' appears also as a renamed model to 'stock.rule'.

It will be more useful in v13, as there are more merged models to keep track.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr