### PR TITLE
[FIX][10.0] install master version of openupgradelib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ vatnumber==1.2
 vobject==0.9.3
 Werkzeug==0.11.11
 wsgiref==0.1.2
-openupgradelib>=1.3.0
+git+https://github.com/OCA/openupgradelib.git@master
 XlsxWriter==0.9.3
 xlwt==1.1.2
 xlrd==1.0.0


### PR DESCRIPTION
Hi all ! 

It's me again ! 

Same as here https://github.com/OCA/OpenUpgrade/pull/2194
to avoid futur problem and have last patches / bugfixes provides by the 3.0.0 version.

CC : @StefanRijnhart, @Yajo, @pedrobaeza  