### PR TITLE
[ADD] base_address_extended: post_init_hook to parse street name correctly

### DIFF
--- a/addons/base_address_extended/__init__.py
+++ b/addons/base_address_extended/__init__.py
@@ -2,3 +2,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import models
+from odoo import api, SUPERUSER_ID
+
+
+def _post_init_hook(cr, registry):
+    """Recalculate street fields now the countries have their street format set"""
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    partners = env['res.partner'].with_context(active_test=False).search([])
+    for field in ['street_name', 'street_number', 'street_number2']:
+        partners._recompute_todo(partners._fields[field])
+    partners.recompute()

--- a/addons/base_address_extended/__manifest__.py
+++ b/addons/base_address_extended/__manifest__.py
@@ -20,4 +20,5 @@ with the street name, the house number, and room number.
         'data/base_address_extended_data.xml',
     ],
     'depends': ['base'],
+    'post_init_hook': '_post_init_hook',
 }


### PR DESCRIPTION
base_address_extended [autoinstalls](https://github.com/OCA/OCB/blob/11.0/addons/l10n_nl/__manifest__.py#L16) for users of ie l10n_nl, but as country data is loaded only after the fields are computed, street names are parsed wrongly.

I think we also should PR much more countries because the [existing configuration](https://github.com/OCA/OCB/blob/14.0/addons/base_address_extended/data/base_address_extended_data.xml) leaves nearly all countries to the [default](https://github.com/OCA/OCB/blob/14.0/addons/base_address_extended/models/res_partner.py#L69), which is wrong for most countries I'm aware of.