### PR TITLE
[IMP] purchase: Optimize migration in SQL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,11 +43,12 @@ script:
     - cat openerp/addons/base/migrations/*/tests/*.yml addons/*/migrations/*/tests/*.yml > ../test_data80.yml
     # Roundtrip to previous release to update the test database with additional test data
     # Loading and committing test data without triggering post tests needs https://github.com/odoo/odoo/pull/13146. This is now included in OpenUpgrade.
+    - old_commit="$(git rev-parse HEAD)"
     - git fetch --depth 2 origin 8.0
     - git reset --hard `git ls-remote |grep refs/heads/8.0 |awk '{print $1}'`
     - pip install -q -r requirements.txt
     - $ODOO --database=$DB --test-file=`readlink -f ../test_data80.yml` --test-commit --stop-after-init
-    - git reset -q --hard $TRAVIS_COMMIT
+    - git reset -q --hard $old_commit
     # Install Python requirements of target release
     - pip install -q -r requirements.txt
     # don't use pypi's openupgradelib, but the one from source to avoid choking

--- a/addons/purchase/migrations/9.0.1.2/end-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/end-migration.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright 2019 Tecnativa - Jairo Llopis
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.logging()
+def deferred_pol_qty_received_compute(env):
+    """Complete migration of purchase.order.line#qty_received
+
+    Skip records that were optimized in SQL in post-migration.
+    """
+    # Execute https://bit.ly/2PgUKaT for matching records
+    pol_todo = env["purchase.order.line"].search([
+        ("order_id.state", "in", ['purchase', 'done']),
+        ("product_id.type", "in", ['consu', 'product']),
+    ])
+    pol_todo._compute_qty_received()
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    deferred_pol_qty_received_compute(env)

--- a/addons/purchase/migrations/9.0.1.2/end-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/end-migration.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright 2019 Tecnativa - Jairo Llopis
+# Copyright 2019 Tecnativa - Pedro M. Baeza
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
 
 from openupgradelib import openupgrade
@@ -7,14 +8,16 @@ from openupgradelib import openupgrade
 
 @openupgrade.logging()
 def deferred_pol_qty_received_compute(env):
-    """Complete migration of purchase.order.line#qty_received
-
-    Skip records that were optimized in SQL in post-migration.
+    """Complete migration of purchase.order.line#qty_received for products
+    with BoMs. We don't go further in initial filtering, as this number should
+    be low and it's not going to be heavy to be computed.
     """
-    # Execute https://bit.ly/2PgUKaT for matching records
+    if 'mrp.bom' not in env:
+        return  # mrp not installed
     pol_todo = env["purchase.order.line"].search([
         ("order_id.state", "in", ['purchase', 'done']),
         ("product_id.type", "in", ['consu', 'product']),
+        ("product_id.product_tmpl_id.bom_ids", "!=", False),
     ])
     pol_todo._compute_qty_received()
 

--- a/addons/purchase/migrations/9.0.1.2/post-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/post-migration.py
@@ -3,6 +3,8 @@
 # © 2015 Serpent Consulting Services Pvt. Ltd.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
+from pprint import pformat
+
 from openupgradelib import openupgrade
 from openerp import api, SUPERUSER_ID
 
@@ -92,9 +94,184 @@ def account_properties(cr):
             """)
 
 
+@openupgrade.logging()
+def set_po_line_amounts(env):
+    """We replicate here the code of the compute function and set the values
+    finally via SQL for avoiding the trigger of the rest of the computed
+    fields that depends on these fields.
+
+    Replaces code from https://bit.ly/2rgpTTV
+    """
+    lines = env['purchase.order.line'].search([])
+    for line in lines:
+        taxes = line.taxes_id.compute_all(
+            line.price_unit, line.order_id.currency_id, line.product_qty,
+            product=line.product_id, partner=line.order_id.partner_id)
+        env.cr.execute("""
+            UPDATE purchase_order_line
+            SET price_tax = %s,
+                price_total = %s,
+                price_subtotal = %s
+            WHERE id = %s""", (
+                taxes['total_included'] - taxes['total_excluded'],
+                taxes['total_included'],
+                taxes['total_excluded'],
+                line.id,
+            )
+        )
+
+
+@openupgrade.logging()
+def set_po_line_computed_rest(env):
+    """Emulate the computation of the rest of the computed fields through
+    equivalent SQL queries.
+    """
+    uom_precision = env['decimal.precision'].precision_get('Product Unit of Measure')
+    # Fail if there are UoM mismatches
+    # Replace https://bit.ly/2s1ePtG
+    openupgrade.logged_query(
+        env.cr,
+        """
+            SELECT
+                pol.id AS order_line_id,
+                pol_u.id AS order_line_uom_id,
+                pol_u.category_id AS order_line_uom_category_id,
+                pol.product_id AS order_line_product_id,
+                ail.id AS invoice_line_id,
+                ail_u.id AS invoice_line_uom_id,
+                ail_u.category_id AS invoice_line_uom_category_id,
+                ail_pp.id AS invoice_line_product_id,
+                ail_pt.name AS invoice_line_product_template_name
+            FROM purchase_order_line pol
+                JOIN account_invoice_line ail ON
+                    pol.id = ail.purchase_line_id
+                JOIN product_product ail_pp ON ail_pp.id = ail.product_id
+                JOIN product_template ail_pt ON ail_pt.id = ail_pp.product_tmpl_id
+                JOIN account_invoice ai ON ai.id = ail.invoice_id
+                JOIN product_uom ail_u on (ail_u.id = ail.uom_id)
+                JOIN product_uom pol_u on (pol_u.id = pol.product_uom)
+            WHERE
+                ail_u.category_id != pol_u.category_id
+        """
+    )
+    uom_category_mismatches = env.cr.dictfetchall()
+    if uom_category_mismatches:
+        raise Exception(
+            "Found these mismatching UoM in related purchase.order.line "
+            "and account.invoice.line records: %s" %
+            pformat(uom_category_mismatches))
+    # Replace https://bit.ly/363UnqR
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE purchase_order_line pol
+            SET qty_invoiced = sub.qty
+            FROM (
+                SELECT
+                    pol2.id,
+                    SUM(
+                        ail.quantity / pol2_u.factor * ail_u.factor * (
+                            CASE
+                                WHEN ai.type = 'in_invoice' THEN 1
+                                ELSE -1
+                            END
+                        )
+                    ) AS qty
+                FROM purchase_order_line pol2
+                    JOIN account_invoice_line ail ON pol2.id = ail.purchase_line_id
+                    JOIN account_invoice ai ON ai.id = ail.invoice_id
+                    JOIN product_uom pol2_u ON pol2_u.id = ail.uom_id
+                    JOIN product_uom ail_u ON ail_u.id = pol2.product_uom
+                WHERE
+                    ai.state != 'cancel' AND
+                    ai.type IN ('in_invoice', 'in_refund')
+                GROUP BY pol2.id
+            ) AS sub
+            WHERE pol.id = sub.id
+        """
+    )
+    # Replace https://bit.ly/369kUDt and leave the rest of the method to
+    # be called in end-migration, where mrp module will be available for
+    # sure in the environment if it is installed
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE purchase_order_line pol
+            SET qty_received = 0.0
+            FROM purchase_order po
+            WHERE
+                po.id = pol.order_id AND
+                po.state NOT IN ('purchase', 'done')
+        """
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE purchase_order_line pol
+            SET qty_received = pol.product_qty
+            FROM purchase_order_line pol2
+            JOIN purchase_order po ON pol2.order_id = po.id
+            JOIN product_product pp ON pol2.product_id = pp.id
+            JOIN product_template pt ON pp.product_tmpl_id = pt.id
+            WHERE
+                po.id = pol2.id AND
+                po.state IN ('purchase', 'done') AND
+                pt.type NOT IN ('consu', 'product')
+        """
+    )
+    # Replace https://bit.ly/3832SEF
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE purchase_order po
+            SET invoice_status = CASE
+                WHEN po.state != 'purchase' THEN 'no'
+                WHEN sub.lines_to_invoice > 0 THEN 'to invoice'
+                WHEN sub.lines = sub.lines_invoiced THEN 'invoiced'
+                ELSE 'no'
+            END
+            FROM (
+                SELECT
+                    po2.id,
+                    COUNT(pol1.*) AS lines,
+                    COUNT(pol2.*) AS lines_to_invoice,
+                    COUNT(pol3.*) AS lines_invoiced
+                FROM
+                    purchase_order po2
+                    -- pol1 contains all lines
+                    LEFT JOIN purchase_order_line pol1
+                        ON po2.id = pol1.order_id
+                    -- pol2 contains lines to invoice
+                    LEFT JOIN purchase_order_line pol2
+                        ON po2.id = pol2.order_id AND
+                        ROUND(pol2.qty_invoiced::numeric, %(uom_precision)s) < ROUND(pol2.product_qty, %(uom_precision)s)
+                    -- pol3 contains invoiced lines
+                    LEFT JOIN purchase_order_line pol3
+                        ON po2.id = pol3.order_id AND
+                        ROUND(pol3.qty_invoiced::numeric, %(uom_precision)s) >= ROUND(pol3.product_qty, %(uom_precision)s)
+                GROUP BY po2.id
+            ) AS sub
+            WHERE po.id = sub.id
+        """,
+        {"uom_precision": uom_precision},
+    )
+    # Fill related column faster by SQL
+    openupgrade.logged_query(
+        env.cr,
+        """
+            UPDATE purchase_order_line pol
+            SET currency_id = po.currency_id
+            FROM purchase_order po
+            WHERE po.id = pol.order_id
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(cr, version):
     env = api.Environment(cr, SUPERUSER_ID, {})
     set_dummy_product(env)
     pricelist_property(cr, env)
     account_properties(cr)
+    set_po_line_amounts(env)
+    set_po_line_computed_rest(env)

--- a/addons/purchase/migrations/9.0.1.2/post-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/post-migration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L.
-# © 2015 Serpent Consulting Services Pvt. Ltd.
+# Copyright 2015 Eficent Business and IT Consulting Services S.L.
+# Copyright 2015 Serpent Consulting Services Pvt. Ltd.
+# Copyright 2019 Tecnativa - Jairo Llopis
+# Copyright 2019 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 
 from pprint import pformat
@@ -128,9 +130,8 @@ def set_po_line_computed_rest(env):
     """
     uom_precision = env['decimal.precision'].precision_get('Product Unit of Measure')
     # Fail if there are UoM mismatches
-    # Replace https://bit.ly/2s1ePtG
-    openupgrade.logged_query(
-        env.cr,
+    # Replace https://github.com/OCA/OpenUpgrade/blob/195b61a948dff1c64279eb68f0544/addons/product/product.py#L120-L122
+    env.cr.execute(
         """
             SELECT
                 pol.id AS order_line_id,
@@ -147,7 +148,6 @@ def set_po_line_computed_rest(env):
                     pol.id = ail.purchase_line_id
                 JOIN product_product ail_pp ON ail_pp.id = ail.product_id
                 JOIN product_template ail_pt ON ail_pt.id = ail_pp.product_tmpl_id
-                JOIN account_invoice ai ON ai.id = ail.invoice_id
                 JOIN product_uom ail_u on (ail_u.id = ail.uom_id)
                 JOIN product_uom pol_u on (pol_u.id = pol.product_uom)
             WHERE
@@ -160,7 +160,7 @@ def set_po_line_computed_rest(env):
             "Found these mismatching UoM in related purchase.order.line "
             "and account.invoice.line records: %s" %
             pformat(uom_category_mismatches))
-    # Replace https://bit.ly/363UnqR
+    # Replace https://github.com/OCA/OpenUpgrade/blob/195b61a948dff1c64279eb68f05/addons/purchase/purchase.py#L477-L487
     openupgrade.logged_query(
         env.cr,
         """
@@ -190,36 +190,62 @@ def set_po_line_computed_rest(env):
             WHERE pol.id = sub.id
         """
     )
-    # Replace https://bit.ly/369kUDt and leave the rest of the method to
-    # be called in end-migration, where mrp module will be available for
+    env.cr.execute("""
+        SELECT
+            pol.id AS order_line_id,
+            pol_u.id AS order_line_uom_id,
+            pol_u.category_id AS order_line_uom_category_id,
+            pol.product_id AS order_line_product_id,
+            sm.id AS stock_move_id,
+            sm_u.id AS stock_move_uom_id,
+            sm_u.category_id AS stock_move_uom_category_id,
+            sm_pp.id AS stock_move_product_id,
+            sm_pt.name AS stock_move_product_template_name
+        FROM purchase_order_line pol
+            JOIN stock_move sm ON pol.id = sm.purchase_line_id
+            JOIN product_product sm_pp ON sm_pp.id = sm.product_id
+            JOIN product_template sm_pt ON sm_pt.id = sm_pp.product_tmpl_id
+            JOIN product_uom sm_u on (sm_u.id = sm.product_uom)
+            JOIN product_uom pol_u on (pol_u.id = pol.product_uom)
+        WHERE
+            sm_u.category_id != pol_u.category_id""")
+    uom_category_mismatches = env.cr.dictfetchall()
+    if uom_category_mismatches:
+        raise Exception(
+            "Found these mismatching UoM in related purchase.order.line "
+            "and stock.move records: %s" % pformat(uom_category_mismatches))
+    # Replace https://github.com/OCA/OpenUpgrade/blob/195b61a948dff1c64279eb68f05/addons/purchase/purchase.py#L492-L498
+    # and leave the rest of the method to be called in end-migration, where mrp module will be available for
     # sure in the environment if it is installed
     openupgrade.logged_query(
-        env.cr,
-        """
-            UPDATE purchase_order_line pol
-            SET qty_received = 0.0
-            FROM purchase_order po
-            WHERE
-                po.id = pol.order_id AND
-                po.state NOT IN ('purchase', 'done')
-        """
-    )
-    openupgrade.logged_query(
-        env.cr,
-        """
-            UPDATE purchase_order_line pol
-            SET qty_received = pol.product_qty
+        env.cr, """
+        UPDATE purchase_order_line pol
+        SET qty_received = sub.qty_received
+        FROM (
+            SELECT CASE
+                WHEN MIN(po.state) NOT IN ('purchase', 'done') THEN 0.0
+                WHEN MIN(po.state) IN ('purchase', 'done')
+                    AND MIN(pt.type) NOT IN ('consu', 'product')
+                    THEN MIN(pol2.product_qty)
+                ELSE SUM(CASE
+                    WHEN sm.state IS NULL OR sm.state != 'done' THEN 0.0
+                    ELSE COALESCE(sm.product_uom_qty / u.factor * u2.factor, 0)
+                    END)
+                END
+            AS qty_received,
+                sm.purchase_line_id AS id
             FROM purchase_order_line pol2
             JOIN purchase_order po ON pol2.order_id = po.id
             JOIN product_product pp ON pol2.product_id = pp.id
             JOIN product_template pt ON pp.product_tmpl_id = pt.id
-            WHERE
-                po.id = pol2.id AND
-                po.state IN ('purchase', 'done') AND
-                pt.type NOT IN ('consu', 'product')
-        """
+            LEFT JOIN stock_move sm ON sm.purchase_line_id = pol2.id
+            LEFT JOIN product_uom u on (u.id = sm.product_uom)
+            LEFT JOIN product_uom u2 on (u2.id = pol2.product_uom)
+            GROUP BY sm.purchase_line_id
+        ) sub
+        WHERE sub.id = pol.id""",
     )
-    # Replace https://bit.ly/3832SEF
+    # Replace https://github.com/OCA/OpenUpgrade/blob/195b61a948dff1c64279eb68f0544/addons/purchase/purchase.py#L47-L60
     openupgrade.logged_query(
         env.cr,
         """
@@ -244,11 +270,13 @@ def set_po_line_computed_rest(env):
                     -- pol2 contains lines to invoice
                     LEFT JOIN purchase_order_line pol2
                         ON po2.id = pol2.order_id AND
-                        ROUND(pol2.qty_invoiced::numeric, %(uom_precision)s) < ROUND(pol2.product_qty, %(uom_precision)s)
+                        ROUND(pol2.qty_invoiced::numeric, %(uom_precision)s) <
+                        ROUND(pol2.product_qty, %(uom_precision)s)
                     -- pol3 contains invoiced lines
                     LEFT JOIN purchase_order_line pol3
                         ON po2.id = pol3.order_id AND
-                        ROUND(pol3.qty_invoiced::numeric, %(uom_precision)s) >= ROUND(pol3.product_qty, %(uom_precision)s)
+                        ROUND(pol3.qty_invoiced::numeric, %(uom_precision)s) >=
+                        ROUND(pol3.product_qty, %(uom_precision)s)
                 GROUP BY po2.id
             ) AS sub
             WHERE po.id = sub.id

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -81,10 +81,11 @@ def migrate(env, version):
     purchase_invoice_lines(cr)
     drop_workflows(env)
     # For avoiding costly computations - It will be handled in post+end
+    openupgrade.logged_query(
+        env.cr, "ALTER TABLE purchase_order_line ADD price_subtotal NUMERIC",
+    )
     openupgrade.add_fields(
         env, [
-            ('price_subtotal', 'purchase.order.line', 'purchase_order_line',
-             'monetary', False, 'purchase'),
             ('price_tax', 'purchase.order.line', 'purchase_order_line',
              'monetary', False, 'purchase'),
             ('price_total', 'purchase.order.line', 'purchase_order_line',

--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -63,6 +63,12 @@ def purchase_invoice_lines(cr):
         WHERE rel.invoice_id = ail.id """)
 
 
+@openupgrade.logging()
+def drop_workflows(env):
+    """Drop purchase workflows, removed in v9."""
+    openupgrade.delete_model_workflow(env.cr, "purchase.order")
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
@@ -73,3 +79,23 @@ def migrate(env, version):
     openupgrade.rename_tables(env.cr, table_renames)
     map_order_state(cr)
     purchase_invoice_lines(cr)
+    drop_workflows(env)
+    # For avoiding costly computations - It will be handled in post+end
+    openupgrade.add_fields(
+        env, [
+            ('price_subtotal', 'purchase.order.line', 'purchase_order_line',
+             'monetary', False, 'purchase'),
+            ('price_tax', 'purchase.order.line', 'purchase_order_line',
+             'monetary', False, 'purchase'),
+            ('price_total', 'purchase.order.line', 'purchase_order_line',
+             'monetary', False, 'purchase'),
+            ('qty_invoiced', 'purchase.order.line', 'purchase_order_line',
+             'float', False, 'purchase'),
+            ('qty_received', 'purchase.order.line', 'purchase_order_line',
+             'float', False, 'purchase'),
+            ('currency_id', 'purchase.order.line', 'purchase_order_line',
+             'many2one', False, 'purchase'),
+            ('invoice_status', 'purchase.order', 'purchase_order',
+             'selection', False, 'purchase'),
+        ]
+    )


### PR DESCRIPTION
There are plenty of new computed stored fields in `purchase`.

Here I imitate ORM methods in SQL to make them much faster to migrate. Inspired in https://github.com/OCA/OpenUpgrade/pull/2100 but adapted for purchase.

@Tecnativa TT18838

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
