### PR TITLE
[IMP] Performance of new partner stored computed fields

### DIFF
--- a/odoo/addons/base/migrations/10.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/10.0.1.3/pre-migration.py
@@ -141,6 +141,33 @@ def ensure_country_state_id_on_existing_records(cr):
                 rows.append(row)
 
 
+def precreate_partner_fields(cr):
+    """ Emulate stored computed methods in a single SQL query """
+    cr.execute(
+        """ALTER TABLE res_partner
+        ADD COLUMN IF NOT EXISTS commercial_company_name VARCHAR,
+        ADD COLUMN IF NOT EXISTS partner_share BOOLEAN
+        """)
+    openupgrade.logged_query(
+        cr,
+        """UPDATE res_partner rp
+        SET commercial_company_name = crp.name
+        FROM res_partner crp
+        WHERE crp.id = rp.commercial_partner_id
+            AND crp.is_company AND COALESCE(crp.name, '') != ''
+        """)
+    openupgrade.logged_query(
+        cr,
+        """UPDATE res_partner rp
+        SET partner_share = NOT EXISTS (
+            SELECT 1 FROM res_users
+            WHERE partner_id = rp.id AND active)
+        OR EXISTS (
+            SELECT 1 FROM res_users
+            WHERE partner_id = rp.id AND active AND share)
+        """)
+
+
 @openupgrade.migrate(use_env=False)
 def migrate(cr, version):
     openupgrade.update_module_names(
@@ -188,6 +215,7 @@ def migrate(cr, version):
         'res.lang', id
         from res_lang''')
     ensure_country_state_id_on_existing_records(cr)
+    precreate_partner_fields(cr)
     openupgrade.update_module_names(
         cr, apriori.merged_modules, merge_modules=True,
     )


### PR DESCRIPTION
Before:
```
2020-02-21 08:52:53,707 14456 NFO migtest9 odoo.models: Storing computed values of res.partner fields commercial_company_name, partner_share
2020-02-21 08:52:54,773 14456 INFO migtest9 odoo.models: Actual recompute of field res.partner.partner_share for xxx recs.
2020-02-21 08:53:41,388 14456 INFO migtest9 odoo.models: Actual recompute of field res.partner.commercial_company_name for xxx recs.
2020-02-21 08:55:39,752 14456 INFO migtest9 odoo.modules.loading: loading base/res/res.lang.csv
```

After:
```
2020-02-21 11:59:28,620 22857 DEBUG migtest9 OpenUpgrade: xxx rows affected after 0:00:16.470477 running UPDATE res_partner rp
        SET commercial_company_name = crp.name
        FROM res_partner crp
        WHERE crp.id = rp.commercial_partner_id
            AND crp.is_company AND COALESCE(crp.name, '') != ''
        
2020-02-21 11:59:55,292 22857 DEBUG migtest9 OpenUpgrade: xxx rows affected after 0:00:26.670982 running UPDATE res_partner rp
        SET partner_share = NOT EXISTS (
            SELECT 1 FROM res_users
            WHERE partner_id = rp.id AND active)
        OR EXISTS (
            SELECT 1 FROM res_users
            WHERE partner_id = rp.id AND active AND share)
```
Shaving off 2 minutes of each run.