### PR TITLE
[11.0][FIX] base: noupdate data from report module

### DIFF
--- a/odoo/addons/base/migrations/11.0.1.3/noupdate_changes_report.xml
+++ b/odoo/addons/base/migrations/11.0.1.3/noupdate_changes_report.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+  <record id="paperformat_euro" model="report.paperformat">
+    <field name="margin_bottom">28</field>
+  </record>
+  <record id="paperformat_us" model="report.paperformat">
+    <field name="margin_bottom">25</field>
+  </record>
+</odoo>

--- a/odoo/addons/base/migrations/11.0.1.3/post-migration.py
+++ b/odoo/addons/base/migrations/11.0.1.3/post-migration.py
@@ -153,3 +153,7 @@ def migrate(env, version):
     openupgrade.load_data(
         env.cr, 'base', 'migrations/11.0.1.3/noupdate_changes.xml',
     )
+    if openupgrade.table_exists(env.cr, "report_paperformat"):
+        openupgrade.load_data(
+            env.cr, 'base', 'migrations/11.0.1.3/noupdate_changes_report.xml',
+        )


### PR DESCRIPTION
The `compare_noupdate_xml_records` tool doesn't consider merged modules. The module `report` was merged on `base`, and it had some noupdate data.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr