### PR TITLE
[13.0][IMP] website_logo: merged in website

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -46,6 +46,7 @@ merged_modules = {
     'web_widget_many2many_tags_multi_selection': 'web',
     # OCA/website
     'website_canonical_url': 'website',
+    'website_logo': 'website',
 }
 
 # only used here for openupgrade_records analysis:


### PR DESCRIPTION
cc @Tecnativa TT25961

The website_logo module of OCA/website is no longer necessary, its functionalities are already included in the odoo website module in V13.0.