### PR TITLE
[13.0][OU-FIX] account: set to zero some null monetary values

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -348,10 +348,9 @@ def migration_invoice_moves(env):
         FROM account_invoice_line ail
             JOIN account_invoice ai ON ail.invoice_id = ai.id AND ai.state IN ('draft', 'cancel')
             LEFT JOIN res_company rc ON ail.company_id = rc.id
-        LEFT JOIN account_move am ON am.old_invoice_id = ai.id
-        LEFT JOIN account_account aa ON ai.account_id = aa.id
-        WHERE am.id IS NOT NULL AND
-            aa.internal_type in ('receivable', 'payable')""",
+        JOIN account_move am ON am.old_invoice_id = ai.id
+        JOIN account_account aa ON ai.account_id = aa.id
+        WHERE aa.internal_type in ('receivable', 'payable')""",
     )
     # Not Draft or Cancel Invoice Taxes
     openupgrade.logged_query(


### PR DESCRIPTION
If we let balance be null in some cases, then errors happen. When accessing partners, the account invoice report is used to compute the invoice totals, and when the price_subtotal for a partner is null we get an error (the balance is used to set the price_subtotal).

NOTE: The method _compute_balance doesn't help in this case because for monetary values, odoo compares previous value with new one to do the write. So if previous was 0.0 and the new one is NULL, then the null converts to 0.0, and then as both are 0.0, thus the write is not done. 

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr