### PR TITLE
[10.0] [FIX] Regression: im_livechat: records in pre migration might not exist

### DIFF
--- a/addons/im_livechat/migrations/10.0.1.0/pre-migration.py
+++ b/addons/im_livechat/migrations/10.0.1.0/pre-migration.py
@@ -11,5 +11,4 @@ xml_ids = [
 
 @openupgrade.migrate()
 def migrate(env, version):
-    for xml_id in xml_ids:
-        env.ref(xml_id).unlink()
+    openupgrade.delete_records_safely_by_xml_id(env, xml_ids)


### PR DESCRIPTION
Records might not exist, especially if im_livechat was not installed
before but was merged into im_odoo_support.

Regression of https://github.com/OCA/openupgradelib/commit/3945526d1

Fixes `ValueError: External ID not found in the system: im_livechat.ir_action_client_open_livechat_menu`
