### PR TITLE
[11.0][IMP] base: rename 'mass_mailing_event'

### DIFF
--- a/odoo/addons/base/migrations/11.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/11.0.1.3/pre-migration.py
@@ -124,6 +124,19 @@ def set_currency_rate_dates(env):
     )
 
 
+def rename_mass_mailing_event(env):
+    env.cr.execute("""
+        SELECT id
+        FROM ir_module_module
+        WHERE name = 'mass_mailing_event' AND state <> 'uninstalled'""")
+    row = env.cr.fetchone()
+    if row:
+        openupgrade.update_module_names(
+            env.cr,
+            [("mass_mailing_event", "mass_mailing_event_registration_exclude")],
+            merge_modules=True)
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.remove_tables_fks(env.cr, _obsolete_tables)
@@ -168,3 +181,7 @@ def migrate(env, version):
     openupgrade.set_xml_ids_noupdate_value(
         env, 'base', ['lang_km'], True)
     set_currency_rate_dates(env)
+
+    # Rename 'mass_mailing_event' module to not collide with the new
+    # core module with the same name.
+    rename_mass_mailing_event(env)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Odoo 11.0 adds a new module called 'mass_mailing_event' that collide with the 'mass_mailing_event' from OCA.

Current behavior before PR:
Module naming collision

Desired behavior after PR is merged:
No collision


cc @tecnativa TT24632

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
