### PR TITLE
[IMP] Generate stock_move_lots entries for mrp_production's

### DIFF
--- a/addons/mrp/migrations/10.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/10.0.2.0/post-migration.py
@@ -45,11 +45,11 @@ def populate_stock_move_lots(cr):
           sm.restrict_lot_id,
           TRUE AS done_move,
           sm2.restrict_lot_id AS lot_produced_id
-        FROM 
+        FROM
           stock_move AS sm
         INNER JOIN
           stock_move AS sm2 ON sm.%s = sm2.id
-        WHERE 
+        WHERE
           sm.restrict_lot_id IS NOT NULL
           AND sm.raw_material_production_id IS NOT NULL
           AND sm.state = 'done'
@@ -80,13 +80,13 @@ def populate_stock_move_lots(cr):
           restrict_lot_id,
           TRUE as done_move
         FROM stock_move
-        WHERE 
+        WHERE
           restrict_lot_id IS NOT NULL
           AND production_id IS NOT NULL
           AND state = 'done'
         """
     )
-    
+
 
 def archive_mrp_bom_date_stop(cr):
     cr.execute(


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Manufacturing orders didn't properly display stock moves for tracked products.

Current behavior before PR: The value quantity_done in the form view for an existing/migrated MO is shown as 0.0, both for raw and finished products (unless they are untracked).

Desired behavior after PR is merged: The value quantity_done in the MO form view shows the proper value for both tracked and untracked products.

--

This patch was made in order to make our own migration work. I post it here in case it is of use for anyone else. This is my first time contributing here, so I haven't signed the CLA yet, but in case you intend to merge it I can do so.