### PR TITLE
[FIX] mail: remove admin from mail.alias

### DIFF
--- a/addons/mail/migrations/12.0.1.0/post-migration.py
+++ b/addons/mail/migrations/12.0.1.0/post-migration.py
@@ -31,9 +31,25 @@ def fill_mail_notification_mail_id(cr):
     )
 
 
+def remove_admin_alias_owner(cr):
+    """Admin's aliases would fail.
+
+    Admin is going to be disabled later in base end-migration.
+    When that happens, any aliases belonging to him would fail.
+
+    By removing the alias owner, we let Odoo decide the default, which will
+    be __system__ usually, the new admin replacement.
+    """
+    openupgrade.logged_query(
+        cr,
+        "UPDATE mail_alias SET alias_user_id = NULL WHERE alias_user_id = 1",
+    )
+
+
 @openupgrade.migrate(use_env=False)
 def migrate(cr, version):
     fill_mail_blacklist_res_partner(cr)
     fill_mail_notification_mail_id(cr)
+    remove_admin_alias_owner(cr)
     openupgrade.load_data(
         cr, 'mail', 'migrations/12.0.1.0/noupdate_changes.xml')


### PR DESCRIPTION
~~Since Administrator is not going to be used anymore, it is best to archive that partner, just like it is done with that user. If not doing so, accessing the user will display a warning about this.~~

When a mail.alias record belongs to admin, it will try to send mails in name of a user that most likely has wrong data in it, and is actually garbage. That can produce a problem where aliases create records but don't notify followers, or even worse, that same problem in loop (depending possibly on if you use IMAP4 or POP3 to fetch mails).

@Tecnativa TT24347
