### PR TITLE
[IMP] Futher details when failing a partner

### DIFF
--- a/openerp/openupgrade/deferred_70.py
+++ b/openerp/openupgrade/deferred_70.py
@@ -57,8 +57,8 @@ def sync_commercial_fields(cr, pool):
         except Exception:
             good = False
             logger.exception(
-                "Failed syncing commercial fields for partner %d",
-                partner.id,
+                "Failed syncing commercial fields for partner %d (%s, %s)",
+                partner.id, partner.name, partner.vat,
             )
     if not good:
         raise Exception(


### PR DESCRIPTION
The ID isn't enough to know the reason of a partner failure, because in v7 migration many new partners are created. I faced a case where the failing partner had an ID that wasn't existing in the v6.1 database, so the ID didn't help.

I'm logging the name and VAT (which is the field that will produce these failures most times) to make these logs even more helpful.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

@Tecnativa TT18838
