### PR TITLE
[13.0][FIX] workflows: update python libraries

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Configuration
         run: |
           sudo apt update
-          sudo apt install libldap2-dev nodejs libxml2-dev libxslt1-dev libevent-dev libsasl2-dev expect unixodbc-dev expect-dev python-lxml python-simplejson python-serial python-yaml python-passlib python-psycopg2 python-werkzeug
+          sudo apt install libldap2-dev nodejs libxml2-dev libxslt1-dev libevent-dev libsasl2-dev expect unixodbc-dev expect-dev python3-lxml python3-simplejson python3-serial python3-yaml python3-passlib python3-psycopg2 python3-werkzeug
           pip install -r requirements.txt
           pip install sphinx
       - name: OpenUpgrade Docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Configuration
         run: |
           sudo apt update
-          sudo apt install libldap2-dev nodejs libxml2-dev libxslt1-dev libevent-dev libsasl2-dev expect unixodbc-dev expect-dev python-lxml python-simplejson python-serial python-yaml python-passlib python-psycopg2 python-werkzeug
+          sudo apt install libldap2-dev nodejs libxml2-dev libxslt1-dev libevent-dev libsasl2-dev expect unixodbc-dev expect-dev python3-lxml python3-simplejson python3-serial python3-yaml python3-passlib python3-psycopg2 python3-werkzeug
       - name: Requirements Installation
         run: |
           sudo npm install -g less less-plugin-clean-css

--- a/.old-travis.yml
+++ b/.old-travis.yml
@@ -8,13 +8,13 @@ addons:
     apt:
         packages:
             - expect-dev  # provides unbuffer utility
-            - python-lxml  # because pip installation is slow
-            - python-simplejson
-            - python-serial
-            - python-yaml
-            - python-passlib
-            - python-psycopg2
-            - python-werkzeug
+            - python3-lxml  # because pip installation is slow
+            - python3-simplejson
+            - python3-serial
+            - python3-yaml
+            - python3-passlib
+            - python3-psycopg2
+            - python3-werkzeug
             - realpath
     postgresql: "10"
 


### PR DESCRIPTION
`python-psycopg2` and `python-werkzeug` don't exist anymore.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr