### PR TITLE
[IMP] Set default values for multiple columns of the same table

### DIFF
--- a/openerp/sql_db.py
+++ b/openerp/sql_db.py
@@ -218,9 +218,10 @@ class Cursor(object):
 
     @check
     def execute(self, query, params=None, log_exceptions=None):
-        if '%d' in query or '%f' in query:
-            _logger.info("SQL queries cannot contain %%d or %%f anymore. Use only %%s:\n%s" % query, 
-                exc_info=_logger.isEnabledFor(logging.DEBUG))
+        # OpenUpgrade: this breaks compatibility with sql.SQL type queries
+        # if '%d' in query or '%f' in query:
+        #     _logger.info("SQL queries cannot contain %%d or %%f anymore. Use only %%s:\n%s" % query,
+        #         exc_info=_logger.isEnabledFor(logging.DEBUG))
         if params and not isinstance(params, (tuple, list, dict)):
             _logger.info("SQL query parameters should be a tuple, list or dict; got %r", params)
             raise ValueError("SQL query parameters should be a tuple, list or dict; got %r" % (params,))


### PR DESCRIPTION
 ...in the same query

Setting the default value for a single field takes just as long as setting
the default values for multiple fields at the same time, so this is a win for
large tables with multiple new fields with a default value. Results in queries
like

UPDATE "account_move_line" SET "amount_residual" = 0.0,
    "amount_residual_currency" = 0.0,
    "debit_cash_basis" = 0.0,
    "balance_cash_basis" = 0.0,
    "credit_cash_basis" = 0.0,
    "balance" = 0.0;
