### PR TITLE
[IMP][10.0] obsolete V9 product_uos module merged in sale in V10.0

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -41,6 +41,7 @@ merged_modules = [
     ('account_full_reconcile', 'account'),
     ('mail_tip', 'mail'),
     ('mrp_operations', 'mrp'),
+    ('product_uos', 'sale'),
     ('project_timesheet', 'hr_timesheet'),
     ('sale_service', 'sale_timesheet'),
     ('share', 'base'),


### PR DESCRIPTION
Closes : 2330

- product_uos is introduced in V9 and depends on sale.
- openupgrade 9.0 installed this module. ([ref](https://github.com/OCA/OpenUpgrade/blob/9.0/addons/product/migrations/9.0.1.2/pre-migration.py#L104))
- product_uos disappeared in V10. 

So a migration from 8.0 to 10.0 let a database with product_uos installed.

CC : @pedrobaeza 

Thanks.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
