### PR TITLE
[ADD] rename partner_street_number to base_address_extended

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -22,6 +22,7 @@ renamed_modules = {
     'account_due_list_aging_comments': 'account_due_list_aging_comment',
     # OCA/partner-contact
     'partner_sector': 'partner_industry_secondary',
+    'partner_street_number': 'base_address_extended',
     # OCA/product-attribute
     'product_uom': 'product_uom_extra_data',  # -> OCA/community-data-files
     # OCA/purchase-workflow


### PR DESCRIPTION
I think we can see [`base_address_extended`](https://github.com/OCA/OCB/blob/11.0/addons/base_address_extended/models/base_address_extended.py) as the successor of `partner_street_number` even though the layout looks somewhat different and the implementation is different. The column names are the same though, so this doesn't need an extra migration.