### PR TITLE
[13.0][FIX] utm: avoid foreign_key error in utm_tag_rel table

### DIFF
--- a/addons/utm/migrations/13.0.1.0/post-migration.py
+++ b/addons/utm/migrations/13.0.1.0/post-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2020 ForgeFlow <http://www.forgeflow.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def update_utm_tag_rel(env):
+    openupgrade.logged_query(
+        env.cr, """
+        INSERT INTO utm_tag_rel (tag_id, campaign_id)
+        SELECT rel.tag_id, mmc.campaign_id
+        FROM mail_mass_mailing_tag_rel rel
+        JOIN mail_mass_mailing_campaign mmc ON mmc.id = rel.campaign_id"""
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if openupgrade.table_exists(env.cr, 'mail_mass_mailing_stage'):
+        update_utm_tag_rel(env)

--- a/addons/utm/migrations/13.0.1.0/pre-migration.py
+++ b/addons/utm/migrations/13.0.1.0/pre-migration.py
@@ -11,7 +11,6 @@ _model_renames = [
 _table_renames = [
     ('mail_mass_mailing_stage', 'utm_stage'),
     ('mail_mass_mailing_tag', 'utm_tag'),
-    ('mail_mass_mailing_tag_rel', 'utm_tag_rel'),
 ]
 
 _xmlid_renames = [
@@ -21,6 +20,7 @@ _xmlid_renames = [
      'utm.campaign_stage_2'),
     ('mass_mailing.campaign_stage_3',
      'utm.campaign_stage_3'),
+    ('mass_mailing.mass_mail_tag_1', 'utm.utm_tag_1'),
 ]
 
 
@@ -36,13 +36,6 @@ def move_mailing_campaign_to_utm_campaign(env):
         SET user_id = mmc.user_id, stage_id = mmc.stage_id, color = mmc.color
         FROM mail_mass_mailing_campaign mmc
         WHERE mmc.campaign_id = uc.id"""
-    )
-    openupgrade.logged_query(
-        env.cr, """
-        UPDATE utm_tag_rel utr
-        SET campaign_id = mmc.campaign_id
-        FROM mail_mass_mailing_campaign mmc
-        WHERE mmc.id = utr.campaign_id"""
     )
 
 

--- a/odoo/addons/base/migrations/13.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/13.0.1.3/pre-migration.py
@@ -556,6 +556,7 @@ _obsolete_tables = (
     "account_voucher",
     "account_voucher_line",
     "lunch_order_line",
+    "mail_mass_mailing_campaign"
     "slide_category",
     "survey_page",
     "account_analytic_tag_account_invoice_line_rel",
@@ -567,6 +568,7 @@ _obsolete_tables = (
     "sale_order_line_invoice_rel",
     "summary_dept_rel",
     "project_task_assign_so_line_rel",
+    "mail_mass_mailing_tag_rel",
 )
 
 


### PR DESCRIPTION
To avoid violating obsolete constraint, we delete the constrains. Thus, we avoid doing the rename of the table and instead we refill it post-migration the new table.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr