### PR TITLE
[12.0][FIX]fill purchase_order_user_id before it is autofilled

### DIFF
--- a/addons/purchase/migrations/12.0.1.2/openupgrade_analysis_work.txt
+++ b/addons/purchase/migrations/12.0.1.2/openupgrade_analysis_work.txt
@@ -32,7 +32,7 @@ purchase     / purchase.order           / message_main_attachment_id (many2one):
 # NOTHING TO DO
 
 purchase     / purchase.order           / user_id (many2one)            : NEW relation: res.users
-# DONE: post-migration: filled from create_uid
+# DONE: pre-migration: filled from create_uid
 
 purchase     / purchase.order.line      / product_uom (many2one)        : relation is now 'uom.uom' ('product.uom')
 # NOTHING TO DO: handled in base module

--- a/addons/purchase/migrations/12.0.1.2/post-migration.py
+++ b/addons/purchase/migrations/12.0.1.2/post-migration.py
@@ -5,15 +5,6 @@
 from openupgradelib import openupgrade
 
 
-def fill_purchase_order_user_id(cr):
-    openupgrade.logged_query(
-        cr, """
-        UPDATE purchase_order
-        SET user_id = create_uid
-        WHERE user_id IS NULL""",
-    )
-
-
 def reset_context_purchase_actions(env):
     env.ref('purchase.purchase_rfq').context = '{}'
     env.ref('purchase.purchase_form_action').context = '{}'
@@ -21,7 +12,6 @@ def reset_context_purchase_actions(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
-    fill_purchase_order_user_id(env.cr)
     reset_context_purchase_actions(env)
     openupgrade.load_data(
         env.cr, 'purchase', 'migrations/12.0.1.2/noupdate_changes.xml')

--- a/addons/purchase/migrations/12.0.1.2/pre-migration.py
+++ b/addons/purchase/migrations/12.0.1.2/pre-migration.py
@@ -54,7 +54,23 @@ def precompute_pol_product_uom_qty(env):
     )
 
 
+def fill_purchase_order_user_id(cr):
+    if not openupgrade.column_exists(cr, 'purchase_order', 'user_id'):
+        # Done here because user_id is filled automatically when upgrading
+        cr.execute(
+            """
+            ALTER TABLE purchase_order ADD COLUMN user_id integer;
+            """)
+    openupgrade.logged_query(
+        cr, """
+        UPDATE purchase_order
+        SET user_id = create_uid
+        WHERE user_id IS NULL""",
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    fill_purchase_order_user_id(env.cr)
     precompute_pol_product_uom_qty(env)
     openupgrade.rename_xmlids(env.cr, xmlid_renames)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Purchase representative is not filled by the migration scripts because Odoo fills it automatically when upgrading the module

Current behavior before PR: 
Purchase representative in purchase order is always administrator. 

Desired behavior after PR is merged:
Purchase representative is the user who created the purchase order

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
