### PR TITLE
[FIX] Vat declaration table blocks account deletion

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -277,6 +277,11 @@ def move_view_accounts(env):
             AsIs(openupgrade.get_legacy_name('type')),
         )
     )
+    # Truncate this transient model table that refers to view accounts
+    openupgrade.logged_query(
+        env.cr,
+        """TRUNCATE account_vat_declaration,
+            account_journal_account_vat_declaration_rel""")
     # Remove constraint that delete in cascade children accounts
     openupgrade.logged_query(
         env.cr, """


### PR DESCRIPTION
Fixes 
```
2020-02-20 20:51:37,695 29096 ERROR migtest OpenUpgrade: Error after 0:00:04.741297 running 
        DELETE FROM account_account
        WHERE openupgrade_legacy_9_0_type = 'view'
2020-02-20 20:51:37,695 29096 ERROR migtest OpenUpgrade: account: error in migration script account/migrations/9.0.1.1/post-migration.py: NotNullViolation('null value in column "chart_account_id" violates not-null constraint
DETAIL:  Failing row contains (310, 34, null, null, null, null, filter_no, null, 46, 2020-02-07 14:23:10.614304, invoices, f, 2020-02-07 14:23:10.614304, 1418, 34, posted).
CONTEXT:  SQL statement "UPDATE ONLY "public"."account_vat_declaration" SET "chart_account_id" = NULL WHERE $1 OPERATOR(pg_catalog.=) "chart_account_id""\n',)
```