### PR TITLE
[12.0][FIX] stock: company_id of stock rule should be the same as the warehouse

### DIFF
--- a/addons/stock/migrations/12.0.1.1/post-migration.py
+++ b/addons/stock/migrations/12.0.1.1/post-migration.py
@@ -112,6 +112,16 @@ def merge_stock_location_path_stock_rule(env):
         )
 
 
+def assure_stock_rule_company_is_correct(env):
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE stock_rule sr
+        SET company_id = sw.company_id
+        FROM stock_warehouse sw
+        WHERE sr.warehouse_id = sw.id AND sw.company_id != sr.company_id"""
+    )
+
+
 def fill_stock_package_level(env):
     """Only stock.move.line records with package_id = result_package_id means
     that a package level should be created, as in previous version,
@@ -176,6 +186,7 @@ def migrate(env, version):
     map_stock_rule_action(cr)
     fill_stock_picking_type_barcode(env)
     merge_stock_location_path_stock_rule(env)
+    assure_stock_rule_company_is_correct(env)
     fill_stock_package_level(env)
     merge_stock_putaway_product(cr)
     openupgrade.load_data(


### PR DESCRIPTION
This is not literally an "issue" in v12, but it's good to have data correctness.

I just found migrating a DB, and found check in v13. I think the problem is due to company_id having the default=lambda self: self.env.user.company_id. Thus, if rules are created with sudo or during migration, then they will have the company of the admin.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr