### PR TITLE
[FIX] crm_claim: remove domain and context from action

### DIFF
--- a/addons/crm_claim/migrations/9.0.1.0/post-migration.py
+++ b/addons/crm_claim/migrations/9.0.1.0/post-migration.py
@@ -5,8 +5,9 @@ from psycopg2.extensions import AsIs
 from openupgradelib import openupgrade
 
 
-@openupgrade.migrate()
-def migrate(cr, version):
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    cr = env.cr
     cr.execute(
         "alter table crm_claim_category add column lead_tag_id int")
     cr.execute(
@@ -28,3 +29,11 @@ def migrate(cr, version):
         "WHERE res_id = ccc.lead_tag_id "
         "AND module = 'crm_claim' "
         "AND imd.name LIKE 'categ_claim%%'")
+    # Patch action's outdated attributes
+    try:
+        env.ref("crm_claim.crm_claim_categ_action").write({
+            "domain": False,
+            "context": "{}",
+        })
+    except ValueError:
+        pass  # action is missing, nothing to do


### PR DESCRIPTION
[This action had in v8 set a domain and a context][1] that are no longer applicable and produce an error when navigating to the crm.claim.category menu item.

In v9, that data is not reset automatically, so it has to be reset by hand in the migration script, as I'm doing here.

@Tecnativa TT18838

[1]: https://github.com/odoo/odoo/blob/9e8f70e4849b0eeaca8b5cf51372ecfa23dc561b/addons/crm_claim/crm_claim_view.xml#L16-L17
