### PR TITLE
[11.0][FIX] openupgrade_records: show real module name in analysis ("moved from XXX module")

### DIFF
--- a/odoo/addons/openupgrade_records/lib/compare.py
+++ b/odoo/addons/openupgrade_records/lib/compare.py
@@ -263,7 +263,7 @@ def compare_xml_sets(old_records, new_records):
                     column['old'] = True
                     found['new'] = True
                     column[match_type] = found['module']
-                    found[match_type] = module_map(column['module'])
+                    found[match_type] = column['module']
                 column['noupdate_switched'] = False
                 found['noupdate_switched'] = \
                     column['noupdate'] != found['noupdate']


### PR DESCRIPTION
Luckily, this doesn't affect the actual analysis. I checked.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr