### PR TITLE
[9.0][FIX] Migrate the actions of menu items out of ir.values

### DIFF
--- a/addons/mail/migrations/9.0.1.0/post-migration.py
+++ b/addons/mail/migrations/9.0.1.0/post-migration.py
@@ -149,6 +149,19 @@ def update_mail_channel_uuid(env):
         channel.write({'uuid': uuid.uuid4()})
 
 
+def delete_mail_group_menu(env):
+    """Clean up menus and actions from deprecated model mail.group"""
+    env.cr.execute(
+        """SELECT id FROM ir_ui_menu
+        WHERE mail_group_id IS NOT NULL
+        """)
+    menu_ids = [menu_id for menu_id, in env.cr.fetchall()]
+    for menu in env['ir.ui.menu'].browse(menu_ids):
+        if menu.action:
+            openupgrade.safe_unlink(menu.action)
+        openupgrade.safe_unlink(menu)
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
@@ -220,6 +233,7 @@ def migrate(env, version):
     )
     # update uuids because in the model rename they got the same default uuid
     update_mail_channel_uuid(env)
+    delete_mail_group_menu(env)
     openupgrade.load_data(
         cr, 'mail', 'migrations/9.0.1.0/noupdate_changes.xml',
     )

--- a/openerp/addons/base/migrations/9.0.1.3/post-migration.py
+++ b/openerp/addons/base/migrations/9.0.1.3/post-migration.py
@@ -68,6 +68,25 @@ def assign_view_keys(env):
         view.key = view.xml_id
 
 
+def populate_menu_action(env):
+    """
+    Populate the menu's action reference that was previously stored in
+    ir_values. This fixes noupdate and manually created menu items for which
+    the action is not (re)set when loading their data definition.
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """UPDATE ir_ui_menu ium
+        SET action = iv.value
+        FROM ir_values iv
+        WHERE iv.model = 'ir.ui.menu'
+            AND iv.key = 'action'
+            AND iv.key2 = 'tree_but_open'
+            AND iv.res_id = ium.id
+            AND ium.action IS NULL
+        """)
+
+
 def publish_attachments(env):
     """
     Attachments are only shown to anonymous users if the public flag is set
@@ -100,5 +119,6 @@ def migrate(env, version):
         env.cr, 'base', 'migrations/9.0.1.3/noupdate_changes.xml',
     )
     assign_view_keys(env)
+    populate_menu_action(env)
     publish_attachments(env)
     cleanup_modules_post(env)


### PR DESCRIPTION
Populate the menu's action reference that was previously stored in
ir_values. This fixes noupdate and manually created menu items for which
the action is not (re)set when loading their data definition, most notably
'My Dashboard' from the Dashboard main menu.

Additionally, remove menu items that were created for mail groups, because
these menu items are obsolete after OpenUpgrade 9.0 and, being left without
a parent menu, will clutter the main menu. They were hidden before the
change described above, as their action was not migrated.

Depends on https://github.com/OCA/openupgradelib/pull/235

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
