### PR TITLE
[FIX] Regression in matched_percentage calculation causing division by zero

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -990,7 +990,7 @@ def fast_compute_cash_basis(env):
                         WHEN 0.0 = ROUND(
                             SUM(ABS(COALESCE(aml.debit, 0.0) - COALESCE(aml.credit, 0.0))),
                             CASE
-                                WHEN MAX(COALESCE(rc.rounding, 0)) BETWEEN 0 AND 1
+                                WHEN MAX(rc.rounding) < 1
                                 THEN CEIL(LOG(1 / MAX(rc.rounding)))
                                 ELSE 0
                             END::INTEGER


### PR DESCRIPTION
Main problem is that BETWEEN is inclusive, which allows for a rounding of 1
as is the case for JPY. The LOG of 1 is 0 which causes a division by zero.
Instead, we can just rely on NULL to invalidate numeric comparisons and check
if the result stands up to the numeric comparison 'smaller than 1'.

Regression of https://github.com/OCA/OpenUpgrade/pull/2115