### PR TITLE
[12.0][FIX] calendar: Don't remove used types

### DIFF
--- a/addons/calendar/migrations/12.0.1.0/post-migration.py
+++ b/addons/calendar/migrations/12.0.1.0/post-migration.py
@@ -16,12 +16,23 @@ def migrate(env, version):
             'calendar_template_meeting_reminder',
         ],
     )
-    openupgrade.delete_records_safely_by_xml_id(
-        env, [
-            'calendar.categ_meet1',
-            'calendar.categ_meet2',
-            'calendar.categ_meet3',
-            'calendar.categ_meet4',
-            'calendar.categ_meet5',
-        ],
-    )
+    event_calendar_type_xml_ids = [
+        'calendar.categ_meet1',
+        'calendar.categ_meet2',
+        'calendar.categ_meet3',
+        'calendar.categ_meet4',
+        'calendar.categ_meet5',
+    ]
+    CalendarEvent = env['calendar.event']
+    IrModelData = env['ir.model.data']
+    for xml_id in event_calendar_type_xml_ids:
+        record = env.ref(xml_id)
+        if CalendarEvent.search([('categ_ids', '=', record.id)]):
+            # delete only XML-ID, as type is used, but not "safely" detected
+            module, name = xml_id.split('.')
+            IrModelData.search([
+                ('module', '=', module),
+                ('name', '=', name),
+            ]).unlink()
+        else:
+            openupgrade.delete_records_safely_by_xml_id(env, [xml_id])


### PR DESCRIPTION
Some data calendar event types have been removed in v12, and we remove them if it's safe to do it, but there's no constraint that avoids to be removed even if the types are used, so we switch to this algorithm for manually detecting if used.

cc @Tecnativa TT19531