### PR TITLE
[11.0][IMP] stock: Don't break on quant merge errors

### DIFF
--- a/addons/stock/migrations/11.0.1.1/end-migration.py
+++ b/addons/stock/migrations/11.0.1.1/end-migration.py
@@ -1,7 +1,8 @@
-# -*- coding: utf-8 -*-
 # Copyright 2018 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
 
+from odoo.exceptions import ValidationError
 from openupgradelib import openupgrade, openupgrade_merge_records
 
 QUANT_MERGE_OPS = {
@@ -12,6 +13,7 @@ QUANT_MERGE_OPS = {
 
 
 def merge_quants(env):
+    logger = logging.getLogger('openupgrade.stock.end_migration')
     group_list = [
         'product_id', 'package_id', 'lot_id', 'location_id', 'owner_id',
     ]
@@ -21,9 +23,23 @@ def merge_quants(env):
         quants = StockQuant.search(group['__domain'])
         if len(quants) == 1:
             continue
-        openupgrade_merge_records.merge_records(
-            env, 'stock.quant', quants[1:].ids, quants[0].id, QUANT_MERGE_OPS,
-        )
+        try:
+            with env.cr.savepoint():
+                openupgrade_merge_records.merge_records(
+                    env, 'stock.quant', quants[1:].ids, quants[0].id, QUANT_MERGE_OPS,
+                )
+        except ValidationError as error:
+            logger.error(
+                'Cannot merge quants %s for '
+                'product %s, package %s, lot %s, location %s, owner %s: %s',
+                quants.ids,
+                quants[0].product_id.default_code or quants[0].product_id.name,
+                quants[0].package_id.name or '-',
+                quants[0].lot_id.name or '-',
+                quants[0].location_id.complete_name,
+                quants[0].owner_id.name or '-',
+                error,
+            )
 
 
 @openupgrade.migrate(use_env=True)


### PR DESCRIPTION
We have stock warehousing with some legacy lots for 'serial' products that were used more than once. With this patch, the migration does not halt on that.
