### PR TITLE
[9.0][FIX] remove useless xml loading, to avoid warning

### DIFF
--- a/addons/product/migrations/9.0.1.2/noupdate_changes.xml
+++ b/addons/product/migrations/9.0.1.2/noupdate_changes.xml
@@ -1,9 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <openerp>
   <data>
-    <record id="list0" model="product.pricelist">
-      <field name="type"/>
-    </record>
     <record id="product_comp_rule" model="ir.rule">
       <field name="active" eval="False"/>
     </record>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

warning, when migrate ``product`` module, from 8.0 to 9.0

**Reasons**

In v 8.0, the field ``type`` exist on ``product.pricelist`` model
ref : https://github.com/OCA/OCB/blob/8.0/addons/product/pricelist.py#L106
In v 9.0, the field ``type`` doesn't on ``product.pricelist`` model
ref : https://github.com/OCA/OCB/blob/9.0/addons/product/pricelist.py#L26

however, openupgrade script migration tries to write on this field, in the post-migration process of the ``product`` module, generating noice in log.

@mreficent : an idea why you wrote this part ? 

https://github.com/OCA/OpenUpgrade/commit/32802de4a5ff4eedf562a83d69cd1fa9df83c0cf

thanks

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
