### PR TITLE
[FIX] website: remove main website menu action

### DIFF
--- a/addons/website/migrations/9.0.1.0/post-migration.py
+++ b/addons/website/migrations/9.0.1.0/post-migration.py
@@ -15,3 +15,5 @@ def migrate(env, version):
     openupgrade.load_data(
         env.cr, 'website', 'migrations/9.0.1.0/noupdate_changes.xml',
     )
+    # Remove action from main website backend menu
+    env.ref("website.menu_website_configuration").action = False


### PR DESCRIPTION
In Odoo v9, this menu has no action, but in v8 it had one. If we don't empty it, it will go to settings view by default, which is not the intended behavior.

@Tecnativa TT21900
