### PR TITLE
[IMP] apriori: Add merged module 'web_widget_color' in 'web'

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -32,7 +32,8 @@ merged_modules = {
     'website_crm_phone_validation': 'website_crm',
     'website_sale_link_tracker': 'website_sale',
     'website_survey': 'survey',
-    # OCA/...
+    # OCA/web
+    'web_widget_color': 'web',
 }
 
 # only used here for openupgrade_records analysis:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Adds 'web_widget_color' as merged in 'web'.
See: https://github.com/odoo/odoo/blob/13.0/addons/web/static/src/js/fields/basic_fields.js#L3283

Current behavior before PR:

Desired behavior after PR is merged:


cc @tecnativa TT19835

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
