### PR TITLE
[MRG] account_asset_management_xls > account_asset_management

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -62,6 +62,7 @@ merged_modules = {
     'account_asset': 'account_asset_management',
     'account_asset_depr_line_cancel': 'account_asset_management',
     'account_asset_disposal': 'account_asset_management',
+    'account_asset_management_xls': 'account_asset_management',
     'account_reversal': 'account',
     # OCA/e-commerce
     'website_sale_default_country': 'website_sale',


### PR DESCRIPTION
As per https://github.com/OCA/account-financial-tools/pull/1120

(the reporting module was never ~~ported~~ merged in 11.0, but the merge here is still valid when migrating from older versions).

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
