### PR TITLE
[12.0][PERF] Improve perf for processing Layout on sale and invoice

### DIFF
--- a/addons/account/migrations/12.0.1.1/pre-migration.py
+++ b/addons/account/migrations/12.0.1.1/pre-migration.py
@@ -99,21 +99,13 @@ def fill_account_invoice_line_sections(cr):
             min(ail.write_uid), min(ail.write_date)
         FROM account_invoice_line ail
         LEFT JOIN sale_layout_category slc ON slc.id = ail.layout_category_id
+        WHERE ail.invoice_id in (
+            SELECT invoice_id
+            FROM account_invoice_line
+            WHERE layout_category_id IS NOT NULL)
         GROUP BY invoice_id, layout_category_id
         ORDER BY invoice_id, layout_category_id, sequence
         """
-    )
-    # We remove recently created account.invoice.line for sections on invoices
-    # where there's no sections at all
-    openupgrade.logged_query(
-        cr, """
-        DELETE FROM account_invoice_line
-        WHERE layout_category_id IS NULL
-            AND display_type = 'line_section'
-            AND invoice_id NOT IN (
-                SELECT invoice_id FROM account_invoice_line
-                WHERE layout_category_id IS NOT NULL
-            )""",
     )
 
 

--- a/addons/sale/migrations/12.0.1.1/pre-migration.py
+++ b/addons/sale/migrations/12.0.1.1/pre-migration.py
@@ -86,21 +86,13 @@ def fill_sale_order_line_sections(cr):
             min(sol.write_uid), min(sol.write_date)
         FROM sale_order_line sol
         LEFT JOIN sale_layout_category slc ON slc.id = sol.layout_category_id
+        WHERE sol.order_id IN (
+            SELECT order_id
+            FROM sale_order_line
+            WHERE layout_category_id IS NOT NULL)
         GROUP BY order_id, layout_category_id
         ORDER BY order_id, layout_category_id, sequence
         """
-    )
-    # We remove recently created sale.order.line for sections on sales orders
-    # where there's no sections at all
-    openupgrade.logged_query(
-        cr, """
-        DELETE FROM sale_order_line
-        WHERE layout_category_id IS NULL
-            AND display_type = 'line_section'
-            AND order_id NOT IN (
-                SELECT order_id FROM sale_order_line
-                WHERE layout_category_id IS NOT NULL
-            )""",
     )
 
 

--- a/addons/sale_management/migrations/12.0.1.0/pre-migration.py
+++ b/addons/sale_management/migrations/12.0.1.0/pre-migration.py
@@ -122,21 +122,13 @@ def fill_sale_order_template_line_sections(cr):
             min(sotl.write_uid), min(sotl.write_date)
         FROM sale_order_template_line sotl
         LEFT JOIN sale_layout_category slc ON slc.id = sotl.layout_category_id
+        WHERE sotl.sale_order_template_id IN (
+            SELECT sale_order_template_id
+            FROM sale_order_template_line
+            WHERE layout_category_id IS NOT NULL)
         GROUP BY sale_order_template_id, layout_category_id
         ORDER BY sale_order_template_id, layout_category_id, sequence
         """
-    )
-    # We remove recently created sale.order.template.line for sections on
-    # templates where there's no sections at all
-    openupgrade.logged_query(
-        cr, """
-        DELETE FROM sale_order_template_line
-        WHERE layout_category_id IS NULL
-            AND display_type = 'line_section'
-            AND sale_order_template_id NOT IN (
-                SELECT sale_order_template_id FROM sale_order_template_line
-                WHERE layout_category_id IS NOT NULL
-            )""",
     )
 
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Adding and removing layout section on sale_order_line and invoice_line is very very long

Current behavior before PR:

The current migration process add layout on every sale and invoice and then remove all not need layout section. The sale and invoice that do not need them are the sale/invoice that do not have line with layout_category

Desired behavior after PR is merged:
Layout section are only insert for sale and invoice that need it.
In my case as I migrate from v8 so I do not have any layout on any sale invoice and this change same me more then 18 hours

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
