### PR TITLE
[13.0][OU-ADD] website_sale_category_description: Merged in website_sale

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -46,6 +46,8 @@ merged_modules = {
     'account_move_chatter': 'account',
     # OCA/account-reconcile
     'account_set_reconcilable': 'account',
+    # OCA/e-commerce
+    'website_sale_category_description': 'website_sale',
     # OCA/event
     'website_event_share': 'website_event',
     # OCA/l10n-spain


### PR DESCRIPTION
It was designed in v12 to match v13 DB schema and feature:

- Field `website_description` at `product.public.category` level.
- QWeb template showing the field at the top.

So we can merge it comfortably.

@Tecnativa TT27879