### PR TITLE
[13.0][FIX] fix migration with product with twice the same attribute

### DIFF
--- a/addons/product/migrations/13.0.1.2/post-migration.py
+++ b/addons/product/migrations/13.0.1.2/post-migration.py
@@ -4,6 +4,42 @@
 from openupgradelib import openupgrade
 
 
+def fill_product_template_attribute_value_attribute_line_id_complexe_case(env):
+    # For some product you can have twice the same attribute
+    # for example you have a bi-color product
+    # you can set
+    # attribute line 1: color => white, black, yellow
+    # attribute line 2: color => green, blue, yellow
+    # if both attibute line have same value for the color it's a litle more
+    # complexe to fill the value as you have two product_template_attribute_value
+    # with the same attribute_value "yellow"
+    # We search all template in this case and process attribute per attribute
+
+    openupgrade.logged_query(
+        env.cr, """
+        SELECT array_agg(id), product_tmpl_id, attribute_id
+        FROM product_template_attribute_line
+        GROUP BY product_tmpl_id, attribute_id
+        HAVING count(id) > 1""")
+    for attribute_line_ids, product_tmpl_id, attribute_id in env.cr.fetchall():
+        for attribute_line_id in attribute_line_ids:
+            openupgrade.logged_query(
+                env.cr, """
+                UPDATE product_template_attribute_value
+                SET attribute_line_id = %s
+                WHERE id in (
+                    SELECT min(ptav.id)
+                    FROM product_template_attribute_value ptav
+                    JOIN product_attribute_value ptv
+                        ON ptv.id = ptav.product_attribute_value_id
+                    WHERE product_tmpl_id = %s
+                        AND ptv.attribute_id = %s
+                        AND ptav.attribute_line_id IS NULL
+                    GROUP BY product_tmpl_id, product_attribute_value_id
+                )
+                    """, (attribute_line_id, product_tmpl_id, attribute_id))
+
+
 def fill_product_template_attribute_value_attribute_line_id(env):
     openupgrade.logged_query(
         env.cr, """
@@ -14,7 +50,8 @@ def fill_product_template_attribute_value_attribute_line_id(env):
         JOIN product_attribute_value_product_template_attribute_line_rel
             avtalr ON avtalr.product_template_attribute_line_id = ptal.id
         WHERE ptal.active = TRUE AND ptav.product_tmpl_id = pt.id AND
-            ptav.product_attribute_value_id = avtalr.product_attribute_value_id
+            ptav.product_attribute_value_id = avtalr.product_attribute_value_id AND
+            ptav.attribute_line_id IS NULL
         """,
     )
 
@@ -63,6 +100,7 @@ def convert_image_attachments(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
+    fill_product_template_attribute_value_attribute_line_id_complexe_case(env)
     fill_product_template_attribute_value_attribute_line_id(env)
     fill_product_template_attribute_value__attribute_id_related(env)
     fill_product_variant_combination_table(env)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

 For some product you can have twice the same attribute
 Example you have a bi-color product you can set
 attribute line 1: color => white, black, yellow
 attribute line 2: color => green, blue, yellow
 if both attribute line have same value for the color it's a litle more
 complexe to fill the value as you have two product_template_attribute_value
 with the same attribute_value "yellow"

Current behavior before PR:

Migration fail

Desired behavior after PR is merged:

Migration work



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
