### PR TITLE
[12.0][MIG] Rename of sale_procurement_group_by_required_date module

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -21,6 +21,9 @@ renamed_modules = {
     # OCA/hr
     'hr_employee_seniority': 'hr_employee_service_contract',
     'hr_family': 'hr_employee_relative',
+    # OCA/sale-workflow
+    'sale_procurement_group_by_requested_date':
+        'sale_procurement_group_by_commitment_date',
     # OCA/server-brand
     'res_config_settings_enterprise_remove': 'remove_odoo_enterprise',
     # OCA/stock-logistics-workflow


### PR DESCRIPTION
Renamed to sale_procurement_group_by_commitment_date (in https://github.com/OCA/sale-workflow/pull/1002).




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr