### PR TITLE
[13.0][OU-FIX] sale: group_auto_done_setting should be enabled by default

### DIFF
--- a/addons/sale/migrations/13.0.1.1/post-migration.py
+++ b/addons/sale/migrations/13.0.1.1/post-migration.py
@@ -110,12 +110,11 @@ def fill_confirmation_date(env):
 
 def check_sale_auto_done(env):
     """System parameter has been replaced by a security group, so we need to
-    add such group if the system parameter was present.
+    add such group. The button action done should be visible (as it was in v12).
     """
-    if env["ir.config_parameter"].sudo().get_param("sale.auto_done_setting"):
-        env.ref("base.group_user").implied_ids = [
-            (4, env.ref("sale.group_auto_done_setting").id),
-        ]
+    env.ref("base.group_user").implied_ids = [
+        (4, env.ref("sale.group_auto_done_setting").id),
+    ]
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
In v12, any user could lock the sale order when they wanted (independently if it was done automatically or not by the config setting) because the button action_done was accessible. But now in v13, the button only is accesible with the setting enabled. In order for the button be accessible (as it was in v12), then the group_auto_done_setting should be enabled.

v12:

```xml
  <record id="view_order_form" model="ir.ui.view">
            <field name="name">sale.order.form</field>
            <field name="model">sale.order</field>
            <field name="arch" type="xml">
                <form string="Sales Order" class="o_sale_order">
                <header>
                 (...)
                     <button name="action_done" type="object" string="Lock" states="sale"
                         help="(...)"/>
                     (...)
```

v13:


```xml
<record id="view_sales_order_auto_done_setting" model="ir.ui.view">
            <field name="name">sale.order.form</field>
            <field name="model">sale.order</field>
            <field name="inherit_id" ref="sale.view_order_form"/>
            <field name="groups_id" eval="[(4, ref('sale.group_auto_done_setting'))]"/>
            <field name="arch" type="xml">
                <xpath expr="//form//header//button[@name='action_draft']" position="after">
                   <button name="action_done" type="object" string="Lock" states="sale"
                        help="(...)" groups="sales_team.group_sale_manager"/>
                   (...)
```



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr