### PR TITLE
[FIX] hr_timesheet: Recompute fields for issues, only if issue_id exists

### DIFF
--- a/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
+++ b/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
@@ -24,7 +24,7 @@ def migrate_project_issue_sheet(env):
     from issues.
     """
     origin_issue_column = openupgrade.get_legacy_name('origin_issue_id')
-    if not origin_issue_column:
+    if not openupgrade.column_exists(env.cr, 'account_analytic_line', origin_issue_column):
         return
     openupgrade.logged_query(
         env.cr, """
@@ -42,7 +42,7 @@ def recompute_tasks_from_issues_fields(env):
     its recomputation.
     """
     origin_issue_column = openupgrade.get_legacy_name('origin_issue_id')
-    if not origin_issue_column:
+    if not openupgrade.column_exists(env.cr, 'project_task', origin_issue_column):
         return
     env.cr.execute("SELECT id FROM project_task WHERE %s IS NOT NULL",
                    (AsIs(origin_issue_column), ))

--- a/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
+++ b/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
@@ -42,6 +42,9 @@ def recompute_tasks_from_issues_fields(env):
     being inserted by SQL, don't have these fields computed, so we force here
     its recomputation.
     """
+    if not openupgrade.column_exists(
+            env.cr, 'account_analytic_line', 'issue_id'):
+        return
     origin_issue_column = openupgrade.get_legacy_name('origin_issue_id')
     env.cr.execute("SELECT id FROM project_task WHERE %s IS NOT NULL",
                    (AsIs(origin_issue_column), ))

--- a/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
+++ b/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
@@ -23,10 +23,9 @@ def migrate_project_issue_sheet(env):
     and then fill `task_id` field in analytic lines with the tasks created
     from issues.
     """
-    if not openupgrade.column_exists(
-            env.cr, 'account_analytic_line', 'issue_id'):
-        return
     origin_issue_column = openupgrade.get_legacy_name('origin_issue_id')
+    if not origin_issue_column:
+        return
     openupgrade.logged_query(
         env.cr, """
         UPDATE account_analytic_line aal
@@ -42,10 +41,9 @@ def recompute_tasks_from_issues_fields(env):
     being inserted by SQL, don't have these fields computed, so we force here
     its recomputation.
     """
-    if not openupgrade.column_exists(
-            env.cr, 'account_analytic_line', 'issue_id'):
-        return
     origin_issue_column = openupgrade.get_legacy_name('origin_issue_id')
+    if not origin_issue_column:
+        return
     env.cr.execute("SELECT id FROM project_task WHERE %s IS NOT NULL",
                    (AsIs(origin_issue_column), ))
     tasks = env['project.task'].browse([x[0] for x in env.cr.fetchall()])

--- a/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
+++ b/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
@@ -24,7 +24,8 @@ def migrate_project_issue_sheet(env):
     from issues.
     """
     origin_issue_column = openupgrade.get_legacy_name('origin_issue_id')
-    if not openupgrade.column_exists(env.cr, 'account_analytic_line', origin_issue_column):
+    if not openupgrade.column_exists(env.cr, 'account_analytic_line',
+                                     origin_issue_column):
         return
     openupgrade.logged_query(
         env.cr, """
@@ -42,7 +43,8 @@ def recompute_tasks_from_issues_fields(env):
     its recomputation.
     """
     origin_issue_column = openupgrade.get_legacy_name('origin_issue_id')
-    if not openupgrade.column_exists(env.cr, 'project_task', origin_issue_column):
+    if not openupgrade.column_exists(env.cr, 'project_task',
+                                     origin_issue_column):
         return
     env.cr.execute("SELECT id FROM project_task WHERE %s IS NOT NULL",
                    (AsIs(origin_issue_column), ))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Issue when account.analytic.account issue_id does not exist:

Current behavior before PR:
hr_timesheet post-migration will fail on recompute_tasks_from_issues_fields

Desired behavior after PR is merged:
hr_timesheet post-migration will succeed.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
