### PR TITLE
[IMP] Improve performance on sql

### DIFF
--- a/addons/stock_account/migrations/11.0.1.1/post-migration.py
+++ b/addons/stock_account/migrations/11.0.1.1/post-migration.py
@@ -116,13 +116,11 @@ def update_stock_move_value_fifo(env):
                 SELECT sum(sq.quantity*sq.cost) as remaining_value,
                     sum(sq.quantity) as remaining_qty
                 FROM stock_quant_move_rel sqsm
-                INNER JOIN stock_move sm
-                ON sqsm.move_id = sm.id
                 INNER JOIN stock_quant sq
                 ON sqsm.quant_id = sq.id
                 INNER JOIN stock_location sl
                 ON sq.location_id = sl.id
-                WHERE sm.id = %s
+                WHERE sqsm.move_id = %s
                     AND (sl.company_id IS NOT NULL
                         OR sl.usage = 'internal')
                 ) AS q1
@@ -135,13 +133,9 @@ def update_stock_move_value_fifo(env):
             FROM (
                 SELECT sum(sq.quantity*sq.cost) as value
                 FROM stock_quant_move_rel sqsm
-                INNER JOIN stock_move sm
-                ON sqsm.move_id = sm.id
                 INNER JOIN stock_quant sq
                 ON sqsm.quant_id = sq.id
-                INNER JOIN stock_location sl
-                ON sq.location_id = sl.id
-                WHERE sm.id = %s
+                WHERE sqsm.move_id = %s
                 ) AS q1
             WHERE to_update.id = %s
         """, (move, move))
@@ -172,13 +166,9 @@ def update_stock_move_value_fifo(env):
             FROM (
                 SELECT sum(sq.quantity*sq.cost) as value
                 FROM stock_quant_move_rel sqsm
-                INNER JOIN stock_move sm
-                ON sqsm.move_id = sm.id
                 INNER JOIN stock_quant sq
                 ON sqsm.quant_id = sq.id
-                INNER JOIN stock_location sl
-                ON sq.location_id = sl.id
-                WHERE sm.id = %s
+                WHERE sqsm.move_id = %s
                 ) AS q1
             WHERE to_update.id = %s
         """, (move, move))


### PR DESCRIPTION
Removes unnecessary joins to speed up execution.

In our case we're migrating a heavy database and this particular migration script has been running for more than 28 hours, still hasn't finished..

Any perf improvement helps..

**Before**
```
mig-11.0=# EXPLAIN ANALYZE
                SELECT sum(sq.quantity*sq.cost) as value
                FROM stock_quant_move_rel sqsm
                INNER JOIN stock_move sm
                ON sqsm.move_id = sm.id
                INNER JOIN stock_quant sq
                ON sqsm.quant_id = sq.id
                INNER JOIN stock_location sl
                ON sq.location_id = sl.id
                WHERE sm.id = 433730
;
                                                                      QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=41.24..41.25 rows=1 width=8) (actual time=0.150..0.151 rows=1 loops=1)
   ->  Hash Join  (cost=16.58..41.18 rows=11 width=16) (actual time=0.144..0.144 rows=0 loops=1)
         Hash Cond: (sq.location_id = sl.id)
         ->  Nested Loop  (cost=15.19..39.77 rows=11 width=20) (actual time=0.039..0.039 rows=0 loops=1)
               ->  Index Only Scan using stock_move_pkey on stock_move sm  (cost=0.14..8.16 rows=1 width=4) (actual time=0.037..0.037 rows=0 loops=1)
                     Index Cond: (id = 433730)
                     Heap Fetches: 0
               ->  Hash Join  (cost=15.05..31.50 rows=11 width=24) (never executed)
                     Hash Cond: (sq.id = sqsm.quant_id)
                     ->  Seq Scan on stock_quant sq  (cost=0.00..15.10 rows=510 width=24) (never executed)
                     ->  Hash  (cost=14.91..14.91 rows=11 width=8) (never executed)
                           ->  Bitmap Heap Scan on stock_quant_move_rel sqsm  (cost=4.24..14.91 rows=11 width=8) (never executed)
                                 Recheck Cond: (move_id = 433730)
                                 ->  Bitmap Index Scan on stock_quant_move_rel_move_id_idx  (cost=0.00..4.24 rows=11 width=0) (never executed)
                                       Index Cond: (move_id = 433730)
         ->  Hash  (cost=1.17..1.17 rows=17 width=4) (actual time=0.062..0.062 rows=17 loops=1)
               Buckets: 1024  Batches: 1  Memory Usage: 9kB
               ->  Seq Scan on stock_location sl  (cost=0.00..1.17 rows=17 width=4) (actual time=0.019..0.031 rows=17 loops=1)
 Planning time: 1.576 ms
 Execution time: 0.386 ms
(20 rows)
```

vs 

**After**
```
mig-11.0=# EXPLAIN ANALYZE
                SELECT sum(sq.quantity*sq.cost) as value
                FROM stock_quant_move_rel sqsm
                INNER JOIN stock_quant sq
                ON sqsm.quant_id = sq.id
                WHERE sqsm.move_id = 433730
;
                                                            QUERY PLAN                                                             
-----------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=31.55..31.56 rows=1 width=8) (actual time=0.012..0.013 rows=1 loops=1)
   ->  Hash Join  (cost=15.05..31.50 rows=11 width=16) (actual time=0.007..0.007 rows=0 loops=1)
         Hash Cond: (sq.id = sqsm.quant_id)
         ->  Seq Scan on stock_quant sq  (cost=0.00..15.10 rows=510 width=20) (actual time=0.005..0.006 rows=0 loops=1)
         ->  Hash  (cost=14.91..14.91 rows=11 width=4) (never executed)
               ->  Bitmap Heap Scan on stock_quant_move_rel sqsm  (cost=4.24..14.91 rows=11 width=4) (never executed)
                     Recheck Cond: (move_id = 433730)
                     ->  Bitmap Index Scan on stock_quant_move_rel_move_id_idx  (cost=0.00..4.24 rows=11 width=0) (never executed)
                           Index Cond: (move_id = 433730)
 Planning time: 0.637 ms
 Execution time: 0.136 ms
(11 rows)
```



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
