### PR TITLE
[FIX] account: skip creating account.payment without method

### DIFF
--- a/addons/account/migrations/10.0.1.1/post-migration.py
+++ b/addons/account/migrations/10.0.1.1/post-migration.py
@@ -148,11 +148,12 @@ def migrate(env, version):
             currency = journal.currency_id or st_line.company_id.currency_id
             payment_methods = journal.inbound_payment_method_ids \
                 if total > 0 else journal.outbound_payment_method_ids
-            communication = st_line._get_communication(
-                payment_methods[0] if payment_methods else False)
+            if not payment_methods:
+                continue
+            communication = st_line._get_communication(payment_methods[0])
             payment = env['account.payment'].create(dict(
                 partner_id=st_line.partner_id.id or False,
-                payment_method_id=payment_methods[:1].id,
+                payment_method_id=payment_methods[0].id,
                 partner_type=(total < 0) and 'supplier' or 'customer',
                 currency_id=currency.id,
                 payment_reference=st_line.move_name,


### PR DESCRIPTION
The field `payment_method_id` is required in the `account.payment` model. For that reason, if there was no payment method found, this code was failing the migration with an error like this:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/openupgradelib/openupgrade.py", line 1734, in wrapped_function
    if use_env2 else cr, version)
  File "/opt/odoo/auto/addons/account/migrations/10.0.1.1/post-migration.py", line 166, in migrate
    'Bank Statement %s') % st_line.date
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 3927, in create
    record = self.browse(self._create(old_vals))
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4022, in _create
    cr.execute(query, tuple(u[2] for u in updates if len(u) > 2))
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 154, in wrapper
    return f(self, *args, **kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 231, in execute
    res = self._obj.execute(query, params)
IntegrityError: null value in column "payment_method_id" violates not-null constraint
```

With this patch, those records will be skipped.

@Tecnativa TT18838
