### PR TITLE
[13.0][FIX] base: assure new categories are noupdate = 1 and not deleted after migration

### DIFF
--- a/odoo/addons/base/migrations/13.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/13.0.1.3/pre-migration.py
@@ -746,8 +746,8 @@ def migrate(env, version):
     remove_offending_translations(env)
     handle_web_favicon_module(env)
     add_res_lang_url_code(env)
-    switch_noupdate_records(env)
     rename_ir_module_category(env)
+    switch_noupdate_records(env)
     openupgrade.logged_query(
         env.cr,
         """ UPDATE ir_model_constraint


### PR DESCRIPTION
If you mark new category as noupdate=1, but then merge this one with an old one with noupdate=0, then you are losing the previous noupdate=1. Thus, the proper way is to first rename/merge and then switch the noupdate.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr