### PR TITLE
[12.0][IMP] populate account.fiscal.year with account.fiscalyear data 

### DIFF
--- a/addons/account/migrations/12.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/12.0.1.1/openupgrade_analysis_work.txt
@@ -32,7 +32,8 @@ account      / account.fiscal.year      / company_id (many2one)         : NEW re
 account      / account.fiscal.year      / date_from (date)              : NEW required: required
 account      / account.fiscal.year      / date_to (date)                : NEW required: required
 account      / account.fiscal.year      / name (char)                   : NEW required: required
-# NOTHING TO DO (new model)
+# Done: post-migration: populate with old account.fiscalyear model
+# if we come from a 8.0 database.
 
 account      / account.group            / parent_left (integer)         : DEL
 account      / account.group            / parent_path (char)            : NEW


### PR DESCRIPTION
- if we come from a 8.0 database, the fiscal years are present in the table ``account_fiscalyear``. (model ``account.fiscalyear``).
- V12.0 reintroduce a similar model ``account.fiscal.year`` in the table ``account_fiscal_year``.

So, this PR improve the V12 migration script, populating new table with the old datas, if the old table is present.

CC : @StefanRijnhart, @pedrobaeza, @MiquelRForgeFlow

Thanks for your review ! 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
