### PR TITLE
[FIX] base: Drop FKs for procurement.order

### DIFF
--- a/addons/stock/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/11.0.1.1/pre-migration.py
@@ -37,17 +37,6 @@ def delete_quants_for_consumable(env):
     )
 
 
-def drop_slow_constraint(env):
-    """Removing this constraint, that doesn't affect new data structure, as
-    it belongs to an obsolete model, we get tons of more performance on
-    quant removal.
-    """
-    openupgrade.logged_query(
-        env.cr, "ALTER TABLE stock_move_operation_link DROP CONSTRAINT "
-                "stock_move_operation_link_reserved_quant_id_fkey",
-    )
-
-
 def fix_act_window(env):
     """Action window with XML-ID 'stock.action_procurement_compute' has
     set src_model='procurement.order', and this will provoke an error as
@@ -69,7 +58,6 @@ def fix_act_window(env):
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     copy_global_rules(env)
-    drop_slow_constraint(env)
     delete_quants_for_consumable(env)
     fix_act_window(env)
     openupgrade.update_module_moved_fields(

--- a/odoo/addons/base/migrations/11.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/11.0.1.3/pre-migration.py
@@ -24,6 +24,10 @@ model_renames_ir_actions_report = [
     ('ir.actions.report.xml', 'ir.actions.report')
 ]
 
+_obsolete_tables = (
+    "procurement_order",
+)
+
 
 def handle_partner_sector(env):
     if openupgrade.table_exists(env.cr, 'res_partner_sector'):
@@ -63,6 +67,7 @@ def fill_cron_action_server_pre(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
+    openupgrade.remove_tables_fks(env.cr, _obsolete_tables)
     openupgrade.update_module_names(
         env.cr, apriori.renamed_modules.items()
     )

--- a/odoo/addons/base/migrations/11.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/11.0.1.3/pre-migration.py
@@ -25,7 +25,36 @@ model_renames_ir_actions_report = [
 ]
 
 _obsolete_tables = (
+    "base_action_rule",
+    "base_action_rule_lead_test",
+    "base_action_rule_line_test",
+    "crm_activity",
+    "hr_timesheet_sheet_sheet",
+    "ir_values",
+    "marketing_campaign",
+    "marketing_campaign_activity",
+    "marketing_campaign_segment",
+    "marketing_campaign_transition",
+    "marketing_campaign_workitem",
     "procurement_order",
+    "project_issue",
+    "report",
+    "res_font",
+    "stock_move_lots",
+    "stock_move_operation_link",
+    "stock_pack_operation",
+    "stock_pack_operation_lot",
+    "stock_picking_wave",
+    "subscription_document",
+    "subscription_document_fields",
+    "subscription_subscription",
+    "subscription_subscription_history",
+    "wkf",
+    "wkf_activity",
+    "wkf_instance",
+    "wkf_transition",
+    "wkf_triggers",
+    "wkf_workitem",
 )
 
 


### PR DESCRIPTION
Running [this v12 migration code][1] in a DB that was migrated from v10 and that had many procurement orders takes days. That's because the FK was set without an index.

At the end of the day, this isn't useful because that table is no longer used, so I'm dropping its FKs here.

WIP until merged:

- [x] https://github.com/OCA/openupgradelib/pull/195

[1]: https://github.com/OCA/OpenUpgrade/blob/bdf26ceb11834fd45ca4b4577532d6f5ee2ca4e4/addons/sale/migrations/12.0.1.1/pre-migration.py#L93-L104

@Tecnativa TT18838