### PR TITLE
[13.0][FIX] base: Don't fail uninstalling when missing models

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1962,6 +1962,10 @@ class IrModelData(models.Model):
 
         # remove non-model records first, grouped by batches of the same model
         for model, items in itertools.groupby(records_items, itemgetter(0)):
+            # OpenUpgrade: don't fail on missing models
+            if not self.env.get(model):
+                continue
+            # End OpenUpgrade
             delete(self.env[model].browse(item[1] for item in items))
 
         # Remove copied views. This must happen after removing all records from


### PR DESCRIPTION
If you have a module in previous versions that adds data on a model, and such model is not loaded in the registry in current version because the module is absent in it, you can't uninstall such module, getting this error:

```
  File "odoo/odoo/addons/base/models/ir_model.py", line 1945, in _module_data_uninstall
    delete(self.env[model].browse(item[1] for item in items))
  File "odoo/odoo/api.py", line 463, in __getitem__
    return self.registry[model_name]._browse(self, (), ())
  File "odoo/odoo/modules/registry.py", line 177, in __getitem__
    return self.models[model_name]
KeyError: 'model'
```

With this patch, data cleanup of such model is skipped and there's no crash.

@Tecnativa TT27288