### PR TITLE
[11.0] base: Revert "[IMP] OpenUpgrade: don't delete xmlids linked to nothing"

### DIFF
--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -1737,9 +1737,6 @@ class IrModelData(models.Model):
                                 res_id, model)
                         # /OpenUpgrade
                     else:
-                        # OpenUpgrade: don't delete xmlids. Use database_cleanup instead
-                        continue
-                        # /OpenUpgrade
                         bad_imd_ids.append(id)
         if bad_imd_ids:
             self.browse(bad_imd_ids).unlink()


### PR DESCRIPTION
This reverts commit 712198acd672c0a2f9a2d6f0b1685828f01cfd27 moreless.

Same as https://github.com/OCA/OpenUpgrade/pull/2236.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr