### PR TITLE
[9.0][FIX] set currency_id to account.configurable_chart_template

### DIFF
--- a/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
@@ -145,6 +145,8 @@ account      / account.chart.template   / company_id (many2one)         : NEW re
 
 
 account      / account.chart.template   / currency_id (many2one)        : now required
+# In pre-migration script, set currency to account.configurable_chart_template data
+# as it is marked as noupdate="1"
 
 account      / account.chart.template   / expense_currency_exchange_account_id (many2one): NEW relation: account.account.template
 account      / account.chart.template   / income_currency_exchange_account_id (many2one): NEW relation: account.account.template

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -381,6 +381,23 @@ def fast_create(env, settings):
         env.cr.execute(sql_request)
 
 
+def fix_configurable_chart_template(env):
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE account_chart_template
+        SET currency_id = (
+            select res_id
+            FROM ir_model_data
+            WHERE module='base' AND name='USD'
+        )
+        WHERE id in (
+            SELECT res_id
+            FROM ir_model_data
+            WHERE module='account' AND name='configurable_chart_template'
+        );"""
+    )
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
@@ -435,3 +452,4 @@ def migrate(env, version):
              'monetary', False, 'account'),
         ]
     )
+    fix_configurable_chart_template(env)


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

the Configurable Chart of Account is : 
in 8.0 : 
-> without currency_id
-> defined in ``account`` module
-> noupdate="1"

in 9.0
-> with currency_id (because it is required)
-> defined in ``l10n_fr_coa`` module
-> noupdate="1"

**Current behavior before PR:**
When upgrading from 8.0 to 9.0 it generates the following error : 

``bad query: ALTER TABLE "account_chart_template" ALTER COLUMN "currency_id" SET NOT NULL
ERROR: column "currency_id" contains null values``

**Desired behavior after PR is merged:**

No error.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
