### PR TITLE
[13.0][FIX] stock_account: unti value of layer out is stored as positive value

### DIFF
--- a/addons/stock_account/migrations/13.0.1.1/post-migration.py
+++ b/addons/stock_account/migrations/13.0.1.1/post-migration.py
@@ -222,7 +222,7 @@ def generate_stock_valuation_layer(env):
                                 svl_in_index += 1
                     if product.cost_method == 'fifo':
                         svl_vals = _prepare_out_svl_vals(
-                            move, move["product_qty"], move["price_unit"], product)
+                            move, move["product_qty"], abs(move["price_unit"]), product)
                     else:
                         svl_vals = _prepare_out_svl_vals(
                             move, move["product_qty"], previous_price, product)


### PR DESCRIPTION
Means to solve https://github.com/OCA/OpenUpgrade/pull/2663

Basically, Odoo stores the unit value for the layer out as positive value. As long the quantity is negative (leaving the company) the resulted total value will be negative.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
