### PR TITLE
[13.0][FIX] website: COW resetting must be done on end-migration

### DIFF
--- a/addons/website/migrations/13.0.1.0/end-migration.py
+++ b/addons/website/migrations/13.0.1.0/end-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2020 Tecnativa - Jairo Llopis
+# Copyright 2021 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.cow_templates_replicate_upstream(env.cr)

--- a/addons/website/migrations/13.0.1.0/post-migration.py
+++ b/addons/website/migrations/13.0.1.0/post-migration.py
@@ -18,4 +18,3 @@ def _fill_website_logo(env):
 def migrate(env, version):
     _fill_website_logo(env)
     openupgrade.load_data(env.cr, 'website', 'migrations/13.0.1.0/noupdate_changes.xml')
-    openupgrade.cow_templates_replicate_upstream(env.cr)


### PR DESCRIPTION
So that other inherited modules like `website_form`, `website_crm` or so get benefit from it.

@Tecnativa TT19845