### PR TITLE
[FIX] res.currency.rate name duplication

### DIFF
--- a/odoo/addons/base/migrations/11.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/11.0.1.3/pre-migration.py
@@ -92,10 +92,9 @@ def fill_cron_action_server_pre(env):
 
 def set_currency_rate_dates(env):
     """Set currency rate date by creation user timezone."""
-    openupgrade.add_fields(env, [
-        ('name', 'res.currency.rate', 'res_currency_rate', 'date',
-         False, 'base'),
-    ])
+    openupgrade.logged_query(
+        env.cr,
+        "ALTER TABLE res_currency_rate ADD COLUMN name DATE")
     cr = env.cr
     openupgrade.logged_query(
         cr, """


### PR DESCRIPTION
Description of the issue/feature this PR addresses: #2249 

Current behavior before PR: error in migration
```
ERROR: ERRORE: un valore chiave duplicato viola il vincolo univoco "ir_model_data_module_name_uniq_index"
DETAIL: La chiave (module, name)=(base, field_res_currency_rate_name) esiste già.
```

Desired behavior after PR is merged: solved




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
