### PR TITLE
[13.0][FIX] stock_account: wrong sign for svl value of out moves

### DIFF
--- a/addons/stock_account/migrations/13.0.1.1/post-migration.py
+++ b/addons/stock_account/migrations/13.0.1.1/post-migration.py
@@ -222,7 +222,7 @@ def generate_stock_valuation_layer(env):
                                 svl_in_index += 1
                     if product.cost_method == 'fifo':
                         svl_vals = _prepare_out_svl_vals(
-                            move, move["product_qty"], move["price_unit"], product)
+                            move, move["product_qty"], -move["price_unit"], product)
                     else:
                         svl_vals = _prepare_out_svl_vals(
                             move, move["product_qty"], previous_price, product)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/33932458/115104362-988d3580-9f60-11eb-8f82-0cf97c63f93c.png)

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
