### PR TITLE
[IMP] sale,sale_management,account: add empty sections

### DIFF
--- a/addons/sale/migrations/12.0.1.1/pre-migration.py
+++ b/addons/sale/migrations/12.0.1.1/pre-migration.py
@@ -77,17 +77,30 @@ def fill_sale_order_line_sections(cr):
     openupgrade.logged_query(
         cr, """
         INSERT INTO sale_order_line (order_id, layout_category_id,
-            sequence, name, price_unit, product_uom_qty, customer_lead,
+            sequence, name,
+            price_unit, product_uom_qty, customer_lead,
             display_type, create_uid, create_date, write_uid, write_date)
         SELECT sol.order_id, sol.layout_category_id,
-            min(sol.sequence) -1 as sequence, max(slc.name), 0, 0, 0,
-            'line_section', min(sol.create_uid), min(sol.create_date),
+            min(sol.sequence) -1 as sequence, max(COALESCE(slc.name, ' ')),
+            0, 0, 0, 'line_section', min(sol.create_uid), min(sol.create_date),
             min(sol.write_uid), min(sol.write_date)
         FROM sale_order_line sol
-        INNER JOIN sale_layout_category slc ON slc.id = sol.layout_category_id
+        LEFT JOIN sale_layout_category slc ON slc.id = sol.layout_category_id
         GROUP BY order_id, layout_category_id
         ORDER BY order_id, layout_category_id, sequence
         """
+    )
+    # We remove recently created sale.order.line for sections on sales orders
+    # where there's no sections at all
+    openupgrade.logged_query(
+        cr, """
+        DELETE FROM sale_order_line
+        WHERE layout_category_id IS NULL
+            AND display_type = 'line_section'
+            AND order_id NOT IN (
+                SELECT order_id FROM sale_order_line
+                WHERE layout_category_id IS NOT NULL
+            )""",
     )
 
 


### PR DESCRIPTION
If you have a sales order/sales template/invoice in v11 with this layout:

- Section 1
  * Line 1
  * Line 2
- Section 2
  * Line 3
* Line 4

It ends up with these lines:

- Section 1
- Line 1
- Line 2
- Section 2
- Line 3
- Line 4

so Line 4 seems that belongs to Section 2.

For avoiding this, we add an extra blank section for lines without v11 layout category.
Also for avoiding noise, we remove that section immediately for sales orders that have
no layout category in any of their lines.

Final result:

- Section 1
- Line 1
- Line 2
- Section 2
- Line 3
-
- Line 4

@Tecnativa TT20064