### PR TITLE
[10.0][FIX] hr_timesheet - improve creation of missing projects for timesheets

### DIFF
--- a/addons/hr_timesheet/migrations/10.0.1.0/pre-migration.py
+++ b/addons/hr_timesheet/migrations/10.0.1.0/pre-migration.py
@@ -7,6 +7,9 @@ from openupgradelib import openupgrade
 COLUMN_RENAMES = {
     'account_analytic_account': [
         ('use_timesheets', None),
+    ],
+    'account_analytic_line': [
+        ('is_timesheet', None),
     ]
 }
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses: the logic for creation of new projects during upgrade is based on the deprecated field ` use_timesheets ` which is not updated anymore. so the analytic account does not appear as "timesheet"

Current behavior before PR: orphaned accounts do not get new projects.

Desired behavior after PR is merged:

after update, new projects are created for each account linked to a timesheet (activity)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
