### PR TITLE
[10.0][IMP] Set invoices paid

### DIFF
--- a/addons/account/migrations/10.0.1.1/pre-migration.py
+++ b/addons/account/migrations/10.0.1.1/pre-migration.py
@@ -1,7 +1,26 @@
 # -*- coding: utf-8 -*-
 # © 2017 Therp BV
+# © 2021 Opener B.V.
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+
+
+def update_invoice_state(cr):
+    """In Odoo 9.0, an invoice was moved from state 'open' to state 'paid'
+    on reconciliation of the move line that was linked as the trigger of
+    payment subflow in the invoice workflow. This flow usually prevented
+    zero amount invoices from getting into state `paid` because zero amount
+    move lines are usually not reconciled. The invoice would be marked as
+    `reconciled` correctly, because there was no residual amount.
+    In Odoo 10.0, any invoice that is marked as `reconciled` will be moved to
+    state `paid` as per `action_invoice_paid` that is triggered from the
+    model's `_write` method. Preemtively set the correct state using SQL here
+    for performance reasons.
+    """
+    openupgrade.logged_query(
+        cr, """UPDATE account_invoice
+        SET state = 'paid'
+        WHERE state = 'open' AND reconciled""")
 
 
 @openupgrade.migrate(use_env=True)
@@ -17,3 +36,4 @@ def migrate(env, version):
             ('account_operation_template', 'account_reconcile_model'),
         ]
     )
+    update_invoice_state(cr)


### PR DESCRIPTION
In Odoo 9.0, an invoice was moved from state 'open' to state 'paid'
on reconciliation of the move line that was linked as the trigger of
payment subflow in the invoice workflow. This flow usually prevented
zero amount invoices from getting into state `paid` because zero amount
move lines are usually not reconciled. The invoice would be marked as
`reconciled` correctly, because there was no residual amount.
In Odoo 10.0, any invoice that is marked as `reconciled` will be moved to
state `paid` as per `action_invoice_paid` that is triggered from the
model's `_write` method<sup>1</sup>. Preemtively set the correct state using SQL here
for performance reasons.

<sup>1</sup> https://github.com/odoo/odoo/blob/10.0/addons/account/models/account_invoice.py#L365

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
