### PR TITLE
[13.0][DEL] Remove coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install libldap2-dev nodejs libxml2-dev libxslt1-dev libevent-dev libsasl2-dev expect unixodbc-dev expect-dev python-lxml python-simplejson python-serial python-yaml python-passlib python-psycopg2 python-werkzeug
-          pip install coveralls
       - name: Requirements Installation
         run: |
           sudo npm install -g less less-plugin-clean-css
@@ -70,8 +69,4 @@ jobs:
           MODULES_NEW=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules120-130.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
           psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES_OLD | sed -e "s/,/','/g")')"
           echo Testing modules $MODULES_NEW
-          OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES_NEW --db_host=$DB_HOST --db_port=$DB_PORT --db_port=$DB_PORT --db_password=$DB_PASSWORD --db_user=$DB_USERNAME --stop-after-init
-      - name: Ending
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: coveralls
+          OPENUPGRADE_TESTS=1 $ODOO --database=$DB --update=$MODULES_NEW --db_host=$DB_HOST --db_port=$DB_PORT --db_password=$DB_PASSWORD --db_user=$DB_USERNAME --stop-after-init


### PR DESCRIPTION
Upload currently fails with
```
Could not submit coverage: 422 Client Error:
Unprocessable Entity for url: https://coveralls.io/api/v1/jobs
```

Even though coverage data is gathered successfully in the correct format.
(See https://github.com/OCA/OpenUpgrade/runs/1738041013#step:13:18
for a run with coveralls debug output)

Having coverage on the migration scripts hardly makes any sense, as it only
displays which code does not run during the migration.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
