### PR TITLE
[FIX] point_of_sale : populate tax_ids if pos_pricelist was installed

### DIFF
--- a/addons/point_of_sale/migrations/9.0.1.0.1/pre-migration.py
+++ b/addons/point_of_sale/migrations/9.0.1.0.1/pre-migration.py
@@ -33,6 +33,27 @@ column_renames = {
 }
 
 
+def populate_pos_order_tax_ids(cr):
+    if not openupgrade.is_module_installed(cr, "pos_pricelist"):
+        return
+
+    openupgrade.logged_query(
+        cr,
+        "ALTER TABLE pline_tax_rel"
+        " RENAME TO account_tax_pos_order_line_rel;")
+
+    openupgrade.logged_query(
+        cr,
+        "ALTER TABLE account_tax_pos_order_line_rel"
+        " RENAME COLUMN pos_line_id TO pos_order_line_id;")
+
+    openupgrade.logged_query(
+        cr,
+        "ALTER TABLE account_tax_pos_order_line_rel"
+        " RENAME COLUMN tax_id TO account_tax_id;")
+
+
 @openupgrade.migrate()
 def migrate(cr, version):
     openupgrade.rename_columns(cr, column_renames)
+    populate_pos_order_tax_ids(cr)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
when migrating from 8.0 to 9.0 (or more), taxes on each lines are lost

Current behavior before PR:
Lost data

Desired behavior after PR is merged:
Data correctly populated. (only if pos_pricelist was installed)




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
