### PR TITLE
[13.0][FIX] stock: get correctly boolean value from ir_config_parameter

### DIFF
--- a/addons/stock/migrations/13.0.1.1/post-migration.py
+++ b/addons/stock/migrations/13.0.1.1/post-migration.py
@@ -128,7 +128,7 @@ def fill_propagate_date_minimum_delta(env):
         FROM ir_config_parameter icp
         WHERE sm.propagate_date IS NULL
             AND icp.key = 'stock.use_propagation_minimum_delta'
-            AND icp.value = 'True'"""
+            AND icp.value::boolean"""
     )
     # stock rule
     openupgrade.logged_query(
@@ -146,7 +146,7 @@ def fill_propagate_date_minimum_delta(env):
         FROM ir_config_parameter icp
         WHERE sr.propagate_date IS NULL
             AND icp.key = 'stock.use_propagation_minimum_delta'
-            AND icp.value != 'True'"""
+            AND NOT icp.value::boolean"""
     )
 
 


### PR DESCRIPTION
If the value is '1' or 't' or 'True', or anything like this, should be True. And '0', or 'f', or 'False' should be False.


--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr