### PR TITLE
[13.0][account][fix] Improve the mapping of invoice line data to move lines.

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -222,8 +222,15 @@ def migration_invoice_moves(env):
             JOIN account_invoice ai ON ail.invoice_id = ai.id AND ai.state NOT IN ('draft', 'cancel')
             JOIN account_move am ON ail.invoice_id = am.old_invoice_id
         """
+    # We assign to the move lines information from the matching invoice line.
+    # Everything that has a tax_line_id (originator tax) is by definition originating
+    # from the invoice taxes, not from invoice lines.
+    # The move lines that have a receivable or payable account (the same as the one
+    # from the invoice) are not associated to any invoice line.
     minimal_where = """
         WHERE am.id = aml.move_id
+            AND aml.tax_line_id IS NULL
+            AND aml.account_id <> ai.account_id
             AND ail.quantity = aml.quantity
             AND ((ail.product_id IS NULL AND aml.product_id IS NULL) OR ail.product_id = aml.product_id)
             AND ((ail.uom_id IS NULL AND aml.product_uom_id IS NULL) OR ail.uom_id = aml.product_uom_id)


### PR DESCRIPTION
Do not map tax related lines or receivable/payable line to invoice lines.

As a result of this:
- Before this fix the tax_ids was assigned to all the move lines relating to an invoice, resulting in incorrect tax reporting results. Now the tax_ids is assigned only to the move lines that is really applicable.

cc @MiquelRForgeFlow 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
