### PR TITLE
[13.0][FIX] product: Insert missing template attribute/value records

### DIFF
--- a/addons/product/migrations/13.0.1.2/openupgrade_analysis_work.txt
+++ b/addons/product/migrations/13.0.1.2/openupgrade_analysis_work.txt
@@ -73,9 +73,10 @@ product      / product.template         / has_configurable_attributes (boolean):
 
 product      / product.template.attribute.line / active (boolean)              : NEW hasdefault
 product      / product.template.attribute.value / ptav_active (boolean)         : NEW hasdefault
-# NOTHING TO DO: New field that has default, will be automatically filled
+# DONE: pre-migration: Insert missing records for variants with attributes that currently are not on the template definition
 
 product      / product.template.attribute.value / attribute_id (many2one)       : is now stored
+# DONE: pre-migration: added SQL column for avoiding the ORM computation
 # DONE: post-migration: filled field (done in post-migration because it's a related to a new field)
 
 product      / product.template.attribute.line / product_template_value_ids (many2many): is now stored


### PR DESCRIPTION
Given this situation in v12:

- Template T with attribute A and values A1, and A2, and attribute B with value B1.
- Generated variants V1 and V2 for attribute values A1/B1 and A2/B2 respectively.
- Generated product.template.attribute.line records for T/A and T/B.
- V2 is used in a quotation.
- Remove B attribute from the template. Result:
  * V2 is archived
  * product.template.attribute.line T/B is removed.

On v13, the record is not removed, but marked with active = False.

From the current data status we find on v12 for these cases, we need to reintroduce missing product.template.attribute.line records with active = False needed later on next steps for DB integrity.

----

Given this situation in v12:

- Template T with attribute A and values A1, and A2.
- Generated variants V1 and V2 for attribute values A1 and A2 respectively.
- Generated product.template.attribute.value for T/A1 and T/A2.
- V2 is used in a quotation.
- Remove A2 attribute value from the template. Result:
  * V2 is archived
  * product.template.attribute.value T/A2 is removed.

On v13, the record is not removed, but marked with ptav_active = False. That's because there's a field in product.product called combination_indices that stores the ID of such line and serves for quick search/indexing on it.

From the current data status we find on v12 for these cases, we need to reintroduce missing product.template.attribute.value records with ptav_active = False for not having later unique constraint errors and proper DB integrity.

This is also the second step for amending the situation described previously.

@Tecnativa TT19791