### PR TITLE
[12.0][IMP] OpenUpgrade: don't delete xmlids linked to nothing

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1715,6 +1715,9 @@ class IrModelData(models.Model):
                                 res_id, model)
                         # /OpenUpgrade
                     else:
+                        # OpenUpgrade: don't delete xmlids. Use database_cleanup instead
+                        continue
+                        # /OpenUpgrade
                         bad_imd_ids.append(id)
         if bad_imd_ids:
             self.browse(bad_imd_ids).unlink()


### PR DESCRIPTION
The xmlids linked to nothing should not be deleted, as maybe they could be used later.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr