### PR TITLE
[FIX] website: migrate logo

### DIFF
--- a/addons/website/migrations/13.0.1.0/post-migration.py
+++ b/addons/website/migrations/13.0.1.0/post-migration.py
@@ -1,0 +1,14 @@
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+from openupgradelib import openupgrade
+
+
+def _fill_website_logo(env):
+    """V13 introduces website.logo, where v12 used res.company.logo."""
+    websites = env["website"].search([])
+    for website in websites:
+        website.logo = website.company_id.logo
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    _fill_website_logo(env)


### PR DESCRIPTION
In v12, websites used the company logo: https://github.com/OCA/OpenUpgrade/blob/c593c3127cc08e3c4e333be4020f6041fc185ba7/addons/website/views/website_templates.xml#L302

In v13, websites have their own logo: https://github.com/OCA/OpenUpgrade/blob/1acf10ec2cf2839bd3ff3fa066142143a93ca86b/addons/website/views/website_templates.xml#L335

Without this patch, websites get migrated without logo.

@Tecnativa TT23136