### PR TITLE
[9.0][FIX] populate account.tax 'tax_group_id' with old 'tax_code_id' field

### DIFF
--- a/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt
@@ -468,6 +468,7 @@ account      / account.tax              / tag_ids (many2many)           : NEW re
 
 account      / account.tax              / tax_code_id (many2one)        : DEL relation: account.tax.code
 account      / account.tax              / tax_group_id (many2one)       : NEW relation: account.tax.group, required: required, req_default: function
+# Done in pre-migration. copying tax_code_id into tax_group_id.
 account      / account.tax              / tax_sign (float)              : DEL 
 account      / account.tax              / type (selection)              : was renamed to amount_type [nothing to to]
 

--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -101,6 +101,7 @@ column_copies = {
     'account_tax': [
         ('type_tax_use', None, None),
         ('type', None, None),
+        ('tax_code_id', 'tax_group_id', None),
     ],
     'account_tax_template': [
         ('type_tax_use', None, None),


### PR DESCRIPTION
**Rational**

- between 8.0 and 9.0, the ``account.tax.code`` model is removed and replaced by an ``account.tax.group`` model.
- The table is currently renamed in the pre-migration script [here ](https://github.com/OCA/OpenUpgrade/blob/9.0/addons/account/migrations/9.0.1.1/pre-migration.py#L116)
- in the mean time, the relation of ``account.tax`` (``tax_code_id``) and ``account.tax.code`` is not preserved. [see in analysis file.](https://github.com/OCA/OpenUpgrade/blob/9.0/addons/account/migrations/9.0.1.1/openupgrade_analysis_work.txt#L469)
- so for the time being, the new field ``tax_group_id`` is populated with this [dummy](https://github.com/OCA/OpenUpgrade/blob/9.0/addons/account/models/account.py#L524) function. 

**Current behaviour**
After the migration, all the taxes have the same ``tax_group_id``. That is wrong, specially in a multi-company and multi CoA context.

**After the PR**
- ``tax_group_id`` has the value of the old ``tax_code_id`` value.

CC : people involved in this script : 
@JordiBForgeFlow, @StefanRijnhart , @pedrobaeza 

thanks for your review ! 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
