### PR TITLE
[12.0][FIX] openupgrade_records: show real module name in analysis ("moved/renamed from XXX module")

### DIFF
--- a/addons/project/migrations/12.0.1.1/openupgrade_analysis.txt
+++ b/addons/project/migrations/12.0.1.1/openupgrade_analysis.txt
@@ -29,9 +29,9 @@ project      / res.company              / project_time_mode_id (many2one): relat
 ---XML records in module 'project'---
 NEW digest.digest: digest.digest_digest_default (noupdate)
 NEW digest.tip: project.digest_tip_project_0
-NEW ir.actions.act_window: project.rating_rating_action_project_report [renamed from project module]
-NEW ir.actions.act_window: project.rating_rating_action_task [renamed from project module]
-NEW ir.actions.act_window: project.rating_rating_action_view_project_rating [renamed from project module]
+NEW ir.actions.act_window: project.rating_rating_action_project_report [renamed from rating_project module]
+NEW ir.actions.act_window: project.rating_rating_action_task [renamed from rating_project module]
+NEW ir.actions.act_window: project.rating_rating_action_view_project_rating [renamed from rating_project module]
 DEL ir.actions.act_window: project.action_project_task_user_tree_filtered
 DEL ir.actions.act_window: project.project_task_action_activity
 DEL ir.actions.act_window: project.project_task_actions_act_window_merge_tasks
@@ -41,7 +41,7 @@ DEL ir.actions.act_window: rating_project.rating_rating_action_view_project_rati
 DEL ir.actions.act_window: rating_project.rating_rating_action_view_project_rating_task
 DEL ir.attachment: project.msg_task_data_14_attach (noupdate)
 DEL ir.attachment: project.msg_task_data_8_attach (noupdate)
-NEW ir.cron: project.ir_cron_rating_project [renamed from project module] (noupdate) (noupdate switched)
+NEW ir.cron: project.ir_cron_rating_project [renamed from rating_project module] (noupdate) (noupdate switched)
 DEL ir.cron: rating_project.ir_cron_rating_project [renamed to project module]
 NEW ir.model.access: project.access_mail_activity_type_project_manager
 DEL ir.model.access: project.access_account_analytic_account_manager [renamed to hr_timesheet module]
@@ -49,7 +49,7 @@ DEL ir.model.access: project.access_account_analytic_account_portal [renamed to 
 DEL ir.model.access: project.access_account_analytic_account_user [renamed to hr_timesheet module]
 DEL ir.model.access: project.access_account_analytic_line_project [renamed to hr_timesheet module]
 DEL ir.model.data: project.duplicate_field_xmlid (noupdate)
-NEW ir.ui.menu: project.rating_rating_menu_project [renamed from project module]
+NEW ir.ui.menu: project.rating_rating_menu_project [renamed from rating_project module]
 DEL ir.ui.menu: project.menu_action_view_task
 DEL ir.ui.menu: project.project_task_menu_activity
 DEL ir.ui.menu: rating_project.rating_rating_menu_project [renamed to project module]
@@ -83,12 +83,12 @@ DEL ir.ui.view: website_rating_project.project_rating_data
 DEL ir.ui.view: website_rating_project.project_rating_page
 DEL mail.message: project.msg_task_data_14 (noupdate)
 DEL mail.message: project.msg_task_data_8 (noupdate)
-NEW mail.message.subtype: project.mt_project_task_rating [renamed from project module]
-NEW mail.message.subtype: project.mt_task_rating [renamed from project module]
+NEW mail.message.subtype: project.mt_project_task_rating [renamed from rating_project module]
+NEW mail.message.subtype: project.mt_task_rating [renamed from rating_project module]
 DEL mail.message.subtype: rating_project.mt_project_task_rating [renamed to project module]
 DEL mail.message.subtype: rating_project.mt_task_rating [renamed to project module]
 NEW mail.template: project.mail_template_data_project_task (noupdate)
-NEW mail.template: project.rating_project_request_email_template [renamed from project module] (noupdate) (noupdate switched)
+NEW mail.template: project.rating_project_request_email_template [renamed from rating_project module] (noupdate) (noupdate switched)
 DEL mail.template: project.mail_template_data_module_install_project (noupdate)
 DEL mail.template: rating_project.rating_project_request_email_template [renamed to project module]
 DEL project.task: project.project_task_data_8 (noupdate)

--- a/addons/repair/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/repair/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -30,18 +30,18 @@ mrp_repair   / stock.move               / repair_id (many2one)          : relati
 repair       / repair.order             / message_main_attachment_id (many2one): NEW relation: ir.attachment
 ---XML records in module 'repair'---
 NEW ir.actions.act_window: repair.act_repair_invoice
-NEW ir.actions.act_window: repair.action_cancel_repair [renamed from repair module]
-NEW ir.actions.act_window: repair.action_repair_order_tree [renamed from repair module]
+NEW ir.actions.act_window: repair.action_cancel_repair [renamed from mrp_repair module]
+NEW ir.actions.act_window: repair.action_repair_order_tree [renamed from mrp_repair module]
 DEL ir.actions.act_window: mrp_repair.act_mrp_repair_invoice
 DEL ir.actions.act_window: mrp_repair.action_cancel_repair [renamed to repair module]
 DEL ir.actions.act_window: mrp_repair.action_repair_order_tree [renamed to repair module]
 NEW ir.actions.report: repair.action_report_repair_order
 DEL ir.actions.report: mrp_repair.action_report_mrp_repair_order
-NEW ir.model.access: repair.access_account_tax_user [renamed from repair module]
+NEW ir.model.access: repair.access_account_tax_user [renamed from mrp_repair module]
 NEW ir.model.access: repair.access_repair_fee_user
 NEW ir.model.access: repair.access_repair_line_user
 NEW ir.model.access: repair.access_repair_user
-NEW ir.model.access: repair.access_stock_production_lot_user [renamed from repair module]
+NEW ir.model.access: repair.access_stock_production_lot_user [renamed from mrp_repair module]
 DEL ir.model.access: mrp_repair.access_account_invoice_line_manager
 DEL ir.model.access: mrp_repair.access_account_invoice_line_user
 DEL ir.model.access: mrp_repair.access_account_invoice_manager
@@ -66,7 +66,7 @@ NEW ir.rule: repair.repair_rule (noupdate)
 DEL ir.rule: mrp_repair.mrp_repair_rule (noupdate)
 NEW ir.sequence: repair.seq_repair (noupdate)
 DEL ir.sequence: mrp_repair.seq_mrp_repair (noupdate)
-NEW ir.ui.menu: repair.menu_repair_order [renamed from repair module]
+NEW ir.ui.menu: repair.menu_repair_order [renamed from mrp_repair module]
 DEL ir.ui.menu: mrp_repair.menu_repair_order [renamed to repair module]
 NEW ir.ui.view: repair.report_repairorder
 NEW ir.ui.view: repair.report_repairorder2

--- a/addons/sale_management/migrations/12.0.1.0/openupgrade_analysis.txt
+++ b/addons/sale_management/migrations/12.0.1.0/openupgrade_analysis.txt
@@ -50,10 +50,10 @@ sale_management / sale.quote.template      / note (text)                   : pre
 sale_management / sale.quote.template      / number_of_days (integer)      : previously in module website_quote
 ---XML records in module 'sale_management'---
 NEW digest.digest: digest.digest_digest_default (noupdate)
-NEW ir.actions.act_window: sale.action_quotations [potentially moved from sale_quotation_builder module]
+NEW ir.actions.act_window: sale.action_quotations [potentially moved from website_quote module]
 NEW ir.actions.act_window: sale_management.sale_order_template_action
-NEW ir.model.access: sale_management.access_sale_order_option [renamed from sale_quotation_builder module]
-NEW ir.model.access: sale_management.access_sale_order_option_all [renamed from sale_quotation_builder module]
+NEW ir.model.access: sale_management.access_sale_order_option [renamed from website_quote module]
+NEW ir.model.access: sale_management.access_sale_order_option_all [renamed from website_quote module]
 NEW ir.model.access: sale_management.access_sale_order_template
 NEW ir.model.access: sale_management.access_sale_order_template_line
 NEW ir.model.access: sale_management.access_sale_order_template_line_manager

--- a/odoo/addons/openupgrade_records/lib/compare.py
+++ b/odoo/addons/openupgrade_records/lib/compare.py
@@ -295,7 +295,7 @@ def compare_xml_sets(old_records, new_records):
                     column['old'] = True
                     found['new'] = True
                     column[match_type] = found['module']
-                    found[match_type] = module_map(column['module'])
+                    found[match_type] = column['module']
                 found['domain'] = column['domain'] != found['domain'] and \
                     column['domain'] != '[]' and found['domain'] is False
                 column['domain'] = False


### PR DESCRIPTION
Little mistake.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr