### PR TITLE
[ADD] base_status: merge with base

### DIFF
--- a/openerp/addons/base/migrations/8.0.1.3/pre-migration.py
+++ b/openerp/addons/base/migrations/8.0.1.3/pre-migration.py
@@ -37,6 +37,7 @@ def cleanup_modules(cr):
     openupgrade.update_module_names(
         cr, [
             ('account_report_company', 'account'),
+            ('base_status', 'base'),
             # from OCA/product-attribute
             ('product_customer_code', 'product_supplierinfo_for_customer'),
             # from OCA/sale-workflow - included in core


### PR DESCRIPTION
Module `base_status` in v7 declared just a couple of mixins and translations.

It is garbage, basically. Merging into base to remove it automatically and stop raising warnings after migrations, like:

    WARNING prod odoo.modules.graph: module base_status: not installable, skipped

@Tecnativa TT18838
