### PR TITLE
[DOC] Tip about pip version (no more import error message)

### DIFF
--- a/odoo/openupgrade/doc/source/migration_details.rst
+++ b/odoo/openupgrade/doc/source/migration_details.rst
@@ -46,6 +46,11 @@ General Tips
 
     $ pip install git+git://github.com/OCA/openupgradelib.git
 
+* You must use the appropriate *pip* version, it is specific to the version of Python that will run OpenUpgrade (for a detailed explanation see https://realpython.com/lessons/why-cant-python-find-my-modules/). Otherwise you will have import error like :
+
+   $ ImportError: No module named <package_name>
+ 
+
 Configuration options
 +++++++++++++++++++++
 

--- a/odoo/openupgrade/doc/source/migration_details.rst
+++ b/odoo/openupgrade/doc/source/migration_details.rst
@@ -44,11 +44,7 @@ General Tips
 
 * When installing the openupgradelib make sure you check out the latest version from github to get the latest updates and fixes::
 
-    $ pip install git+git://github.com/OCA/openupgradelib.git
-
-* You must use the appropriate *pip* version, it is specific to the version of Python that will run OpenUpgrade (for a detailed explanation see https://realpython.com/lessons/why-cant-python-find-my-modules/). Otherwise you will have import error like :
-
-   $ ImportError: No module named <package_name>
+    $ pip/pip3 install git+git://github.com/OCA/openupgradelib.git
  
 
 Configuration options


### PR DESCRIPTION
Explain why there OpenUpgrade can't find libopenupgrade : install libopenupgrade with the right pip version.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
