### PR TITLE
[13.0][FIX] mass_mailing: fill campaign_id in some models

### DIFF
--- a/addons/mass_mailing/migrations/13.0.2.0/openupgrade_analysis_work.txt
+++ b/addons/mass_mailing/migrations/13.0.2.0/openupgrade_analysis_work.txt
@@ -31,7 +31,11 @@ new model mailing.mailing.schedule.date [transient]
 ---Fields in module 'mass_mailing'---
 mass_mailing / link.tracker             / mass_mailing_campaign_id (many2one): DEL relation: mail.mass_mailing.campaign
 mass_mailing / link.tracker.click       / mass_mailing_campaign_id (many2one): DEL relation: mail.mass_mailing.campaign
-# NOTHING TO DO: As the link is linked to a mailing, and this mailing has a campaign, there's no loss of data
+mass_mailing / mail.mass_mailing        / mass_mailing_campaign_id (many2one): DEL relation: mail.mass_mailing.campaign
+mass_mailing / mail.mail.statistics     / mass_mailing_campaign_id (many2one): DEL relation: mail.mass_mailing.campaign
+mass_mailing / mailing.trace            / campaign_id (many2one)        : NEW relation: utm.campaign, isrelated: related, stored
+mass_mailing / mail.mass_mailing.campaign / campaign_id (many2one)        : DEL relation: utm.campaign, required
+# DONE: post-migration: filled campaign_id fields when empty
 
 mass_mailing / link.tracker             / mass_mailing_id (many2one)    : relation is now 'mailing.mailing' ('mail.mass_mailing') [nothing to do]
 mass_mailing / link.tracker.click       / mass_mailing_id (many2one)    : relation is now 'mailing.mailing' ('mail.mass_mailing') [nothing to do]
@@ -55,8 +59,6 @@ mass_mailing / mail.mail                / mailing_trace_ids (one2many)  : NEW re
 mass_mailing / mail.mail                / statistics_ids (one2many)     : DEL relation: mail.mail.statistics
 mass_mailing / mail.mass_mailing        / statistics_ids (one2many)     : DEL relation: mail.mail.statistics
 mass_mailing / mailing.mailing          / mailing_trace_ids (one2many)  : NEW relation: mailing.trace
-mass_mailing / mail.mail.statistics     / mass_mailing_campaign_id (many2one): DEL relation: mail.mass_mailing.campaign
-mass_mailing / mailing.trace            / campaign_id (many2one)        : NEW relation: utm.campaign, isrelated: related, stored
 mass_mailing / mail.mass_mailing.campaign / mass_mailing_ids (one2many)   : DEL relation: mail.mass_mailing
 mass_mailing / utm.campaign             / mailing_mail_ids (one2many)   : NEW relation: mailing.mailing
 # DONE: pre-migration: renamed fields
@@ -95,7 +97,6 @@ mass_mailing / mailing.mailing          / body_arch (html)              : NEW
 # NOTHING TO DO: Content is filled from body_html when editing via UI, and it's only a "transient" field.
 
 mass_mailing / mailing.list             / subscription_ids (one2many)   : NEW relation: mailing.contact.subscription
-mass_mailing / mail.mass_mailing        / mass_mailing_campaign_id (many2one): DEL relation: mail.mass_mailing.campaign
 mass_mailing / mailing.mailing          / activity_ids (one2many)       : NEW relation: mail.activity
 mass_mailing / mailing.mailing          / mailing_type (selection)      : NEW required, selection_keys: ['mail'], req_default: function, hasdefault
 mass_mailing / mailing.mailing          / message_follower_ids (one2many): NEW relation: mail.followers
@@ -110,7 +111,6 @@ mass_mailing / mailing.mailing          / subject (char)                : NEW re
 # DONE: pre-migration: Put utm.source.name content and copy translations
 
 mass_mailing / mail.mass_mailing.campaign / _inherits (False)             : DEL
-mass_mailing / mail.mass_mailing.campaign / campaign_id (many2one)        : DEL relation: utm.campaign, required
 mass_mailing / mail.mass_mailing.campaign / color (integer)               : module is now 'utm' ('mass_mailing')
 mass_mailing / mail.mass_mailing.campaign / medium_id (many2one)          : DEL relation: utm.medium
 mass_mailing / mail.mass_mailing.campaign / source_id (many2one)          : DEL relation: utm.source

--- a/addons/mass_mailing/migrations/13.0.2.0/post-migration.py
+++ b/addons/mass_mailing/migrations/13.0.2.0/post-migration.py
@@ -8,7 +8,20 @@ _unlink_by_xmlid = [
 ]
 
 
+def fill_several_campaign_id(env):
+    tables = ["mailing_mailing", "mailing_trace", "link_tracker", "link_tracker_click"]
+    for table in tables:
+        openupgrade.logged_query(
+            env.cr, """
+            UPDATE {} AS tt
+            SET campaign_id = mmc.campaign_id
+            FROM mail_mass_mailing_campaign mmc
+            WHERE tt.mass_mailing_campaign_id = mmc.id
+                AND tt.campaign_id IS NULL""".format(table))
+
+
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
+    fill_several_campaign_id(env)
     openupgrade.delete_records_safely_by_xml_id(env, _unlink_by_xmlid)
     openupgrade.load_data(env.cr, 'mass_mailing', 'migrations/13.0.2.0/noupdate_changes.xml')

--- a/addons/mass_mailing/migrations/13.0.2.0/pre-migration.py
+++ b/addons/mass_mailing/migrations/13.0.2.0/pre-migration.py
@@ -41,7 +41,6 @@ _table_renames = [
 
 _field_renames = [
     ('link.tracker.click', 'link_tracker_click', 'mail_stat_id', 'mailing_trace_id'),
-    ('mailing.trace', 'mailing_trace', 'mass_mailing_campaign_id', 'campaign_id'),
     ('mail.mail', 'mail_mail', 'statistics_ids', 'mailing_trace_ids'),
     ('utm.campaign', 'utm_campaign', 'mass_mailing_ids', 'mailing_mail_ids'),
     ('mailing.mailing', 'mailing_mailing', 'statistics_ids', 'mailing_trace_ids'),


### PR DESCRIPTION
The model `mail.mass_mailing.campaign` was merged into `utm.campaign`. There were some models that had a many2one field for each of those models (`mass_mailing_campaign_id` and `campaign_id` correspondingly). But can happen in some cases that `campaign_id` was empty but `mass_mailing_campaign_id` was filled, thus we need to fill `campaign_id`. Also there was a wrong field rename related to this issue.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr