### PR TITLE
[11.0][IMP] mrp: perf issue in consume sml

### DIFF
--- a/addons/mrp/migrations/11.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/11.0.2.0/post-migration.py
@@ -197,12 +197,6 @@ def fill_stock_move_line_consume_rel(cr):
             ON sml1.move_id = sqmr1.move_id
         INNER JOIN stock_move_line sml2
             ON sml2.move_id = sqmr2.move_id
-        WHERE NOT EXISTS (
-            SELECT *
-            FROM stock_move_line_consume_rel
-            WHERE consume_line_id = sml1.id
-                AND produce_line_id = sml2.id
-        )
         """
     )
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Insertion is really really long (more then one day), I have more then 1 millions of mrp.production order

Current behavior before PR:

The table stock_move_line_consume_rel is empty (new table), but we do a check to not insert the record if already exist.
The issue is before inserting a record a check is done, so inserting record is really long for postgresql (version 10)


Desired behavior after PR is merged:

Remove this check as the table is empty (new table on V11)
And the distinct will already remove duplicated entry

@MiquelRForgeFlow can you give your feedback please.

I am re-running the migration so I will have stats soon

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
