### PR TITLE
[FIX] website_blog: respect name and subtitle

### DIFF
--- a/addons/website_blog/migrations/13.0.1.0/noupdate_changes.xml
+++ b/addons/website_blog/migrations/13.0.1.0/noupdate_changes.xml
@@ -1,8 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
   <record id="blog_blog_1" model="blog.blog">
-    <field name="name">Our blog</field>
-    <field name="subtitle">We are a team of passionate people whose goal is to improve everyone's life.</field>
     <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_5.jpg')", "resize_class": "o_record_has_cover cover_mid", "background-color": "oe_black", "opacity": "0.4"}</field>
   </record>
 </odoo>


### PR DESCRIPTION
This shouldn't be included as a noupdate change. It should be respected as it was, instead.

This requires merging https://github.com/OCA/OpenUpgrade/pull/2374 to be actually useful.

@Tecnativa TT23136