### PR TITLE
[FIX] utm: Rename `crm.tracking.*` to `utm.*`

### DIFF
--- a/addons/crm/migrations/9.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/crm/migrations/9.0.1.0/openupgrade_analysis_work.txt
@@ -1,34 +1,32 @@
 ---Fields in module 'crm'---
 crm          / calendar.event           / phonecall_id (many2one)       : DEL relation: crm.phonecall
-crm          / crm.activity             / _inherits (False)             : NEW 
+crm          / crm.activity             / _inherits (False)             : NEW
 crm          / crm.activity             / activity_1_id (many2one)      : NEW relation: crm.activity
 crm          / crm.activity             / activity_2_id (many2one)      : NEW relation: crm.activity
 crm          / crm.activity             / activity_3_id (many2one)      : NEW relation: crm.activity
-crm          / crm.activity             / days (integer)                : NEW 
-crm          / crm.activity             / sequence (integer)            : NEW 
+crm          / crm.activity             / days (integer)                : NEW
+crm          / crm.activity             / sequence (integer)            : NEW
 crm          / crm.activity             / subtype_id (many2one)         : NEW relation: mail.message.subtype, required: required
 crm          / crm.activity             / team_id (many2one)            : NEW relation: crm.team
 
 # New model replacing phone calls et al. We create a message for every phone call on the lead/partner (or user if not set) with crm_activity_data_call's message type
 
 crm          / crm.lead                 / campaign_id (many2one)        : relation is now 'utm.campaign' ('crm.tracking.campaign')
-
-# base pre-migration: model renamed
+crm          / crm.lead                 / medium_id (many2one)          : relation is now 'utm.medium' ('crm.tracking.medium')
+crm          / crm.lead                 / source_id (many2one)          : relation is now 'utm.source' ('crm.tracking.source')
+# NOTHING TO DO: Models renamed in base
 
 crm          / crm.lead                 / categ_ids (many2many)         : DEL relation: crm.case.categ
 crm          / crm.lead                 / tag_ids (many2many)           : NEW relation: crm.lead.tag
 
 # renamed categ_ids to tag_ids and crm.case.categ to crm.lead.tag
 
-crm          / crm.lead                 / date_conversion (datetime)    : NEW 
+crm          / crm.lead                 / date_conversion (datetime)    : NEW
 crm          / crm.lead                 / last_activity_id (many2one)   : NEW relation: crm.activity
 crm          / crm.lead                 / lost_reason (many2one)        : NEW relation: crm.lost.reason
 
 # nothing to do
 
-crm          / crm.lead                 / medium_id (many2one)          : relation is now 'utm.medium' ('crm.tracking.medium')
-
-# base pre-migration: model renamed
 
 crm          / crm.lead                 / message_follower_ids (many2many): not a function anymore
 crm          / crm.lead                 / message_follower_ids (many2many): relation is now 'mail.followers' ('res.partner')
@@ -43,8 +41,8 @@ crm          / crm.lead                 / priority (selection)          : select
 
 # 4 is mapped to 3
 
-crm          / crm.lead                 / ref (reference)               : DEL 
-crm          / crm.lead                 / ref2 (reference)              : DEL 
+crm          / crm.lead                 / ref (reference)               : DEL
+crm          / crm.lead                 / ref2 (reference)              : DEL
 
 # Migrated to sale order's opportunity field in sale_crm where applicable
 
@@ -52,10 +50,6 @@ crm          / crm.lead                 / section_id (many2one)         : relati
 crm          / crm.lead                 / section_id (many2one)         : was renamed to team_id [nothing to to]
 
 # Nothing to do (model is renamed in sales_team migration)
-
-crm          / crm.lead                 / source_id (many2one)          : relation is now 'utm.source' ('crm.tracking.source')
-
-# base pre-migration: model renamed
 
 crm          / crm.lead                 / stage_id (many2one)           : relation is now 'crm.stage' ('crm.case.stage')
 
@@ -69,41 +63,41 @@ crm          / crm.lead                 / website_message_ids (one2many): NEW re
 
 # nothing to do
 
-crm          / crm.lead.tag             / color (integer)               : NEW 
+crm          / crm.lead.tag             / color (integer)               : NEW
 crm          / crm.lead.tag             / name (char)                   : NEW required: required
 crm          / crm.lead.tag             / team_id (many2one)            : NEW relation: crm.team
 
 # renamed from crm.case.categ
 
-crm          / crm.lost.reason          / active (boolean)              : NEW 
+crm          / crm.lost.reason          / active (boolean)              : NEW
 crm          / crm.lost.reason          / name (char)                   : NEW required: required
 
 # nothing to do
 
-crm          / crm.stage                / fold (boolean)                : NEW 
-crm          / crm.stage                / legend_priority (text)        : NEW 
+crm          / crm.stage                / fold (boolean)                : NEW
+crm          / crm.stage                / legend_priority (text)        : NEW
 crm          / crm.stage                / name (char)                   : NEW required: required
-crm          / crm.stage                / on_change (boolean)           : NEW 
+crm          / crm.stage                / on_change (boolean)           : NEW
 crm          / crm.stage                / probability (float)           : NEW required: required, req_default: 10.0
-crm          / crm.stage                / requirements (text)           : NEW 
-crm          / crm.stage                / sequence (integer)            : NEW 
+crm          / crm.stage                / requirements (text)           : NEW
+crm          / crm.stage                / sequence (integer)            : NEW
 crm          / crm.stage                / team_ids (many2many)          : NEW relation: crm.team
 crm          / crm.stage                / type (selection)              : NEW required: required, selection_keys: ['both', 'lead', 'opportunity'], req_default: both
 
 # renamed from crm.case.stage, renamed pivot table for team_ids
 
-crm          / crm.team                 / _inherits (False)             : NEW 
+crm          / crm.team                 / _inherits (False)             : NEW
 crm          / crm.team                 / alias_id (many2one)           : NEW relation: mail.alias, required: required
 crm          / crm.team                 / resource_calendar_id (many2one): NEW relation: resource.calendar
 crm          / crm.team                 / stage_ids (many2many)         : NEW relation: crm.stage
-crm          / crm.team                 / use_leads (boolean)           : NEW 
-crm          / crm.team                 / use_opportunities (boolean)   : NEW 
+crm          / crm.team                 / use_leads (boolean)           : NEW
+crm          / crm.team                 / use_opportunities (boolean)   : NEW
 
 # nothing to do (crm.team#stage_ids is the inverse of crm.team#team_ids)
 
 crm          / res.partner              / phonecall_ids (one2many)      : DEL relation: crm.phonecall
-crm          / res.users                / target_sales_done (integer)   : NEW 
-crm          / res.users                / target_sales_won (integer)    : NEW 
+crm          / res.users                / target_sales_done (integer)   : NEW
+crm          / res.users                / target_sales_won (integer)    : NEW
 
 # nothing to do
 

--- a/addons/crm/migrations/9.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/crm/migrations/9.0.1.0/openupgrade_analysis_work.txt
@@ -13,7 +13,7 @@ crm          / crm.activity             / team_id (many2one)            : NEW re
 
 crm          / crm.lead                 / campaign_id (many2one)        : relation is now 'utm.campaign' ('crm.tracking.campaign')
 
-# Data is moved to utm_campaign and ids updated
+# base pre-migration: model renamed
 
 crm          / crm.lead                 / categ_ids (many2many)         : DEL relation: crm.case.categ
 crm          / crm.lead                 / tag_ids (many2many)           : NEW relation: crm.lead.tag
@@ -28,7 +28,7 @@ crm          / crm.lead                 / lost_reason (many2one)        : NEW re
 
 crm          / crm.lead                 / medium_id (many2one)          : relation is now 'utm.medium' ('crm.tracking.medium')
 
-# Data is moved to utm_medium and ids updates
+# base pre-migration: model renamed
 
 crm          / crm.lead                 / message_follower_ids (many2many): not a function anymore
 crm          / crm.lead                 / message_follower_ids (many2many): relation is now 'mail.followers' ('res.partner')
@@ -55,7 +55,7 @@ crm          / crm.lead                 / section_id (many2one)         : was re
 
 crm          / crm.lead                 / source_id (many2one)          : relation is now 'utm.source' ('crm.tracking.source')
 
-# Data is moved to utm_source and ids updated
+# base pre-migration: model renamed
 
 crm          / crm.lead                 / stage_id (many2one)           : relation is now 'crm.stage' ('crm.case.stage')
 

--- a/addons/crm/migrations/9.0.1.0/pre-migration.py
+++ b/addons/crm/migrations/9.0.1.0/pre-migration.py
@@ -37,47 +37,6 @@ column_copys = {
 }
 
 
-def migrate_tracking_campaign(cr):
-    # we can't simply rename the table because it's already created when
-    # installing utm. There's also a (quite academic) chance that it contains
-    # more than demo data
-    cr.execute(
-        'alter table utm_campaign add column crm_tracking_campaign_id int')
-    cr.execute(
-        'insert into utm_campaign (name, crm_tracking_campaign_id) '
-        'select name, id from crm_tracking_campaign')
-    openupgrade.lift_constraints(cr, 'crm_lead', 'campaign_id')
-    cr.execute(
-        'update crm_lead set campaign_id=c.id '
-        'from utm_campaign c where crm_tracking_campaign_id=campaign_id')
-
-
-def migrate_tracking_medium(cr):
-    # see above
-    cr.execute(
-        'alter table utm_medium add column crm_tracking_medium_id int')
-    cr.execute(
-        'insert into utm_medium (name, active, crm_tracking_medium_id) '
-        'select name, active, id from crm_tracking_medium')
-    openupgrade.lift_constraints(cr, 'crm_lead', 'medium_id')
-    cr.execute(
-        'update crm_lead set medium_id=m.id '
-        'from utm_medium m where crm_tracking_medium_id=medium_id')
-
-
-def migrate_tracking_source(cr):
-    # see above
-    cr.execute(
-        'alter table utm_source add column crm_tracking_source_id int')
-    cr.execute(
-        'insert into utm_source (name, crm_tracking_source_id) '
-        'select name, id from crm_tracking_source')
-    openupgrade.lift_constraints(cr, 'crm_lead', 'source_id')
-    cr.execute(
-        'update crm_lead set source_id=s.id '
-        'from utm_source s where crm_tracking_source_id=source_id')
-
-
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
@@ -86,9 +45,6 @@ def migrate(env, version):
     openupgrade.copy_columns(cr, column_copys)
     openupgrade.rename_tables(cr, table_renames)
     openupgrade.rename_models(cr, model_renames)
-    migrate_tracking_campaign(cr)
-    migrate_tracking_medium(cr)
-    migrate_tracking_source(cr)
     openupgrade.map_values(
         cr, openupgrade.get_legacy_name('priority'), 'priority',
         [('4', '3')], table='crm_lead',

--- a/addons/crm_claim/migrations/9.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/crm_claim/migrations/9.0.1.0/openupgrade_analysis_work.txt
@@ -13,17 +13,18 @@ crm_claim    / crm.claim.stage          / section_ids (many2many)       : DEL re
 crm_claim    / crm.claim.stage          / team_ids (many2many)          : NEW relation: crm.team
 # renames pivot table and relevant column
 ---XML records in module 'crm_claim'---
+DEL crm.tracking.campaign: crm_claim.claim_source1
+DEL crm.tracking.campaign: crm_claim.claim_source2
+NEW utm.campaign: crm_claim.claim_source1
+NEW utm.campaign: crm_claim.claim_source2
+# NOTHING TO DO: False positive that will disappear in new analysis
+
 DEL crm.case.categ: crm_claim.categ_claim1
 DEL crm.case.categ: crm_claim.categ_claim2
 DEL crm.case.categ: crm_claim.categ_claim3
 NEW crm.claim.category: crm_claim.categ_claim1
 NEW crm.claim.category: crm_claim.categ_claim2
 NEW crm.claim.category: crm_claim.categ_claim3
-
-DEL crm.tracking.campaign: crm_claim.claim_source1
-DEL crm.tracking.campaign: crm_claim.claim_source2
-# base pre-migration: models renamed
-
 NEW ir.actions.act_window: crm_claim.crm_claim_category_claim0
 DEL ir.actions.act_window: crm_claim.crm_case_categ_claim0
 DEL ir.actions.act_window.view: crm_claim.action_report_crm_claim_graph
@@ -34,7 +35,3 @@ NEW ir.ui.menu: base.menu_services
 NEW ir.ui.view: crm_claim.crm_claim_category_form
 NEW ir.ui.view: crm_claim.crm_claim_category_tree
 NEW ir.ui.view: crm_claim.view_report_crm_claim_pivot
-
-NEW utm.campaign: crm_claim.claim_source1
-NEW utm.campaign: crm_claim.claim_source2
-# base pre-migration: models renamed

--- a/addons/crm_claim/migrations/9.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/crm_claim/migrations/9.0.1.0/openupgrade_analysis_work.txt
@@ -19,8 +19,11 @@ DEL crm.case.categ: crm_claim.categ_claim3
 NEW crm.claim.category: crm_claim.categ_claim1
 NEW crm.claim.category: crm_claim.categ_claim2
 NEW crm.claim.category: crm_claim.categ_claim3
+
 DEL crm.tracking.campaign: crm_claim.claim_source1
 DEL crm.tracking.campaign: crm_claim.claim_source2
+# base pre-migration: models renamed
+
 NEW ir.actions.act_window: crm_claim.crm_claim_category_claim0
 DEL ir.actions.act_window: crm_claim.crm_case_categ_claim0
 DEL ir.actions.act_window.view: crm_claim.action_report_crm_claim_graph
@@ -31,5 +34,7 @@ NEW ir.ui.menu: base.menu_services
 NEW ir.ui.view: crm_claim.crm_claim_category_form
 NEW ir.ui.view: crm_claim.crm_claim_category_tree
 NEW ir.ui.view: crm_claim.view_report_crm_claim_pivot
+
 NEW utm.campaign: crm_claim.claim_source1
 NEW utm.campaign: crm_claim.claim_source2
+# base pre-migration: models renamed

--- a/addons/sale_crm/migrations/9.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/sale_crm/migrations/9.0.1.0/openupgrade_analysis_work.txt
@@ -8,8 +8,8 @@ sale_crm     / sale.order               / tag_ids (many2many)           : NEW re
 sale_crm     / sale.order               / campaign_id (many2one)        : relation is now 'utm.campaign' ('crm.tracking.campaign')
 sale_crm     / sale.order               / medium_id (many2one)          : relation is now 'utm.medium' ('crm.tracking.medium')
 sale_crm     / sale.order               / source_id (many2one)          : relation is now 'utm.source' ('crm.tracking.source')
-# Done: select link ids from tables migrated in crm module
-sale_crm     / res.users                / target_sales_invoiced (integer): NEW 
+# NOTHING TO DO: Models renamed in base
+sale_crm     / res.users                / target_sales_invoiced (integer): NEW
 # Nothing to do: new field with no logic associated to it, just for reference purposes.
 ---XML records in module 'sale_crm'---
 NEW ir.actions.act_window: crm.crm_lead_opportunities

--- a/addons/sale_crm/migrations/9.0.1.0/post-migrate.py
+++ b/addons/sale_crm/migrations/9.0.1.0/post-migrate.py
@@ -18,21 +18,6 @@ def get_sale_order_opportunity_id(env):
          AsIs(openupgrade.get_legacy_name('ref2'))))
 
 
-def get_sale_order_link_id(env, link):
-    openupgrade.logged_query(
-        env.cr, """\
-        UPDATE sale_order so
-        SET %(link)s_id = uc.id
-        FROM utm_%(link)s uc
-        WHERE so.%(legacy)s IS NOT NULL
-            AND so.%(legacy)s = uc.crm_tracking_%(link)s_id""", {
-            'link': AsIs(link),
-            'legacy': AsIs(openupgrade.get_legacy_name('%s_id' % link)),
-        })
-
-
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     get_sale_order_opportunity_id(env)
-    for link in 'campaign', 'medium', 'source':
-        get_sale_order_link_id(env, link)

--- a/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/pre-migration.py
@@ -41,6 +41,41 @@ def remove_obsolete(cr):
         """.format(OBSOLETE_RULES))
 
 
+@openupgrade.logging()
+def rename_utm(env):
+    """Handle crm.tracking.* -> utm.* renames.
+
+    This must be done in base because utm is a new module in v9, and crm
+    depends on it. This means that utm will not execute migration scripts
+    (because it's installed, not migrated), and crm migration scripts will
+    have all utm data already in place.
+
+    What we do here instead is to migrate minimal parts before utm
+    is even installed.
+    """
+    if openupgrade.table_exists(env.cr, "crm_tracking_campaign"):
+        openupgrade.rename_models(env.cr, [
+            ("crm.tracking.campaign", "utm.campaign"),
+            ("crm.tracking.medium", "utm.medium"),
+            ("crm.tracking.source", "utm.source"),
+        ])
+        openupgrade.rename_tables(env.cr, [
+            ("crm_tracking_campaign", "utm_campaign"),
+            ("crm_tracking_medium", "utm_medium"),
+            ("crm_tracking_source", "utm_source"),
+        ])
+        openupgrade.rename_xmlids(env.cr, [
+            ("crm.crm_medium_banner", "utm.utm_medium_banner"),
+            ("crm.crm_medium_direct", "utm.utm_medium_direct"),
+            ("crm.crm_medium_email", "utm.utm_medium_email"),
+            ("crm.crm_medium_phone", "utm.utm_medium_phone"),
+            ("crm.crm_medium_website", "utm.utm_medium_website"),
+            ("crm.crm_source_mailing", "utm.utm_source_mailing"),
+            ("crm.crm_source_newsletter", "utm.utm_source_newsletter"),
+            ("crm.crm_source_search_engine", "utm.utm_source_search_engine"),
+        ])
+
+
 def cleanup_modules(cr):
     """Don't report as missing these modules, as they are integrated in
     other modules."""
@@ -128,6 +163,7 @@ def migrate(env, version):
     map_res_partner_type(cr)
     migrate_translations(env.cr)
     switch_noupdate_flag(env.cr)
+    rename_utm(env)
 
 
 def pre_create_columns(cr):

--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -139,4 +139,7 @@ merged_modules = [
 ]
 
 renamed_models = {
+    "crm.tracking.campaign": "utm.campaign",
+    "crm.tracking.medium": "utm.medium",
+    "crm.tracking.source": "utm.source",
 }


### PR DESCRIPTION
- Done in `base` because `utm` is a new module and migration must be done before it is installed.
- Removed some migration from `crm` which is buggy after the new paradigm.

@Tecnativa TT18838
