### PR TITLE
[ADD] rename account_bank_statement_import_camt to the OCA version

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -115,6 +115,9 @@ merged_modules = {
     'web_widget_domain_v11': 'web',
     # OCA/website
     'website_seo_redirection': 'website',
+    # OCA/bank-statement-import
+    'account_bank_statement_import_camt':
+    'account_bank_statement_import_camt_oca',
 }
 
 renamed_models = {


### PR DESCRIPTION
I think it's safe to assume that an OpenUpgrade user will want to use the [OCA version](https://github.com/OCA/bank-statement-import/tree/11.0/account_bank_statement_import_camt_oca) of this addon.