### PR TITLE
[13.0][UPD] openupgrade_records: retrocompatibility with upgrade_analysis (v14)

### DIFF
--- a/odoo/addons/openupgrade_records/__manifest__.py
+++ b/odoo/addons/openupgrade_records/__manifest__.py
@@ -17,6 +17,7 @@
         'security/ir.model.access.csv',
     ],
     'installable': True,
+    'depends': ['base'],
     'external_dependencies': {
         'python': ['odoorpc', 'openupgradelib'],
     },


### PR DESCRIPTION
If you try to run an analysis with upgrade_analysis comparing v13 and v14, happens that the noupdata computations break because they don't exist in v13.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr