### PR TITLE
[12.0][FIX] Don't reset module states on exception

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -85,7 +85,9 @@ class Registry(Mapping):
                     try:
                         odoo.modules.load_modules(registry._db, force_demo, status, update_module)
                     except Exception:
-                        odoo.modules.reset_modules_state(db_name)
+                        # OpenUpgrade: don't reset module states so that the migration
+                        # can be continued after fixing the error
+                        # odoo.modules.reset_modules_state(db_name)
                         raise
                 except Exception:
                     _logger.exception('Failed to load registry')


### PR DESCRIPTION
This is in all Odoo versions from 10.0 on. Whenever an uncaught exception occurs, module states are reset from `to upgrade` to `installed`. I think this is harmful in migration context.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
