### PR TITLE
[FIX][10.0] Prevent duplicate move lines when correcting old reconciliations

### DIFF
--- a/addons/account/migrations/10.0.1.1/post-migration.py
+++ b/addons/account/migrations/10.0.1.1/post-migration.py
@@ -2,6 +2,7 @@
 # Copyright 2017 Therp BV
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from odoo import _
 from openupgradelib import openupgrade
 
 
@@ -120,7 +121,7 @@ def migrate(env, version):
     # gather non-zero bank statement lines that have journal entries,
     # but no linked payments, meaning they are reconciled, but no
     # payment was created.
-    cr.execute('''
+    openupgrade.logged_query(cr, '''
         select l.id
         from account_bank_statement_line l
         join account_move m
@@ -161,8 +162,8 @@ def migrate(env, version):
             state='reconciled',
             amount=abs(total),
             communication=communication,
-            name=st_line.statement_id.name or
-                _('Bank Statement %s') % st_line.date
+            name=st_line.statement_id.name or _(
+                'Bank Statement %s') % st_line.date
         ))
 
         # link this new payment to the statement line
@@ -171,4 +172,3 @@ def migrate(env, version):
             ('name', '=', st_line.move_name),
         ])
         move.line_ids.write(dict(payment_id=payment.id))
-

--- a/addons/account/migrations/10.0.1.1/post-migration.py
+++ b/addons/account/migrations/10.0.1.1/post-migration.py
@@ -116,3 +116,59 @@ def migrate(env, version):
     openupgrade.load_data(
         cr, 'account', 'migrations/10.0.1.1/noupdate_changes.xml',
     )
+
+    # gather non-zero bank statement lines that have journal entries,
+    # but no linked payments, meaning they are reconciled, but no
+    # payment was created.
+    cr.execute('''
+        select l.id
+        from account_bank_statement_line l
+        join account_move m
+            on m.statement_line_id = l.id
+        join account_move_line ml
+            on ml.move_id = m.id
+        left join account_payment ap
+            on ml.payment_id = ap.id
+        where abs(l.amount) > 0.0001
+        group by l.id
+        having (
+            sum(case when ap.id is not null then 1 else 0 end) = 0
+            and sum(case when ml.id is not null then 1 else 0 end) > 0
+        )
+    ''')
+    statement_lines = env['account.bank.statement.line'].browse([
+        row[0] for row in cr.fetchall()])
+
+    # create payments for these
+    for st_line in statement_lines:
+        total = st_line.amount
+        journal = st_line.journal_id
+        currency = journal.currency_id or st_line.company_id.currency_id
+        payment_methods = (total > 0) and \
+            journal.inbound_payment_method_ids or \
+            journal.outbound_payment_method_ids
+        communication = st_line._get_communication(
+            payment_methods[0] if payment_methods else False)
+        payment = env['account.payment'].create(dict(
+            partner_id=st_line.partner_id.id or False,
+            payment_method_id=payment_methods[:1].id,
+            partner_type=(total < 0) and 'supplier' or 'customer',
+            currency_id=currency.id,
+            payment_reference=st_line.move_name,
+            payment_type=(total > 0) and 'inbound' or 'outbound',
+            journal_id=journal.id,
+            payment_date=st_line.date,
+            state='reconciled',
+            amount=abs(total),
+            communication=communication,
+            name=st_line.statement_id.name or
+                _('Bank Statement %s') % st_line.date
+        ))
+
+        # link this new payment to the statement line
+        move = env['account.move'].search([
+            ('statement_line_id', '=', st_line.id),
+            ('name', '=', st_line.move_name),
+        ])
+        move.line_ids.write(dict(payment_id=payment.id))
+

--- a/addons/account/migrations/10.0.1.1/post-migration.py
+++ b/addons/account/migrations/10.0.1.1/post-migration.py
@@ -141,34 +141,34 @@ def migrate(env, version):
         row[0] for row in cr.fetchall()])
 
     # create payments for these
-    for st_line in statement_lines:
-        total = st_line.amount
-        journal = st_line.journal_id
-        currency = journal.currency_id or st_line.company_id.currency_id
-        payment_methods = (total > 0) and \
-            journal.inbound_payment_method_ids or \
-            journal.outbound_payment_method_ids
-        communication = st_line._get_communication(
-            payment_methods[0] if payment_methods else False)
-        payment = env['account.payment'].create(dict(
-            partner_id=st_line.partner_id.id or False,
-            payment_method_id=payment_methods[:1].id,
-            partner_type=(total < 0) and 'supplier' or 'customer',
-            currency_id=currency.id,
-            payment_reference=st_line.move_name,
-            payment_type=(total > 0) and 'inbound' or 'outbound',
-            journal_id=journal.id,
-            payment_date=st_line.date,
-            state='reconciled',
-            amount=abs(total),
-            communication=communication,
-            name=st_line.statement_id.name or _(
-                'Bank Statement %s') % st_line.date
-        ))
+    for chunk in openupgrade.chunked(statement_lines):
+        for st_line in chunk:
+            total = st_line.amount
+            journal = st_line.journal_id
+            currency = journal.currency_id or st_line.company_id.currency_id
+            payment_methods = journal.inbound_payment_method_ids \
+                if total > 0 else journal.outbound_payment_method_ids
+            communication = st_line._get_communication(
+                payment_methods[0] if payment_methods else False)
+            payment = env['account.payment'].create(dict(
+                partner_id=st_line.partner_id.id or False,
+                payment_method_id=payment_methods[:1].id,
+                partner_type=(total < 0) and 'supplier' or 'customer',
+                currency_id=currency.id,
+                payment_reference=st_line.move_name,
+                payment_type=(total > 0) and 'inbound' or 'outbound',
+                journal_id=journal.id,
+                payment_date=st_line.date,
+                state='reconciled',
+                amount=abs(total),
+                communication=communication,
+                name=st_line.statement_id.name or _(
+                    'Bank Statement %s') % st_line.date
+            ))
 
-        # link this new payment to the statement line
-        move = env['account.move'].search([
-            ('statement_line_id', '=', st_line.id),
-            ('name', '=', st_line.move_name),
-        ])
-        move.line_ids.write(dict(payment_id=payment.id))
+            # link this new payment to the statement line
+            move = env['account.move'].search([
+                ('statement_line_id', '=', st_line.id),
+                ('name', '=', st_line.move_name),
+            ])
+            move.line_ids.write(dict(payment_id=payment.id))


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Odoo 10.0 [creates account.payment records](https://github.com/OCA/OCB/blob/10.0/addons/account/models/account_bank_statement.py#L911) on reconcilation from bank statement since [this commit](https://github.com/OCA/OCB/commit/3d48f2a375f22fc3da0f013041cfe0ce9ba6fb13). Odoo 9.0 and before [did not do this](https://github.com/OCA/OCB/blob/9.0/addons/account/models/account_bank_statement.py#L826).

On cancelling a reconciliation on a bank statement, Odoo 10.0 uses the [payment_id stored on account.move.line](https://github.com/OCA/OCB/blob/10.0/addons/account/models/account_bank_statement.py#L426) to find the move lines to delete. However for the bank statement lines created in 9.0 or earlier, there is no linked payment_id and as such those move lines are not found and not deleted. When the reconcilation is done again, duplicate move lines result and the ledger goes faulty.

With this PR, account.payment records are created for each reconciled bank statement line, so that corrections can be made.

Current behavior before PR:

Cancelling a pre-migration bank statement line reconciliation and making it again results in duplicate move lines.

Desired behavior after PR is merged:

Cancelling a pre-migration bank statement line reconciliation and making it again results in old move lines being deleted and replaced by new ones.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
