### PR TITLE
use the pypi version of PyChart

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ def py2exe_options():
                     "skip_archive": 1,
                     "optimize": 0, # keep the assert running, because the integrated tests rely on them.
                     "dist_dir": 'dist',
-                    "packages": [ "DAV", "HTMLParser", "pillow", "asynchat", "asyncore", "commands", "dateutil", "decimal", "docutils", "email", "encodings", "imaplib", "jinja2", "lxml", "lxml._elementpath", "lxml.builder", "lxml.etree", "lxml.objectify", "mako", "openerp", "poplib", "pychart", "pydot", "pyparsing", "pytz", "reportlab", "select", "simplejson", "smtplib", "uuid", "vatnumber", "vobject", "xml", "xml.dom", "yaml", ],
+                    "packages": [ "DAV", "HTMLParser", "pillow", "asynchat", "asyncore", "commands", "dateutil", "decimal", "docutils", "email", "encodings", "imaplib", "jinja2", "lxml", "lxml._elementpath", "lxml.builder", "lxml.etree", "lxml.objectify", "mako", "openerp", "poplib", "python-chart", "pydot", "pyparsing", "pytz", "reportlab", "select", "simplejson", "smtplib", "uuid", "vatnumber", "vobject", "xml", "xml.dom", "yaml", ],
                     "excludes" : ["Tkconstants","Tkinter","tcl"],
                 }
             }
@@ -111,10 +111,9 @@ setuptools.setup(
       scripts          = ['openerp-server'],
       data_files       = data(),
       packages         = setuptools.find_packages(),
-      dependency_links = ['http://download.gna.org/pychart/'],
       #include_package_data = True,
       install_requires = [
-          'pychart', # not on pypi, use: pip install http://download.gna.org/pychart/PyChart-1.39.tar.gz
+          'python-chart',
           'babel',
           'docutils',
           'feedparser',


### PR DESCRIPTION
Port https://github.com/OCA/OCB/pull/251 to OpenUpgrade, to allow starting `openerp-server` without this failure:



Description of the issue/feature this PR addresses:

> this will save pain when download.gna.org is down
> https://pypi.python.org/pypi/Python-Chart/1.39

Current behavior before PR:
```
openerp-server --version
Traceback (most recent call last):
  File "/usr/local/bin/openerp-server", line 4, in <module>
    __import__('pkg_resources').require('openerp==7.0')
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3250, in <module>
    @_call_aside
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3234, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3263, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'pychart' distribution was not found and is required by openerp
```

Desired behavior after PR is merged: :boot: :boot: (boots)


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
@Tecnativa TT18838