### PR TITLE
[IMP] stock: Faster stock.move migration

### DIFF
--- a/addons/stock/stock.py
+++ b/addons/stock/stock.py
@@ -612,7 +612,7 @@ class stock_quant(osv.osv):
         self.write(cr, SUPERUSER_ID, ids, {'cost': newprice}, context=context)
 
     def quants_unreserve(self, cr, uid, move, context=None):
-        related_quants = [x.id for x in move.reserved_quant_ids]
+        related_quants = move.reserved_quant_ids.ids
         if related_quants:
             #if move has a picking_id, write on that picking that pack_operation might have changed and need to be recomputed
             if move.picking_id:


### PR DESCRIPTION
This patch solves a bug and bunch of bottlenecks that were slowing down the execution of `move_stock_qty()`. The summary of changes is:

1. Inside `quants_unreserve()` I replaced a generator call for the much faster `.ids`. I know the usual thing is to not touch Odoo code, but this change doesn't affect logic but just performance.
2. Use sets instead of tuples for the `in` operator, always faster.
3. Avoid a bug in `_move_assign()` and `_move_done()` where the same outer variable name was being reused inside a loop, changing the result in unclean ways.
4. Index some fields that will be searched *a lot*.
5. Disable automatic field prefetching. Migrated models have lots of computed and relational fields that end up consuming more time than doing 1 query per field when needed.
6. Prefetch needed fields of as many records as possible before running the code, to avoid the previous point affecting the process negatively.
7. Add more logging so you can know the progress. This can be a big logging black hole otherwise.

Before this patch, it was processing about 3 moves/s in my server. After, it took about 10 mins prefetching things, but then it processed an average of 12 moves/s with peaks of more than 30 moves/s. That's 4x faster!

@Tecnativa TT18838