### PR TITLE
[12.0][FIX] account: Don't disable payment term multi-company rule

### DIFF
--- a/addons/account/migrations/12.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/12.0.1.1/openupgrade_analysis_work.txt
@@ -291,9 +291,8 @@ DEL ir.model.access: account.access_account_financial_report_invoice
 # NOTHING TO DO
 
 NEW ir.rule: account.account_payment_term_comp_rule (noupdate)
-# DONE: post-migration: Disabled (active=False) this rule, or when migrating
-# we will get missing payment terms in a multi-company environment
-# (as previously there wasn't a record rule).
+# TODO: There's no payment term company consistency check across documents, so not easy to determine how to act here,
+# so let's not do anything for now
 
 NEW ir.ui.menu: account.account_analytic_group_menu
 NEW ir.ui.menu: account.action_account_reconcile_model_menu

--- a/addons/account/migrations/12.0.1.1/post-migration.py
+++ b/addons/account/migrations/12.0.1.1/post-migration.py
@@ -5,14 +5,6 @@ from openupgradelib import openupgrade
 from psycopg2.extensions import AsIs
 
 
-def disable_account_payment_term_comp_rule(env):
-    # This rule is disabled (active=False), because if not, when migrating
-    # we will get missing payment terms in a multi-company environment
-    # (as previously there wasn't a record rule).
-    payment_rule = env.ref('account.account_payment_term_comp_rule')
-    payment_rule.active = False
-
-
 def map_account_journal_bank_statements_source(cr):
     openupgrade.map_values(
         cr,
@@ -261,7 +253,6 @@ def populate_fiscal_years(env):
 @openupgrade.migrate()
 def migrate(env, version):
     cr = env.cr
-    disable_account_payment_term_comp_rule(env)
     map_account_journal_bank_statements_source(cr)
     map_account_payment_term_line_option(cr)
     map_account_tax_type_tax_use(cr)


### PR DESCRIPTION
This rule is introduced one version after introducing the `company_id` field in `account.payment.term`. At this level, we can have payment terms created for one company, but used in documents of other company, so it doesn't serve to disable the rule for avoiding the mess, and more as in v13, the company consistency is checked per document.

Let's keep the rule enabled and get the yell before going to v13 then.

@Tecnativa TT29056 TT31655