### PR TITLE
[FIX] website_blog: fix blog and post covers

### DIFF
--- a/addons/website_blog/migrations/13.0.1.0/noupdate_changes.xml
+++ b/addons/website_blog/migrations/13.0.1.0/noupdate_changes.xml
@@ -1,8 +1,8 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
-  <record id="blog_blog_1" model="blog.blog">
-<!--    <field name="name">Our blog</field>-->
-<!--    <field name="subtitle">We are a team of passionate people whose goal is to improve everyone's life.</field>-->
-    <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_5.jpg')", "resize_class": "o_record_has_cover cover_mid", "background-color": "oe_black", "opacity": "0.4"}</field>
-  </record>
+<!--  <record id="blog_blog_1" model="blog.blog">
+    <field name="name">Our blog</field>
+    <field name="subtitle">We are a team of passionate people whose goal is to improve everyone's life.</field>
+     <field name="cover_properties">{"background-image": "url('/website_blog/static/src/img/cover_5.jpg')", "resize_class": "o_record_has_cover cover_mid", "background-color": "oe_black", "opacity": "0.4"}</field>
+  </record> -->
 </odoo>

--- a/addons/website_blog/migrations/13.0.1.0/post-migration.py
+++ b/addons/website_blog/migrations/13.0.1.0/post-migration.py
@@ -1,12 +1,47 @@
 # Copyright 2020 ForgeFlow <http://www.forgeflow.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import json
+
 from openupgradelib import openupgrade
+
+
+def _preserve_post_covers(env):
+    """Preserve how blog post covers display.
+
+    Performs these transformations to preserve blog post cover sizes:
+
+    * Full size:
+      .cover.container-fluid.cover_full ➡ .o_record_has_cover.cover_full
+    * Medium size:
+      .cover.container-fluid.cover_narrow ➡ .o_record_has_cover.cover_mid
+    * Narrow size:
+      .cover.container.cover_narrow ➡ .o_record_has_cover.cover_auto
+    """
+    posts = env["blog.post"].search([("cover_properties", "!=", False)])
+    for post in posts:
+        properties = json.loads(post.cover_properties)
+        resize_classes = set(properties.get("resize_class", "").split())
+        if "cover" in resize_classes:
+            resize_classes.add("o_record_has_cover")
+            # Mid
+            if {"container-fluid", "cover_narrow"} <= resize_classes:
+                resize_classes.add("cover_mid")
+            # Narrow
+            elif {"container", "cover_narrow"} <= resize_classes:
+                resize_classes.add("cover_auto")
+            resize_classes.difference_update({"cover", "container", "container-fluid"})
+            post.write(
+                {
+                    "cover_properties": json.dumps(
+                        dict(properties, resize_class=list(resize_classes))
+                    )
+                }
+            )
 
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.load_data(
-        env.cr, "website_blog", "migrations/13.0.1.0/noupdate_changes.xml")
+    _preserve_post_covers(env)
     openupgrade.delete_records_safely_by_xml_id(
         env, [
             "website_blog.blog_post_cover_01",

--- a/addons/website_blog/migrations/13.0.1.0/pre-migration.py
+++ b/addons/website_blog/migrations/13.0.1.0/pre-migration.py
@@ -20,5 +20,7 @@ def switch_noupdate_records(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
+    openupgrade.load_data(
+        env.cr, "website_blog", "migrations/13.0.1.0/noupdate_changes.xml")
     openupgrade.rename_xmlids(env.cr, _xmlid_renames)
     switch_noupdate_records(env)


### PR DESCRIPTION
v13 introduces `blog.blog` covers. Thus, it's better to keep the default value for `blog_blog_1` instead of setting an url to it. The default will be a solid color instead.

Also, `blog.post` covers behave similarly, but use different classes, so here I provide the required transformation.

@Tecnativa TT23206