### PR TITLE
[13.0][FIX] mass_mailing: Subject is now filled

### DIFF
--- a/addons/mass_mailing/migrations/13.0.2.0/openupgrade_analysis_work.txt
+++ b/addons/mass_mailing/migrations/13.0.2.0/openupgrade_analysis_work.txt
@@ -101,11 +101,13 @@ mass_mailing / mailing.mailing          / mailing_type (selection)      : NEW re
 mass_mailing / mailing.mailing          / message_follower_ids (one2many): NEW relation: mail.followers
 mass_mailing / mailing.mailing          / message_ids (one2many)        : NEW relation: mail.message
 mass_mailing / mailing.mailing          / message_main_attachment_id (many2one): NEW relation: ir.attachment
-mass_mailing / mailing.mailing          / subject (char)                : NEW required
 mass_mailing / mailing.mailing          / unique_ab_testing (boolean)   : NEW hasdefault
 mass_mailing / mailing.trace            / failure_type (selection)      : NEW selection_keys: ['BOUNCE', 'RECIPIENT', 'SMTP', 'UNKNOWN']
 mass_mailing / mailing.trace            / trace_type (selection)        : NEW required, selection_keys: ['mail'], req_default: function, hasdefault
 # NOTHING TO DO: New features
+
+mass_mailing / mailing.mailing          / subject (char)                : NEW required
+# DONE: pre-migration: Put utm.source.name content and copy translations
 
 mass_mailing / mail.mass_mailing.campaign / _inherits (False)             : DEL
 mass_mailing / mail.mass_mailing.campaign / campaign_id (many2one)        : DEL relation: utm.campaign, required


### PR DESCRIPTION
In v12, the related utm.source.name was used as subject. Now they are 2 different fields, and we need to fill the new one with the
content of the previous one.

@Tecnativa TT28794