### PR TITLE
[12.0][OU-FIX] #2339, set noupdate of ir.model.fields XMLIDs to FALSE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,8 @@ script:
 # only flake8 migration scripts from the openupgrade project, presumably
 # identifyable by using the openupgrade helpers
     - flake8 --max-line-length=120 scripts $(find . \( -name 'pre-*.py' -or -name 'post-*.py' \) -exec grep -q openupgrade {} \; -print)
-    - flake8 odoo/addons/*/migrations/*/tests/ --max-line-length=120
-    - flake8 addons/*/migrations/*/tests/ --max-line-length=120
+    - flake8 odoo/addons/*/migrations/tests/ --max-line-length=120 --exclude=__init__.py
+    - flake8 addons/*/migrations/tests/ --max-line-length=120 --exclude=__init__.py
     - npm install -g less less-plugin-clean-css
     - createdb $DB
     - wget -q -O- https://github.com/OCA/OpenUpgrade/releases/download/databases/11.0.psql | pg_restore -d $DB --no-owner
@@ -65,7 +65,8 @@ script:
     - MODULES_NEW=base,$(sed -n '/^+========/,$p'  odoo/openupgrade/doc/source/modules110-120.rst | grep "Done\|Partial\|Nothing" | grep -v "theme_" | sed -r -n 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' | sed '/^\s*$/d' | paste -d, -s)
     - psql $DB -c "update ir_module_module set state='uninstalled' where name not in ('$(echo $MODULES_OLD | sed -e "s/,/','/g")')"
     - echo Testing modules $MODULES_NEW
-    - OPENUPGRADE_TESTS=1 coverage run $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init
+    # Silence redundant logs from unlinking records (1 line is enough) to prevent Travis log overflow
+    - OPENUPGRADE_TESTS=1 $ODOO --database=$DB --update=$MODULES_NEW --stop-after-init --log-handler odoo.models.unlink:WARNING
     # try to build the documentation
     - pip install sphinx
     - sh scripts/build_openupgrade_docs

--- a/addons/delivery_hs_code/migrations/tests/__init__.py
+++ b/addons/delivery_hs_code/migrations/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_field_xmlid

--- a/addons/delivery_hs_code/migrations/tests/test_field_xmlid.py
+++ b/addons/delivery_hs_code/migrations/tests/test_field_xmlid.py
@@ -1,0 +1,19 @@
+# © 2021 Opener B.V. <https://opener.amsterdam>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from odoo.tests.common import TransactionCase
+
+
+class TestFieldXmlid(TransactionCase):
+    def test_field_xmlid(self):
+        """Check that an xmlid was created for the field in its new home
+        module after it moved from module 'delivery' to this
+        module higher up the dependency chain."""
+        field = self.env["ir.model.fields"].search(
+            [("model", "=", "product.template"),
+             ("name", "=", "hs_code")])
+        self.assertTrue(field)
+        self.assertTrue(
+            self.env["ir.model.data"].search(
+                [("module", "=", "delivery_hs_code"),
+                 ("model", "=", field._name),
+                 ("res_id", "=", field.id)]))

--- a/addons/sale/migrations/tests/__init__.py
+++ b/addons/sale/migrations/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_field_xmlid

--- a/addons/sale/migrations/tests/test_field_xmlid.py
+++ b/addons/sale/migrations/tests/test_field_xmlid.py
@@ -1,0 +1,19 @@
+# © 2021 Opener B.V. <https://opener.amsterdam>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+from odoo.tests.common import TransactionCase
+
+
+class TestFieldXmlid(TransactionCase):
+    def test_field_xmlid(self):
+        """Check that an xmlid was created for the field in its new home
+        module after it moved from module 'website_sale' to this module lower
+        down in the dependency chain."""
+        field = self.env["ir.model.fields"].search(
+            [("model", "=", "product.attribute.value"),
+             ("name", "=", "html_color")])
+        self.assertTrue(field)
+        self.assertTrue(
+            self.env["ir.model.data"].search(
+                [("module", "=", "sale"),
+                 ("model", "=", field._name),
+                 ("res_id", "=", field.id)]))

--- a/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
@@ -234,3 +234,10 @@ def migrate(env, version):
             'view_menu',
             'lang_km',
         ], False)
+    # In Odoo 12.0, fields xmlids are noupdate FALSE instead of NULL and are
+    # thus included when cleaning up obsolete data records in _process_end.
+    openupgrade.logged_query(
+        env.cr,
+        """UPDATE ir_model_data
+        SET noupdate=FALSE
+        WHERE model='ir.model.fields' AND noupdate IS NULL""")

--- a/odoo/openupgrade/openupgrade_loading.py
+++ b/odoo/openupgrade/openupgrade_loading.py
@@ -4,12 +4,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 import logging
-import os
-import threading
 from odoo import release
 from openupgradelib.openupgrade_tools import table_exists
 from odoo.tools import config, safe_eval
-from odoo.modules.module import adapt_version, get_module_path, TestStream
+from odoo.modules.module import get_module_path
 from odoo.tools import pycompat
 
 
@@ -245,73 +243,3 @@ def compare_registries(cr, module, registry, local_registry):
                             (key, value, record_id)
                             )
                     old_field[key] = value
-
-
-def run_tests(package, report):
-    if package == '_deferred':
-        name = 'deferred'
-        tests_dir = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), 'tests_deferred')
-    else:
-        name = package.name
-        tests_dir = os.path.join(
-            get_module_path(name),
-            'migrations',
-            adapt_version(package.data['version']),
-            'tests',
-        )
-    # check for an environment variable because we don't want to mess
-    # with odoo's config.py, but we also don't want to run existing
-    # tests
-    if os.environ.get('OPENUPGRADE_TESTS') and os.path.exists(tests_dir):
-        import unittest
-        threading.currentThread().testing = True
-        tests = unittest.defaultTestLoader.discover(
-            tests_dir, top_level_dir=tests_dir)
-        report.record_result(
-            unittest.TextTestRunner(
-                verbosity=2, stream=TestStream(name)
-            ).run(tests).wasSuccessful()
-        )
-        threading.currentThread().testing = False
-
-
-def update_field_xmlid(model, field):
-    """ OpenUpgrade edit start: In rare cases, an old module defined a field
-    on a model that is not defined in another module earlier in the
-    chain of inheritance. Then we need to assign the ir.model.fields'
-    xmlid to this other module, otherwise the column would be dropped
-    when uninstalling the first module.
-    An example is res.partner#display_name defined in 7.0 by
-    account_report_company, but now the field belongs to the base
-    module
-    Given that we arrive here in order of inheritance, we simply check
-    if the field's xmlid belongs to a module already loaded, and if not,
-    update the record with the correct module name. """
-    model.env.cr.execute(
-        "SELECT f.*, d.module, d.id as xmlid_id, d.name as xmlid "
-        "FROM ir_model_fields f LEFT JOIN ir_model_data d "
-        "ON f.id=d.res_id and d.model='ir.model.fields' WHERE f.model=%s",
-        (model._name,))
-    for rec in model.env.cr.dictfetchall():
-        if ('module' in model.env.context and
-                rec['module'] and
-                rec['name'] in model._fields.keys() and
-                rec['module'] != model.env.context['module'] and
-                rec['module'] not in model.env.registry._init_modules):
-            logging.getLogger(__name__).info(
-                'Moving XMLID for ir.model.fields record of %s#%s '
-                'from %s to %s', model._name, rec['name'], rec['module'],
-                model.env.context['module'])
-            model.env.cr.execute(
-                "SELECT id FROM ir_model_data WHERE module=%(module)s "
-                "AND name=%(xmlid)s",
-                dict(rec, module=model.env.context['module']))
-            if model.env.cr.fetchone():
-                logging.getLogger(__name__).info(
-                    'Aborting, an XMLID for this module already exists.')
-                continue
-            model.env.cr.execute(
-                "UPDATE ir_model_data SET module=%(module)s "
-                "WHERE id=%(xmlid_id)s",
-                dict(rec, module=model.env.context['module']))


### PR DESCRIPTION
Fixes #2339

Also

* add loaded models to the set of loaded XMLIDs
* purge models with noupdate NULL instead of FALSE
* Remove redundant update_fields_xmlid method and add tests
* fixes broken migration tests mechanism
* fix unreleased savepoint
* improve logging when deletion fails (should be rare now)
* remove coverage as it is giving out red marks to PRs for no reason
* reduce logging of deletions in CI
* remove ir.model.relation from ir.model's unlink


This PR is part of a set of PRs for OpenUpgrade 9.0 up to 13.0. Background:

While Odoo deletes obsolete field and model entries from the data model
metadata explicitely in their migration scripts, in OpenUpgrade I have
always meant to rely on the mechanism of purging 'untouched' XMLIDs that
takes care of the deletion of obsolete data records (e.g. views).

However, this mechanism was not applied to field and model entries because
their XMLIDs were created with noupdate NULL instead of FALSE and as such
excluded in the query to gather all obsolete data records.

Also missing was marking the XMLIDs of fields and models as loaded in the
first place.

All of this is working properly in Odoo 13 (introduced gradually across new
releases) so all of this is backported from newer versions one way or
another.
