### PR TITLE
[11.0][IMP] rating: prepopulate stored field on mail_message

### DIFF
--- a/addons/rating/migrations/11.0.1.0/pre-migration.py
+++ b/addons/rating/migrations/11.0.1.0/pre-migration.py
@@ -14,3 +14,14 @@ COLUMN_COPIES = {
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.copy_columns(env.cr, COLUMN_COPIES)
+
+    # Precreate and populate mail_message's new stored field rating_value
+    openupgrade.add_fields(env, [
+        ("rating_value", "mail.message",
+         "mail_message", "float", False, "rating", 0)])
+    openupgrade.logged_query(
+        env.cr,
+        """UPDATE mail_message mm
+        SET rating_value = rr.rating
+        FROM rating_rating rr
+        WHERE rr.message_id = mm.id""")


### PR DESCRIPTION
An old optimization I had lying around. Prevents a compute method from kicking in on all messages in the system (https://github.com/odoo/odoo/blob/11.0/addons/rating/models/mail_message.py#L15)