### PR TITLE
[12.0][FIX] account: reference_type is used in account_payment_order module

### DIFF
--- a/addons/account/migrations/12.0.1.1/pre-migration.py
+++ b/addons/account/migrations/12.0.1.1/pre-migration.py
@@ -10,6 +10,9 @@ _column_copies = {
     'account_payment_term_line': [
         ('option', None, None),
     ],
+    'account_invoice': [
+        ('reference_type', None, None),
+    ],
 }
 
 _column_renames = {
@@ -22,9 +25,6 @@ _column_renames = {
     'account_chart_template': [
         ('company_id', None),
         ('transfer_account_id', None)
-    ],
-    'account_invoice': [
-        ('reference_type', None),
     ],
 }
 


### PR DESCRIPTION
If not, reference_type defined in account_payment_order become empty after migration. See https://github.com/OCA/bank-payment/blob/12.0/account_payment_order/models/account_invoice.py#L19



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr