### PR TITLE
[13.0][FIX] stock_account: don't fetch price_history for 'fifo'

### DIFF
--- a/addons/stock_account/migrations/13.0.1.1/post-migration.py
+++ b/addons/stock_account/migrations/13.0.1.1/post-migration.py
@@ -163,7 +163,9 @@ def generate_stock_valuation_layer(env):
     all_svl_list = []
     for product in products:
         for company in companies:
-            history_lines = get_product_price_history(env, company.id, product.id)
+            history_lines = []
+            if product.cost_method != "fifo":
+                history_lines = get_product_price_history(env, company.id, product.id)
             moves = get_stock_moves(env, company.id, product.id)
             svl_in_vals_list = []
             svl_out_vals_list = []


### PR DESCRIPTION
Because if the cost_method is "fifo", then the `history_lines` is not used, and it's a waste of time calculating something that is not used.



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr