### PR TITLE
[FIX] install master version of openupgradelib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -40,4 +40,4 @@ vatnumber==1.2
 vobject==0.6.6
 wsgiref==0.1.2
 xlwt==0.7.5
-openupgradelib>=1.3.0
+git+https://github.com/OCA/openupgradelib.git@master


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

Unable to use Openupgrade in V9.0, using installation via ``pip install -r requirements.txt``

**Reasons**

- Openupgrade 9.0 requires the installation of openupgradelib >=1.3.0
- openupgradelib 3.0.0 is not available on pipy (only 2.0.0 [ref](https://pypi.org/project/openupgradelib/))
- This PR https://github.com/OCA/OpenUpgrade/pull/2114 (merged on 16 Dec 2019) introduce in the post migration of ``account_voucher`` the use of the function ``chuncked()`` present in openupgrade for version >=3.0.0

**Fix**

to avoid such problem in the futur, I stick to the head version of the github (like other version https://github.com/OCA/OpenUpgrade/blob/12.0/requirements.txt#L54)


CC : original author / reviewers of #2114 : 
@pedrobaeza, @Yajo, @StefanRijnhart 

Thanks !  


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
