### PR TITLE
[FIX] website_blog: use sets for attr_rm

### DIFF
--- a/addons/website_blog/migrations/12.0.1.0/post-migration.py
+++ b/addons/website_blog/migrations/12.0.1.0/post-migration.py
@@ -8,16 +8,13 @@ from openupgradelib.openupgrade_tools import convert_html_fragment,\
 _SNIPPET_BLOG_POST_REPLACEMENTS = (
     _r(selector='div[data-template="snippet_latest_posts.'
                 'media_list_template"]',
-       attr_rm={"data-template": "snippet_latest_posts.media_list_template"},
+       attr_rm={"data-template"},
        attr_add={
            "data-template": "website_blog.s_latest_posts_list_template",
        }),
     _r(selector='div[data-template="snippet_latest_posts.'
                 's_latest_posts_big_picture_template"]',
-       attr_rm={
-           "data-template":
-               "snippet_latest_posts.s_latest_posts_big_picture_template"
-       },
+       attr_rm={"data-template"},
        attr_add={
            "data-template":
                "website_blog.s_latest_posts_big_picture_template"}),


### PR DESCRIPTION
According to [the docs][1], `attr_rm` expects a `set`.

It was working as before, because a dict's keys behave like a set, but using a dict could easily confuse the reader.

@Tecnativa TT20968

[1]: https://github.com/OCA/openupgradelib/blob/66c32ef58921592abbe65b7841f96db37fc258c4/openupgradelib/openupgrade_tools.py#L128
