### PR TITLE
[14.0][OU-ADD] stock_inventory_include_exhausted: Merged stock_inventory_include_exhausted to stock

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -30,6 +30,8 @@ merged_modules = {
     "website_theme_install": "website",
     # OCA/partner-contact
     "partner_bank_active": "base",
+    # OCA/stock-logistics-warehouse
+    "stock_inventory_include_exhausted": "stock",
     # OCA/...
 }
 


### PR DESCRIPTION
Merged `stock_inventory_include_exhausted` to `stock` according to https://github.com/OCA/stock-logistics-warehouse/pull/1103

@Tecnativa TT28606