### PR TITLE
[FIX] Properly log failed partner ID

### DIFF
--- a/openerp/openupgrade/deferred_70.py
+++ b/openerp/openupgrade/deferred_70.py
@@ -58,7 +58,7 @@ def sync_commercial_fields(cr, pool):
             good = False
             logger.exception(
                 "Failed syncing commercial fields for partner %d",
-                partner_obj.id,
+                partner.id,
             )
     if not good:
         raise Exception(


### PR DESCRIPTION
https://github.com/OCA/OpenUpgrade/pull/2067 introduced a typo that produces this failure:

```
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/openerp/cli/server.py", line 97, in preload_registry
    db, registry = openerp.pooler.get_db_and_pool(dbname,update_module=update_module)
  File "/opt/odoo/custom/src/odoo/openerp/pooler.py", line 33, in get_db_and_pool
    registry = RegistryManager.get(db_name, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/openerp/modules/registry.py", line 203, in get
    update_module)
  File "/opt/odoo/custom/src/odoo/openerp/modules/registry.py", line 233, in new
    openerp.modules.load_modules(registry.db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 421, in load_modules
    deferred_70.migrate_deferred(cr, pool)
  File "/opt/odoo/custom/src/odoo/openerp/openupgrade/deferred_70.py", line 71, in migrate_deferred
    sync_commercial_fields(cr, pool)
  File "/opt/odoo/custom/src/odoo/openerp/openupgrade/deferred_70.py", line 61, in sync_commercial_fields
    partner_obj.id,
AttributeError: 'res.partner' object has no attribute 'id'
```

Obvious fix.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@Tecnativa TT18838
