### PR TITLE
[IMP] Do not drop indexes

### DIFF
--- a/openerp/models.py
+++ b/openerp/models.py
@@ -2662,10 +2662,16 @@ class BaseModel(object):
                                         "Use a search view instead if you simply want to make the field searchable."
                                     _schema.warning(msg, self._table, f._type, k)
                             if res2 and not f.select:
-                                cr.execute('DROP INDEX "%s_%s_index"' % (self._table, k))
-                                cr.commit()
-                                msg = "Table '%s': dropping index for column '%s' of type '%s' as it is not required anymore"
-                                _schema.debug(msg, self._table, k, f._type)
+                                # OpenUpgrade: do not drop indexes
+                                # Odoo will drop any index that is defined in any other module than the module
+                                # that adds the column itself. Such indexes were supposedly added by customization
+                                # modules because they were needed in real life scenarios. Typically, removing
+                                # such indexes are harmful to the performance of the migration, plus it adds the
+                                # cost of re-adding the indexes on the upgrade of the module that defines them.
+                                # cr.execute('DROP INDEX "%s_%s_index"' % (self._table, k))
+                                # cr.commit()
+                                msg = "Table '%s': not dropping index for column '%s'"
+                                _schema.debug(msg, self._table, k)
 
                             if isinstance(f, fields.many2one) or (isinstance(f, fields.function) and f._type == 'many2one' and f.store):
                                 dest_model = self.pool[f._obj]


### PR DESCRIPTION
Odoo will drop any index that is defined in any other module than the module
that adds the column itself. Such indexes were supposedly added by customization
modules because they were needed in real life scenarios. Typically, removing
such indexes are harmful to the performance of the migration, plus it adds the
cost of re-adding the indexes on the upgrade of the module that defines them.
