### PR TITLE
[13.0][sale] only set order_date equal to confirmation_date if the confirmation_date exists

### DIFF
--- a/addons/sale/migrations/13.0.1.1/post-migration.py
+++ b/addons/sale/migrations/13.0.1.1/post-migration.py
@@ -103,7 +103,8 @@ def fill_confirmation_date(env):
         env.cr,
         """UPDATE sale_order
         SET date_order = confirmation_date
-        WHERE state IN ('sale', 'done')"""
+        WHERE state IN ('sale', 'done')
+        AND confirmation_date IS NOT NULL"""
     )
 
 


### PR DESCRIPTION
Found migrating a demo database, where the confirmation date is blank for confimed or completed sales orders.

cc @MiquelRForgeFlow 


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
