### PR TITLE
[10.0][OU-MRG] admin_technical_features

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -72,6 +72,8 @@ merged_modules = [
     ('sale_order_back2draft', 'sale'),
     ('product_customer_code_sale',
      'product_supplierinfo_for_customer_sale'),
+    # OCA/server-tools
+    ('admin_technical_features', 'base_technical_features'),
     # OCA/social
     ('mass_mailing_security_group', 'mass_mailing'),
     # OCA/stock-logistics-workflow


### PR DESCRIPTION
Maybe I am biased because I was the original author of `base_technical_features`, but the module does replace `admin_technical_features` functionally as it makes the checkbox `Show technical features (without debug mode)` available for users in group_no_one and actually checks it for the admin user (https://github.com/OCA/server-tools/blob/10.0/base_technical_features/data/res_users.xml). Also, `admin_technical_features` was never migrated beyond 9.0.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
