### PR TITLE
[11.0][FIX] website: set website.page url by view key, view xmlid

### DIFF
--- a/addons/website/migrations/11.0.1.0/post-migration.py
+++ b/addons/website/migrations/11.0.1.0/post-migration.py
@@ -16,7 +16,13 @@ def fill_website_pages(env):
         INSERT INTO website_page
             (url, view_id, website_indexed, website_published, create_uid,
              create_date, write_uid, write_date)
-        SELECT COALESCE(wm.url, '/page/' || iuv.name), iuv.id, TRUE, TRUE,
+        SELECT COALESCE(
+                wm.url,
+                '/page/' || COALESCE(
+                    substring(iuv.key from 9), imd.name, iuv.name
+                )
+            ),
+            iuv.id, TRUE, TRUE,
             iuv.create_uid,
             iuv.create_date, iuv.write_uid, iuv.write_date
         FROM
@@ -28,6 +34,10 @@ def fill_website_pages(env):
             AND (wm.website_id = iuv.website_id
             OR wm.website_id IS NULL
             OR iuv.website_id IS NULL)
+        LEFT JOIN
+            ir_model_data imd ON imd.module='website'
+            AND imd.model='ir.ui.view'
+            AND imd.res_id=iuv.id
         WHERE
             wp.id IS NULL
             AND iuv.page = TRUE""",


### PR DESCRIPTION
I wonder how this could have worked before? In v10, the page controller [requests a template](https://github.com/OCA/OCB/blob/10.0/addons/website/controllers/main.py#L121) which then [requests a view](https://github.com/OCA/OCB/blob/10.0/addons/website/models/website.py#L425) which [searches for the key](https://github.com/OCA/OCB/blob/10.0/addons/website/models/ir_ui_view.py#L81) and [falls back to the xmlid](https://github.com/OCA/OCB/blob/10.0/odoo/addons/base/ir/ir_ui_view.py#L959).

@karan-dreambits can you explain in which cases the linking by name works? I'm under the impression it will only ever work if the name happens to be the same as the key, in which case we can delete this part of the query.