### PR TITLE
[FIX] openupgrade_records: incorrect view definition

### DIFF
--- a/odoo/addons/openupgrade_records/views/generate_records_wizard.xml
+++ b/odoo/addons/openupgrade_records/views/generate_records_wizard.xml
@@ -8,12 +8,10 @@
             <form string="OpenUpgrade Generate Records Wizard">
                 <field name="state" invisible="1"/>
                 <group states="init" colspan="4">
-                    <label string="This will reinitialize all the modules installed on this database. Do not continue if you use this database in production."
-                           />
+                    <p>This will reinitialize all the modules installed on this database. Do not continue if you use this database in production.</p>
                 </group>
                 <group states="ready" colspan="4">
-                    <label string="Modules initialized and records created"
-                           />
+                    <p>Modules initialized and records created</p>
                 </group>
                 <footer>
                     <button string="Continue"

--- a/odoo/addons/openupgrade_records/views/install_all_wizard.xml
+++ b/odoo/addons/openupgrade_records/views/install_all_wizard.xml
@@ -8,13 +8,11 @@
             <form string="OpenUpgrade Install All Modules Wizard">
                 <field name="state" invisible="1"/>
                 <group states="init" colspan="4">
-                    <label string="This will install all modules on the database. Do not continue if you use this database in production." colspan="4"
-                           />
+                    <p>This will install all modules on the database. Do not continue if you use this database in production.</p>
                     <field name="to_install"/>
                 </group>
                 <group states="ready" colspan="4">
-                    <label string="Modules installed"
-                           />
+                    <p>Modules installed</p>
                 </group>
                 <footer>
                     <button class="btn-primary"


### PR DESCRIPTION
**Current behavior before PR:**

Error during the installation of the module openupgrade_records because the view definition is using obsolete "label".

**Desired behavior after PR is merged:**

Fixed.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
