### PR TITLE
[FIX] product: wrong filled product_variant_combination table

### DIFF
--- a/addons/product/migrations/13.0.1.2/post-migration.py
+++ b/addons/product/migrations/13.0.1.2/post-migration.py
@@ -36,8 +36,11 @@ def fill_product_variant_combination_table(env):
         (product_product_id, product_template_attribute_value_id)
         SELECT pavppr.product_product_id, ptav.id
         FROM product_attribute_value_product_product_rel pavppr
-        JOIN product_template_attribute_value ptav ON
-            ptav.product_attribute_value_id = pavppr.product_attribute_value_id
+        JOIN product_product pp
+            ON pp.id = pavppr.product_product_id
+        JOIN product_template_attribute_value ptav
+            ON ptav.product_attribute_value_id = pavppr.product_attribute_value_id
+                AND pp.product_tmpl_id = ptav.product_tmpl_id
         """,
     )
 


### PR DESCRIPTION
Fill product_variant_combination table filtered by product template

Current behavior:
![image](https://user-images.githubusercontent.com/33932458/85409264-46f96180-b56e-11ea-96b6-0302b1eb7db0.png)


With my patch:
![image](https://user-images.githubusercontent.com/33932458/85409345-5d9fb880-b56e-11ea-9b23-6ff143ad7748.png)

Closed: #2354

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
