### PR TITLE
[13.0][UPT]l10n_es

### DIFF
--- a/addons/l10n_es/migrations/13.0.4.0/pre-migration.py
+++ b/addons/l10n_es/migrations/13.0.4.0/pre-migration.py
@@ -1,0 +1,28 @@
+# Copyright 2020 ForgeFlow <http://www.forgeflow.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+def set_account_move_number_to_invoice_number(env):
+    """l10n_es_account_invoice_sequence introduced different numbering between
+    invoices and account moves.
+    As long as we have only account_moves in version 13 we have to choose one.
+    In case that module is installed we trust the sequence of the invoice
+    """
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE account_move am0 SET name = ai.invoice_number
+        FROM account_invoice ai INNER JOIN account_move am
+        ON ai.move_id = am.id
+        WHERE ai.invoice_number is not null
+        AND am.id = am0.id
+        """
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if openupgrade.column_exists(
+            env.cr, "account_invoice", "invoice_number"):
+        set_account_move_number_to_invoice_number(env)

--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -47,6 +47,8 @@ merged_modules = {
     # OCA/website
     'website_canonical_url': 'website',
     'website_logo': 'website',
+    # OCA/l10n-spain
+    'l10n_es_account_invoice_sequence': 'l10n_es',
 }
 
 # only used here for openupgrade_records analysis:


### PR DESCRIPTION
l10n_es_account_invoice_sequence introduced different numbering between invoices and account moves using a specific sequence selected in the journal. In v13 invoice number is lost. It is best to keep the sequence of the invoice in this case. We should trust that sequence, as long as all localization reports used that sequence.