### PR TITLE
[12.0][IMP] openupgrade_records: add compatibility with v13

### DIFF
--- a/odoo/addons/openupgrade_records/models/openupgrade_record.py
+++ b/odoo/addons/openupgrade_records/models/openupgrade_record.py
@@ -95,6 +95,8 @@ class Record(models.Model):
             'hasdefault',
             'table',
             'inherits',
+            '_inherits',
+            '_order',
             ]
 
         template = dict([(x, False) for x in keys])
@@ -109,5 +111,12 @@ class Record(models.Model):
                 })
             repre.update(
                 dict([(x.name, x.value) for x in record.attribute_ids]))
+            if repre['table']:
+                repre.update({
+                    'column1': self.env[repre['model']]._fields[
+                        repre['field']].column1,
+                    'column2': self.env[repre['model']]._fields[
+                        repre['field']].column2,
+                })
             data.append(repre)
         return data

--- a/odoo/openupgrade/openupgrade_loading.py
+++ b/odoo/openupgrade/openupgrade_loading.py
@@ -142,6 +142,7 @@ def log_model(model, local_registry):
     if model._inherits:
         model_registry['_inherits'] = {
             '_inherits': pycompat.text_type(model._inherits)}
+    model_registry['_order'] = {'_order': str(model._order)}
     for k, v in model._fields.items():
         properties = {
             'type': typemap.get(v.type, v.type),


### PR DESCRIPTION
With last changes in v13 (https://github.com/OCA/OpenUpgrade/pull/2565), where has been added _inherits and m2m columns comparison, we need this commit to avoid errors when doing the analysis.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr