### PR TITLE
[IMP] stock: Faster warehouse migration

### DIFF
--- a/openerp/openupgrade/deferred_80.py
+++ b/openerp/openupgrade/deferred_80.py
@@ -199,12 +199,34 @@ def migrate_stock_move_warehouse(cr):
     openupgrade.logged_query(
         cr,
         """
+        CREATE INDEX IF NOT EXISTS procurement_order_move_dest_id_index
+        ON procurement_order USING BTREE(move_dest_id)
+        """,
+    )
+    openupgrade.logged_query(
+        cr,
+        """
+        CREATE INDEX IF NOT EXISTS stock_move_procurement_id_index
+        ON stock_move USING BTREE(procurement_id)
+        """,
+    )
+    openupgrade.logged_query(
+        cr,
+        """
         UPDATE stock_move sm
         SET warehouse_id = po.warehouse_id
         FROM procurement_order po
         WHERE sm.procurement_id = po.id
             OR po.move_dest_id = sm.id
         """)
+    openupgrade.logged_query(
+        cr,
+        "DROP INDEX procurement_order_move_dest_id_index",
+    )
+    openupgrade.logged_query(
+        cr,
+        "DROP INDEX stock_move_procurement_id_index",
+    )
 
 
 def migrate_deferred(cr, pool):


### PR DESCRIPTION
I got these logs today:

```log
DEBUG prod OpenUpgrade: 482275 rows affected after 13:59:31.075858 running
        UPDATE stock_move sm
        SET warehouse_id = po.warehouse_id
        FROM procurement_order po
        WHERE sm.procurement_id = po.id
            OR po.move_dest_id = sm.id
```

Yes, 14h running this query. It definitely needs a couple of indexes. After adding those, see:

```sql
prod=# CREATE INDEX IF NOT EXISTS procurement_order_move_dest_id_index
prod-#         ON procurement_order USING BTREE(move_dest_id);
CREATE INDEX
prod=# CREATE INDEX IF NOT EXISTS stock_move_procurement_id_index
prod-#         ON stock_move USING BTREE(procurement_id);
CREATE INDEX
prod=# SELECT COUNT(*) FROM stock_move sm, procurement_order po
prod-#         WHERE sm.procurement_id = po.id
prod-#             OR po.move_dest_id = sm.id;
 count
--------
 482275
(1 row)

prod=# EXPLAIN ANALYZE SELECT COUNT(*) FROM stock_move sm, procurement_order po
        WHERE sm.procurement_id = po.id
            OR po.move_dest_id = sm.id;
                                                                                QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Finalize Aggregate  (cost=1512713.58..1512713.59 rows=1 width=8) (actual time=712.008..712.008 rows=1 loops=1)
   ->  Gather  (cost=1512713.36..1512713.57 rows=2 width=8) (actual time=711.925..712.732 rows=3 loops=1)
         Workers Planned: 2
         Workers Launched: 2
         ->  Partial Aggregate  (cost=1511713.36..1511713.37 rows=1 width=8) (actual time=709.991..709.991 rows=1 loops=3)
               ->  Nested Loop  (cost=0.95..1511209.84 rows=201408 width=0) (actual time=5.799..698.615 rows=160758 loops=3)
                     ->  Parallel Seq Scan on procurement_order po  (cost=0.00..74746.18 rows=287218 width=8) (actual time=0.010..53.967 rows=229775 loops=3)
                     ->  Bitmap Heap Scan on stock_move sm  (cost=0.95..4.98 rows=2 width=8) (actual time=0.002..0.002 rows=1 loops=689324)
                           Recheck Cond: ((procurement_id = po.id) OR (po.move_dest_id = id))
                           Heap Blocks: exact=159909
                           ->  BitmapOr  (cost=0.95..0.95 rows=2 width=0) (actual time=0.001..0.001 rows=0 loops=689324)
                                 ->  Bitmap Index Scan on stock_move_procurement_id_index  (cost=0.00..0.44 rows=1 width=0) (actual time=0.001..0.001 rows=1 loops=689324)
                                       Index Cond: (procurement_id = po.id)
                                 ->  Bitmap Index Scan on stock_move_pkey  (cost=0.00..0.51 rows=1 width=0) (actual time=0.000..0.000 rows=0 loops=689324)
                                       Index Cond: (po.move_dest_id = id)
 Planning Time: 0.229 ms
 Execution Time: 712.770 ms
(17 rows)
```

Instant!


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@Tecnativa TT18838

