### PR TITLE
[12.0][FIX] project: delete obsolete duplicate_field_xmlid

### DIFF
--- a/addons/project/migrations/12.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/project/migrations/12.0.1.1/openupgrade_analysis_work.txt
@@ -81,6 +81,9 @@ NEW ir.cron: project.ir_cron_rating_project (noupdate)
 DEL ir.cron: rating_project.ir_cron_rating_project
 # DONE: post-migration: put as noupdate
 
+DEL ir.model.data: project.duplicate_field_xmlid (noupdate)
+# DOME: pre-migration: deleted xmlid
+
 NEW ir.model.access: project.access_mail_activity_type_project_manager
 DEL ir.model.access: project.access_account_analytic_account_manager
 DEL ir.model.access: project.access_account_analytic_account_portal

--- a/addons/project/migrations/12.0.1.1/pre-migration.py
+++ b/addons/project/migrations/12.0.1.1/pre-migration.py
@@ -59,3 +59,6 @@ def migrate(env, version):
     openupgrade.set_xml_ids_noupdate_value(
         env, 'project', ['ir_cron_rating_project',
                          'rating_project_request_email_template'], True)
+    openupgrade.delete_records_safely_by_xml_id(
+        env, ['project.duplicate_field_xmlid'],
+    )


### PR DESCRIPTION
This deletion was detected in https://github.com/OCA/OpenUpgrade/commit/a0eae5c92e3fd31619fc63144f1a45f6a8705436, but for some reason, we didn't pay attention to it in that moment.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr