### PR TITLE
[IMP] Improve delete_quants_for_consumable_performance

### DIFF
--- a/addons/stock/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/11.0.1.1/pre-migration.py
@@ -69,8 +69,8 @@ def fix_act_window(env):
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     copy_global_rules(env)
-    delete_quants_for_consumable(env)
     drop_slow_constraint(env)
+    delete_quants_for_consumable(env)
     fix_act_window(env)
     openupgrade.update_module_moved_fields(
         env.cr, 'stock.move', ['has_tracking'], 'mrp', 'stock',


### PR DESCRIPTION
Description of the issue/feature this PR addresses:  Call first drop_slow_constraint just before delete_quants_for_consumable for improved delete performance
 
Current behavior before PR: If there any consumable quants in the database when migrating to v11 the database call that deletes that quants is slow.

Desired behavior after PR is merged: Using drop_slow_constraint before delete_quants_for_consumable improves the deletion performance

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
