### PR TITLE
[10.0][OU-IMP] Reuse the rescued expense sheets from Odoo 8.0

### DIFF
--- a/addons/mrp/migrations/10.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/10.0.2.0/post-migration.py
@@ -18,9 +18,11 @@ def populate_stock_move_quantity_done_store(cr):
         """
     )
 
+
 def populate_stock_move_lots(cr):
     # Raw materials with tracking:
-    openupgrade.logged_query(cr,
+    openupgrade.logged_query(
+        cr,
         """
         INSERT INTO
           stock_move_lots (
@@ -56,7 +58,8 @@ def populate_stock_move_lots(cr):
         """ % openupgrade.get_legacy_name("consumed_for")
     )
     # Finished products with tracking:
-    openupgrade.logged_query(cr,
+    openupgrade.logged_query(
+        cr,
         """
         INSERT INTO
           stock_move_lots (


### PR DESCRIPTION
The sheets where already preserved in https://github.com/OCA/OpenUpgrade/pull/2327, but new sheets were still created for the related expenses.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
