### PR TITLE
[10.0][OU-FIX] #2339, purge obsolete models and fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,8 @@ script:
     - MODULES_NEW=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules90-100.rst | grep "Done\|Partial\|Nothing" | grep -v "l10n_be"  | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
     - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES_OLD | sed -e "s/,/','/g")')"
     - echo Testing modules $MODULES_NEW
-    - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init
+    # Silence redundant logs from unlinking records (1 line is enough) to prevent Travis log overflow
+    - OPENUPGRADE_TESTS=1 $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init --log-handler odoo.models.unlink:WARNING
     # try to build the documentation
     - pip install sphinx
     - sh scripts/build_openupgrade_docs


### PR DESCRIPTION
Fixes #2339

* add loaded models and fields to the set of loaded XMLIDs
* purge models and fields with noupdate NULL instead of FALSE

Also

* remove coverage as it is giving out red marks to PRs for no reason
* check reference count before deleting a record after module upgrade
* improve logging when deletion fails (should be rare now)
* reduce logging of deletions in CI
* remove ir.model.relation from ir.model's unlink

This PR is part of a set of PRs for OpenUpgrade 9.0 up to 13.0. Background:

While Odoo deletes obsolete field and model entries from the data model
metadata explicitely in their migration scripts, in OpenUpgrade I have
always meant to rely on the mechanism of purging 'untouched' XMLIDs that
takes care of the deletion of obsolete data records (e.g. views).

However, this mechanism was not applied to field and model entries because
their XMLIDs were created with noupdate NULL instead of FALSE and as such
excluded in the query to gather all obsolete data records.

Also missing was marking the XMLIDs of fields and models as loaded in the
first place.

All of this is working properly in Odoo 13 (introduced gradually across new
releases) so all of this is backported from newer versions one way or
another.