### PR TITLE
[13.0][IMP] sale_timesheet_existing_project is no longer needed in V13

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -32,6 +32,8 @@ merged_modules = {
     'website_crm_phone_validation': 'website_crm',
     'website_sale_link_tracker': 'website_sale',
     'website_survey': 'survey',
+    # OCA/timesheet
+    'sale_timesheet_existing_project': 'sale_timesheet',
     # OCA/web
     'web_widget_color': 'web',
 }


### PR DESCRIPTION
sale_timesheet_existing_project is no longer needed in V13

Cc @Tecnativa TT21549
