### PR TITLE
[UPD] mrp: adding migration of `product_uom_id` field in `mrp_workorder`

### DIFF
--- a/addons/mrp_account/migrations/13.0.1.0/post-migration.py
+++ b/addons/mrp_account/migrations/13.0.1.0/post-migration.py
@@ -1,0 +1,21 @@
+# Copyright 2020 Andrii Skrypka
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def set_mrp_workorder_product_uom_id(cr):
+    openupgrade.logged_query(
+        cr, """
+        UPDATE mrp_workorder w
+        SET    product_uom_id = pt.uom_id
+        FROM   product_product pp
+        JOIN   product_template pt ON pp.product_tmpl_id = pt.id
+        WHERE  w.product_id = pp.id
+        AND    w.product_uom_id IS NULL;
+        """
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    set_mrp_workorder_product_uom_id(env.cr)


### PR DESCRIPTION
Without this update, when button_start a workorder, odoo returns "missing UOM" validation error

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
