### PR TITLE
[11.0][FIX] stock: global route should have maximum sequence

### DIFF
--- a/addons/stock/migrations/11.0.1.1/post-migration.py
+++ b/addons/stock/migrations/11.0.1.1/post-migration.py
@@ -73,6 +73,7 @@ def create_specific_procurement_rules_from_globals(env):
             "warehouse_ids": [(6, 0, warehouses.ids)],
             "pull_ids": [(6, 0, rules.ids)],
             "push_ids": [(6, 0, paths.ids)],
+            "sequence": 999999999,
         })
 
 


### PR DESCRIPTION
We don't want this route to be the first one being evaluated when searching rules in the common standard logic.

Is 999999999 enough big? In fact, the biggest one should be 2^31-1, but we don't need to put that, right?



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr