### PR TITLE
[FIX] auth_ldap: remove view ref from action

### DIFF
--- a/addons/auth_ldap/migrations/11.0.1.0/post-migration.py
+++ b/addons/auth_ldap/migrations/11.0.1.0/post-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Tecnativa - Jairo Llopis
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Let action direct to the tree view by default, as expected
+    env.ref('auth_ldap.action_ldap_installer').view_id = False


### PR DESCRIPTION
Without this change, the action directs the user to always create a new LDAP server.

After the patch, the user is directed to the tree view of LDAP servers, as expected. There, he can create one if needed.

@Tecnativa TT23686
