### PR TITLE
[9.0] Merge account_banking_payment_transfer with account_payment_order

### DIFF
--- a/openerp/addons/openupgrade_records/lib/apriori.py
+++ b/openerp/addons/openupgrade_records/lib/apriori.py
@@ -127,6 +127,7 @@ merged_modules = [
     ('sale_documents_comments', 'sale_comment_propagation'),
     # from OCA/bank-payment
     ('account_payment_sale_stock', 'account_payment_sale'),
+    ('account_banking_payment_transfer', 'account_payment_order'),
     # from OCA/website
     ('website_event_register_free', 'website_event'),
     ('website_event_register_free_with_sale', 'website_event_sale'),


### PR DESCRIPTION
Merge account_banking_payment_transfer with account_payment_order like described in: https://github.com/OCA/bank-payment/issues/222




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
