### PR TITLE
[IMP] Speed up resize of mail_message's model column

### DIFF
--- a/addons/mail/migrations/9.0.1.0/pre-migration.py
+++ b/addons/mail/migrations/9.0.1.0/pre-migration.py
@@ -62,3 +62,7 @@ def migrate(env, version):
             ADD COLUMN %s integer;
             """ % openupgrade.get_legacy_name('alias_id')
         )
+
+    # This view blocks the quick resize of mail_message.model, forcing
+    # Odoo to go the slow way of creating a new column and copy the data
+    env.cr.execute("DROP VIEW IF EXISTS crm_claim_report")


### PR DESCRIPTION
Prevents

```2019-12-06 13:46:13.203 UTC [7859] ou9@migtest ERROR:  cannot alter type of a column used by a view or rule
2019-12-06 13:46:13.203 UTC [7859] ou9@migtest ERROR:  cannot alter type of a column used by a view or rule
2019-12-06 13:46:13.203 UTC [7859] ou9@migtest DETAIL:  rule _RETURN on view crm_claim_report depends on column "model"
2019-12-06 13:46:13.203 UTC [7859] ou9@migtest STATEMENT:  ALTER TABLE "mail_message" ALTER COLUMN "model" TYPE VARCHAR
```
Here: https://github.com/OCA/OpenUpgrade/blob/9.0/openerp/models.py#L2578

The slow method of resizing the column takes 8 minutes on this particular database.