### PR TITLE
[13.0][ADD] stock_picking_report_custom_description: Merged on stock

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -63,6 +63,8 @@ merged_modules = {
     # OCA/social
     'mail_history': 'mail',
     'mass_mailing_unique': 'mass_mailing',
+    # OCA/stock-logistics-reporting
+    'stock_picking_report_custom_description': 'stock',
     # OCA/stock-logistics-warehouse
     'sale_stock_info_popup': 'sale_stock',
     # OCA/timesheet


### PR DESCRIPTION
cc @Tecnativa TT22092

As said on this PR https://github.com/OCA/stock-logistics-reporting/pull/121 this module have no sense to be mantained because what it does is implemented on core version.

Please @carlosdauden @pedrobaeza check it 