### PR TITLE
[RFR] Prefill invoice amount fields but take care of multicurrency invoices

### DIFF
--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -163,10 +163,9 @@ FAST_CREATIONS = [
     UPDATE account_invoice
     SET amount_total_signed = - amount_total
     WHERE type IN ('in_refund', 'out_refund');
-    """)
-]
-
-MONO_CURRENCY_FAST_CREATIONS = [
+    """),
+    # For multicurrency invoices, these values will be overwritten
+    # in the post script
     ('account_invoice', 'amount_total_company_signed', 'numeric', """
     UPDATE account_invoice
     SET amount_total_company_signed = amount_total_signed;
@@ -436,13 +435,3 @@ def migrate(env, version):
              'monetary', False, 'account'),
         ]
     )
-    # Fast create other fields, in the simple case of mono currency
-    cr.execute("""
-    SELECT ai.currency_id, rc.currency_id
-    FROM account_invoice ai
-    INNER JOIN res_company rc on ai.company_id = rc.id
-    WHERE ai.currency_id != rc.currency_id;
-    """)
-    multi_currency = cr.fetchone()
-    if not multi_currency:
-        fast_create(env, MONO_CURRENCY_FAST_CREATIONS)


### PR DESCRIPTION
In this particular setup, we have about 3 percent multicurrency invoices. Having only one multicurrency invoice would trigger the expensive ORM method for computing the invoice amount fields (total amount, total amount signed, total amount signed in the company currency). As per this change, prepopulate the SQL methods with non-mc values, then trigger the recompute for multicurrency invoices only.

Previously:

* 00:08:45 recompute of field account.invoice.amount_total_company_signed for all invoices

With this change:

* 00:01:27 Fast creation + population queries
* 00:00:35 Triggering recompute of amount fields for the remaining multicurrency invoices
