### PR TITLE
[12.0][FIX] account migration, do not force account.group_show_line_subtotals_tax_excluded

### DIFF
--- a/addons/account/migrations/12.0.1.1/noupdate_changes.xml
+++ b/addons/account/migrations/12.0.1.1/noupdate_changes.xml
@@ -104,12 +104,6 @@
   <record id="data_account_type_direct_costs" model="account.account.type">
     <field name="internal_group">expense</field>
   </record>
-  <record id="base.group_portal" model="res.groups">
-    <field name="implied_ids" eval="[(4, ref('account.group_show_line_subtotals_tax_excluded'))]"/>
-  </record>
-  <record id="base.group_public" model="res.groups">
-    <field name="implied_ids" eval="[(4, ref('account.group_show_line_subtotals_tax_excluded'))]"/>
-  </record>
   <record id="base.group_user" model="res.groups">
     <field name="implied_ids" eval="[(4, ref('account.group_products_in_bills'))]"/>
   </record>


### PR DESCRIPTION
See https://github.com/OCA/OpenUpgrade/issues/2144

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
