### PR TITLE
[11.0][OU-FIX] #2339, purge obsolete models and fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,8 @@ script:
     - MODULES_NEW=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules100-110.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
     - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES_OLD | sed -e "s/,/','/g")')"
     - echo Testing modules $MODULES_NEW
-    - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init
+    # Silence redundant logs from unlinking records (1 line is enough) to prevent Travis log overflow
+    - OPENUPGRADE_TESTS=1 $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init --log-handler odoo.models.unlink:WARNING
     # try to build the documentation
     - pip install sphinx
     - sh scripts/build_openupgrade_docs

--- a/odoo/addons/base/ir/ir_model.py
+++ b/odoo/addons/base/ir/ir_model.py
@@ -837,15 +837,16 @@ class IrModelFields(models.Model):
         # Given that we arrive here in order of inheritance, we simply check
         # if the field's xmlid belongs to a module already loaded, and if not,
         # update the record with the correct module name.
+        model = self.env[field.model_name]
         self.env.cr.execute(
             "SELECT f.*, d.module, d.id as xmlid_id, d.name as xmlid "
             "FROM ir_model_fields f LEFT JOIN ir_model_data d "
-            "ON f.id=d.res_id and d.model='ir.model.fields' WHERE f.model=%s",
-            (field.model_name,))
+            "ON f.id=d.res_id and d.model='ir.model.fields' WHERE f.name=%s AND f.model=%s",
+            (field.name, field.model_name,))
         for rec in self.env.cr.dictfetchall():
             if 'module' in self.env.context and\
                     rec['module'] and\
-                    rec['name'] in self._fields.keys() and\
+                    rec['name'] in model._fields.keys() and\
                     rec['module'] != self.env.context['module'] and\
                     rec['module'] not in self.env.registry._init_modules:
                 _logger.info(
@@ -865,7 +866,7 @@ class IrModelFields(models.Model):
                         dict(rec, module=self.env.context['module']))
             if ('module' in self.env.context and
                 rec['module'] and
-                rec['name'] in self._fields.keys() and
+                rec['name'] in model._fields.keys() and
                 (rec['module'] == self.env.context['module'] or
                  rec['module'] not in self.env.registry._init_modules)):
                 # Register the xmlid of the field as loaded


### PR DESCRIPTION
Fixes #2339

* add loaded models and fields to the set of loaded XMLIDs
* purge models and fields with noupdate NULL instead of FALSE

Also

* Fix update_fields_xmlid searching for fields by ir.model.fields instead of
the actual model that the field belongs to
* fix KeyError in case of a missing model in ir.model.fields' unlink
* remove coverage as it is giving out red marks to PRs for no reason
* check reference count before deleting a record after module upgrade
* improve logging when deletion fails (should be rare now)
* reduce logging of deletions in CI
* remove ir.model.relation from ir.model's unlink


This PR is part of a set of PRs for OpenUpgrade 9.0 up to 13.0. Background:

While Odoo deletes obsolete field and model entries from the data model
metadata explicitely in their migration scripts, in OpenUpgrade I have
always meant to rely on the mechanism of purging 'untouched' XMLIDs that
takes care of the deletion of obsolete data records (e.g. views).

However, this mechanism was not applied to field and model entries because
their XMLIDs were created with noupdate NULL instead of FALSE and as such
excluded in the query to gather all obsolete data records.

Also missing was marking the XMLIDs of fields and models as loaded in the
first place.

All of this is working properly in Odoo 13 (introduced gradually across new
releases) so all of this is backported from newer versions one way or
another.
