### PR TITLE
[IMP] Improve migration logging... yet again

### DIFF
--- a/openerp/openupgrade/deferred_70.py
+++ b/openerp/openupgrade/deferred_70.py
@@ -57,8 +57,10 @@ def sync_commercial_fields(cr, pool):
         except Exception:
             good = False
             logger.exception(
-                "Failed syncing commercial fields for partner %d (%s, %s)",
-                partner.id, partner.name, partner.vat,
+                "Failed syncing commercial fields for partner %d %r",
+                partner.id,
+                (partner.name, partner.vat, partner.commercial_partner_id,
+                 partner.commercial_partner_id.name),
             )
     if not good:
         raise Exception(


### PR DESCRIPTION
It turns out the partner that fails is called "/", and [it's a common name generated in the migration itself][1], so that information doesn't help much. The new but still useless log:

    2019-11-18 19:38:36,739 1 ERROR prod OpenUpgrade: Failed syncing commercial fields for partner 115945 (/, False)

OK, let's try logging even more and see if we finally get to the guilty record.

@Tecnativa TT18838

[1]: https://github.com/OCA/OpenUpgrade/blob/a792a63cd7a496b5dd75f202a9e5b64b355f17de/openerp/addons/base/migrations/7.0.1.3/post-migration.py#L299
