### PR TITLE
[11.0][UPD] Fix cost_method from default values

### DIFF
--- a/addons/stock_account/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock_account/migrations/11.0.1.1/pre-migration.py
@@ -15,7 +15,8 @@ def update_fifo_cost_method(env):
         SET json_value = '"fifo"'
         WHERE field_id in (SELECT id FROM ir_model_fields 
                          WHERE model = 'product.template' 
-                             AND name = 'cost_method')
+                             AND name = 'cost_method'
+                             AND json_value = '"real"')
         """,
     )
     openupgrade.logged_query(

--- a/addons/stock_account/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock_account/migrations/11.0.1.1/pre-migration.py
@@ -10,7 +10,7 @@ def update_fifo_cost_method(env):
     is 'average'. Values mapped according this.
     """
     openupgrade.logged_query(
-    env.cr, """
+        env.cr, """
         UPDATE ir_default
         SET json_value = '"fifo"'
         WHERE field_id in (SELECT id FROM ir_model_fields

--- a/addons/stock_account/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock_account/migrations/11.0.1.1/pre-migration.py
@@ -11,6 +11,15 @@ def update_fifo_cost_method(env):
     """
     openupgrade.logged_query(
         env.cr, """
+        UPDATE ir_default
+        SET json_value = '"fifo"'
+        WHERE field_id= (SELECT id FROM ir_model_fields 
+                         WHERE model = 'product.template' 
+                             AND name = 'cost_method')
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr, """
         UPDATE ir_property
         SET value_text = 'fifo'
         WHERE name='property_cost_method'

--- a/addons/stock_account/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock_account/migrations/11.0.1.1/pre-migration.py
@@ -13,7 +13,7 @@ def update_fifo_cost_method(env):
         env.cr, """
         UPDATE ir_default
         SET json_value = '"fifo"'
-        WHERE field_id= (SELECT id FROM ir_model_fields 
+        WHERE field_id in (SELECT id FROM ir_model_fields 
                          WHERE model = 'product.template' 
                              AND name = 'cost_method')
         """,

--- a/addons/stock_account/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock_account/migrations/11.0.1.1/pre-migration.py
@@ -10,14 +10,13 @@ def update_fifo_cost_method(env):
     is 'average'. Values mapped according this.
     """
     openupgrade.logged_query(
-        env.cr, """
+    env.cr, """
         UPDATE ir_default
         SET json_value = '"fifo"'
-        WHERE field_id in (SELECT id FROM ir_model_fields 
-                         WHERE model = 'product.template' 
-                             AND name = 'cost_method'
-                             AND json_value = '"real"')
-        """,
+        WHERE field_id in (SELECT id FROM ir_model_fields
+                        WHERE model = 'product.template'
+                            AND name = 'cost_method'
+                            AND json_value = '"real"')""",
     )
     openupgrade.logged_query(
         env.cr, """


### PR DESCRIPTION
Fix cost_method from default values

Description of the issue/feature this PR addresses: Replacing "real" with "fifo" in the ir_default table

Current behavior before PR: Error while creating new product because "real" value returns to "fifo"

Desired behavior after PR is merged: It expects the "real" value to change with "fifo" and while the new product is created, the cost_method is waiting to arrive fifo.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
