### PR TITLE
[IMP] sale: Faster workflow deletion

### DIFF
--- a/addons/purchase/migrations/9.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/9.0.1.2/pre-migration.py
@@ -63,6 +63,12 @@ def purchase_invoice_lines(cr):
         WHERE rel.invoice_id = ail.id """)
 
 
+@openupgrade.logging()
+def drop_workflows(env):
+    """Drop sale workflows, removed in v9."""
+    openupgrade.delete_model_workflow(env.cr, "sale.order")
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
@@ -72,4 +78,5 @@ def migrate(env, version):
     openupgrade.rename_columns(env.cr, column_renames)
     openupgrade.rename_tables(env.cr, table_renames)
     map_order_state(cr)
+    drop_workflows(env)
     purchase_invoice_lines(cr)


### PR DESCRIPTION
This makes use of the optimized workflow deletion from openupgradelib, saving several hours in the end-migration stage.

@Tecnativa TT18838



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
