### PR TITLE
[13.0][OU-ADD] website_snippet_anchor: Merged website_snippet_anchor to website

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -64,6 +64,7 @@ merged_modules = {
     # OCA/website
     'website_canonical_url': 'website',
     'website_logo': 'website',
+    'website_snippet_anchor': 'website',
 }
 
 # only used here for openupgrade_records analysis:


### PR DESCRIPTION
Merged `website_snippet_anchor` to `website` according to https://github.com/OCA/website/tree/12.0/website_snippet_anchor#known-issues--roadmap

@Tecnativa TT27593