### PR TITLE
[11.0][FIX] stock: use a global route to avoid creating too many rules

### DIFF
--- a/addons/stock/migrations/11.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/stock/migrations/11.0.1.1/openupgrade_analysis_work.txt
@@ -16,9 +16,7 @@ stock        / procurement.rule         / sequence (integer)            : previo
 
 stock        / procurement.rule         / route_id (many2one)           : now required
 stock        / stock.location.path      / route_id (many2one)           : now required
-# Done:
-#   pre-migration: Copy records with this field empty to another table
-#   post-migration: Create a record of these global rules for each existing route
+# Done: post-migration: Create a global route and link the global rules to that route
 
 stock        / product.putaway          / method (selection)            : DEL required: required, selection_keys: function, req_default: function
 # Nothing to do: Only one value used in core. If any community module extends it, an adaptation will be required on that module

--- a/addons/stock/migrations/11.0.1.1/pre-migration.py
+++ b/addons/stock/migrations/11.0.1.1/pre-migration.py
@@ -5,21 +5,6 @@
 from openupgradelib import openupgrade
 
 
-def copy_global_rules(env):
-    """Copy global rules to another table and remove them from main one."""
-    for table in ['procurement_rule', 'stock_location_path']:
-        openupgrade.logged_query(
-            env.cr, """
-            CREATE TABLE %s AS (
-                SELECT * FROM %s
-                WHERE route_id IS NULL
-            )""" % (openupgrade.get_legacy_name(table), table)
-        )
-        openupgrade.logged_query(
-            env.cr, "DELETE FROM %s WHERE route_id IS NULL" % table,
-        )
-
-
 def delete_quants_for_consumable(env):
     """On v11, consumable products don't generate quants, so we can remove them
     as soon as possible for cleaning the DB and avoid other computations (like
@@ -57,7 +42,6 @@ def fix_act_window(env):
 
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
-    copy_global_rules(env)
     delete_quants_for_consumable(env)
     fix_act_window(env)
     openupgrade.update_module_moved_fields(


### PR DESCRIPTION
If your bbdd has too many companies, and your global rules don't use several warehouses, then when transforming that global rule into specific rules for each route, you are creating many unnecessary rules. To avoid that, the proper way should be create a global route and then update the global rules by using that route.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr