### PR TITLE
[12.0][FIX] missing sale_order_id

### DIFF
--- a/addons/sale_timesheet/migrations/12.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/sale_timesheet/migrations/12.0.1.0/openupgrade_analysis_work.txt
@@ -13,6 +13,7 @@ sale_timesheet / product.template         / project_template_id (many2one): NEW 
 sale_timesheet / project.project          / billable_type (selection)     : NEW selection_keys: ['employee_rate', 'no', 'task_rate']
 sale_timesheet / project.project          / sale_line_employee_ids (one2many): NEW relation: project.sale.line.employee.map
 sale_timesheet / project.project          / sale_order_id (many2one)      : NEW relation: sale.order
+# DONE: filled sale_order_id from sale_order_line.order_id as there is new sql constraints sale_order_required_if_sale_line
 sale_timesheet / project.sale.line.employee.map / employee_id (many2one)        : NEW relation: hr.employee, required: required
 sale_timesheet / project.sale.line.employee.map / project_id (many2one)         : NEW relation: project.project, required: required, req_default: function
 sale_timesheet / project.sale.line.employee.map / sale_line_id (many2one)       : NEW relation: sale.order.line, required: required

--- a/addons/sale_timesheet/migrations/12.0.1.0/post-migration.py
+++ b/addons/sale_timesheet/migrations/12.0.1.0/post-migration.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Sergio Corato <https://github.com/sergiocorato>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def migrate_project_sale_order(env):
+    openupgrade.logged_query(
+        env.cr, """
+            UPDATE project_project p
+            SET sale_order_id = sol.order_id
+            FROM sale_order_line sol
+            WHERE sol.id = p.sale_line_id
+            AND p.sale_order_id != sol.order_id
+        """)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    migrate_project_sale_order(env)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: missing sale order id on project.project

Current behavior before PR: sql constrains on sale_order_id fail

Desired behavior after PR is merged: sql constrains do not fail




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr