### PR TITLE
[FIX] utm: avoid issue '"utm_stage" does not exist'

### DIFF
--- a/addons/utm/migrations/13.0.1.0/pre-migration.py
+++ b/addons/utm/migrations/13.0.1.0/pre-migration.py
@@ -1,6 +1,7 @@
 # Copyright 2020 ForgeFlow <http://www.forgeflow.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+from odoo.tools import create_model_table
 
 _model_renames = [
     ('mail.mass_mailing.stage', 'utm.stage'),
@@ -63,3 +64,5 @@ def migrate(env, version):
             ],
             False,
         )
+    else:
+        create_model_table(cr, "utm_stage", "Campaign Stage")


### PR DESCRIPTION
Only affected databases without mass_mailing, because those cannot obtain "utm_stage" table from "mail_mass_mailing_stage".

**Description of the issue/feature this PR addresses:**

_utm.stage_ model is created after _utm.campaign_ model, but stage_id field of _utm.campaign_ relates to _utm.stage_. When installing the module, it doesn't break. But for unkown reason, when migrating, it breaks.

Thus, as an easy solution, we define the _utm.stage_ model before _utm.campaign_ model.

Another solution could be create the utm_stage table manually in pre-migration.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr