### PR TITLE
[12.0] base: Revert "[IMP] OpenUpgrade: don't delete xmlids linked to nothing"

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1728,9 +1728,6 @@ class IrModelData(models.Model):
                                 res_id, model)
                         # /OpenUpgrade
                     else:
-                        # OpenUpgrade: don't delete xmlids. Use database_cleanup instead
-                        continue
-                        # /OpenUpgrade
                         bad_imd_ids.append(id)
         if bad_imd_ids:
             self.browse(bad_imd_ids).unlink()


### PR DESCRIPTION
This reverts commit 93d0f7ea6d1655458f9034ac1328714b29395ac6.

It was long ago, I didn't remember. And that was wrong.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr