### PR TITLE
10.0 fix point of sale bad invoice journal

### DIFF
--- a/addons/point_of_sale/migrations/10.0.1.0.1/openupgrade_analysis_work.txt
+++ b/addons/point_of_sale/migrations/10.0.1.0.1/openupgrade_analysis_work.txt
@@ -13,7 +13,7 @@ point_of_sale / pos.config               / state (selection)             : DEL r
 point_of_sale / pos.config               / default_fiscal_position_id (many2one): NEW relation: account.fiscal.position
 point_of_sale / pos.config               / iface_fullscreen (boolean)    : DEL
 point_of_sale / pos.config               / invoice_journal_id (many2one) : NEW relation: account.journal
-# NOTHING TO DO
+# Done: pre-migration. We set the invoice_journal_id with the journal_id value, because, default function return bad journal in multicompany context. We populate the value only if the column doesn't exist. (that is the case if the OCA module pos_invoice_journal is installed in previous version)
 
 point_of_sale / pos.order.line           / pack_lot_ids (one2many)       : NEW relation: pos.pack.operation.lot
 # NOTHING TO DO

--- a/addons/point_of_sale/migrations/10.0.1.0.1/pre-migration.py
+++ b/addons/point_of_sale/migrations/10.0.1.0.1/pre-migration.py
@@ -1,0 +1,30 @@
+# coding: utf-8
+# Copyright (C) 2020 - Today: GRAP (http://www.grap.coop)
+# @author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+from psycopg2 import ProgrammingError
+
+
+def _populate_invoice_journal_id(env):
+    try:
+        # We try to create the new field.
+        # It will fail if pos_invoice_journal has been installed
+        openupgrade.logged_query(
+            env.cr, """
+            ALTER TABLE pos_config
+            ADD column invoice_journal_id integer;"""
+        )
+    except ProgrammingError:
+        return
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE pos_config
+        SET invoice_journal_id = journal_id;"""
+    )
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    _populate_invoice_journal_id(env)

--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -61,6 +61,8 @@ merged_modules = [
     ('website_sale_b2c', 'sale'),  # used groups are in sale
     # OCA/manufacture
     ('mrp_production_unreserve', 'mrp'),
+    # OCA/pos
+    ('pos_invoice_journal', 'point_of_sale'),
     # OCA/purchase-workflow
     ('purchase_fiscal_position_update', 'purchase'),
     # OCA/sale-workflow


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The V10 introduce on ``pos.config`` a new journal field ``invoice_journal_id``

**Current behavior before PR:**
The default function ``_default_invoice_journal`` is used to populate this new column.  ([see](https://github.com/OCA/OpenUpgrade/blob/10.0/addons/point_of_sale/models/pos_config.py#L38))
the journal ID will be wrong in a multi company context.

**Fix**
Added a pre-migration script to add the field, if not exist. (the field can exist if the module V8 [pos_invoice_journal](https://github.com/OCA/pos/tree/8.0/pos_invoice_journal) is installed)

CC : original authors : @JordiBForgeFlow, @MiquelRForgeFlow 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
