### PR TITLE
[13.0][OU-FIX] account: consider anglo_saxon_accounting

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -221,6 +221,7 @@ def migration_invoice_moves(env):
         FROM account_invoice_line ail
             JOIN account_invoice ai ON ail.invoice_id = ai.id AND ai.state NOT IN ('draft', 'cancel')
             JOIN account_move am ON ail.invoice_id = am.old_invoice_id
+            JOIN res_company rc ON ai.company_id = rc.id
         """
     # We assign to the move lines information from the matching invoice line.
     # Everything that has a tax_line_id (originator tax) is by definition originating
@@ -249,6 +250,7 @@ def migration_invoice_moves(env):
     openupgrade.logged_query(
         env.cr, query + minimal_where + """
             AND aml.old_invoice_line_id IS NULL
+            AND rc.anglo_saxon_accounting IS DISTINCT FROM TRUE
         RETURNING aml.id""",
     )
     aml_ids += tuple(x[0] for x in env.cr.fetchall())


### PR DESCRIPTION
Anglo Saxon accounting creates additional moves lines that should have `exclude_from_invoice_tab = TRUE`.

See https://github.com/odoo/odoo/blob/13.0/addons/stock_account/models/account_move.py#L49 and https://github.com/odoo/odoo/blob/13.0/addons/stock_account/models/account_move.py#L109. (you can find equivalent methods in previous versions)

Example of additional move lines: https://github.com/odoo/odoo/blob/12.0/addons/stock_account/models/product.py#L343




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr