### PR TITLE
[FIX] mrp + openupgrade_records : do not create column when installing mrp

### DIFF
--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -14,16 +14,19 @@ def _pre_init_mrp(cr):
           leads to "Out of Memory" crashes
         - stock.move.line.done_move is a stored+related on the former... 
         - Also set the default value for unit_factor in the same UPDATE query to save some SQL constraint checks"""
-    cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" float;""")
-    cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "is_done" bool;""")
-    cr.execute("""ALTER TABLE "stock_move_line" ADD COLUMN "done_move" bool;""")
-    cr.execute("""UPDATE stock_move
-                     SET is_done=COALESCE(state in ('done', 'cancel'), FALSE),
-                         unit_factor=1.0;""")
-    cr.execute("""UPDATE stock_move_line
-                     SET done_move=sm.is_done
-                    FROM stock_move sm
-                   WHERE move_id=sm.id;""")
+    # Openupgrade: the following lines will generate an errors, when running
+    # openupgrade_records.
+    # cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "unit_factor" float;""")
+    # cr.execute("""ALTER TABLE "stock_move" ADD COLUMN "is_done" bool;""")
+    # cr.execute("""ALTER TABLE "stock_move_line" ADD COLUMN "done_move" bool;""")
+    # cr.execute("""UPDATE stock_move
+    #                  SET is_done=COALESCE(state in ('done', 'cancel'), FALSE),
+    #                      unit_factor=1.0;""")
+    # cr.execute("""UPDATE stock_move_line
+    #                  SET done_move=sm.is_done
+    #                 FROM stock_move sm
+    #                WHERE move_id=sm.id;""")
+    pass
 
 def _create_warehouse_data(cr, registry):
     """ This hook is used to add a default manufacture_pull_id, manufacture


### PR DESCRIPTION
due to recent commit in odoo 13.0 (https://github.com/odoo/odoo/commit/549de5601efdad3ebdb03feb8beb1e898f80113a)
 that has been recently introduced in OpenUpgrade (probably [here](https://github.com/OCA/OpenUpgrade/pull/2460)), the use of openugrade_records is not working any more, because odoo fails to recreate existing column.

this trivial patch fixes that bug.

CC : @StefanRijnhart 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
