### PR TITLE
[13.0] [FIX] account migration: create invoice_payment_state in pre-migration

### DIFF
--- a/addons/account/migrations/13.0.1.1/pre-migration.py
+++ b/addons/account/migrations/13.0.1.1/pre-migration.py
@@ -117,6 +117,7 @@ def create_account_move_new_columns(env):
             ('amount_tax', 'numeric'),
             ('amount_tax_signed', 'numeric'),
             ('amount_residual_signed', 'numeric'),
+            ('invoice_payment_state', 'character varying'),
         ],
     }
     for table, column_spec_list in data.items():


### PR DESCRIPTION
The `invoice_payment_state` is computed by the `_compute_amount` method which computes 8 other total fields. Creating the `invoice_payment_state` column in the pre-migration script should avoid the `_compute_amount` to be called.