### PR TITLE
[13.0][FIX] Delete old module categories

### DIFF
--- a/odoo/addons/base/migrations/13.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/13.0.1.3/pre-migration.py
@@ -716,7 +716,8 @@ def rename_ir_module_category(env):
             if new_row:
                 openupgrade_merge_records.merge_records(
                     env, "ir.module.category", [old_row[0]], new_row[0],
-                    method="sql", model_table="ir_module_category")
+                    method="sql", model_table="ir_module_category",
+                    delete=True)
             else:
                 openupgrade.rename_xmlids(env.cr, [(old_xmlid, new_xmlid)])
 


### PR DESCRIPTION
Minor fix to avoid issue with modules still referencing obsolete categories.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr