### PR TITLE
[13.0][FIX]stock_account: prevent empty layers to be created

### DIFF
--- a/addons/stock_account/migrations/13.0.1.1/post-migration.py
+++ b/addons/stock_account/migrations/13.0.1.1/post-migration.py
@@ -217,10 +217,12 @@ def generate_stock_valuation_layer(env):
                                     candidate_cost * svl_in_vals_list[svl_in_index]["remaining_qty"],
                                     precision_digits=precision_price)
                                 qty = 0
-                            else:
+                            elif svl_in_vals_list[svl_in_index]["remaining_qty"]:
                                 qty -= svl_in_vals_list[svl_in_index]["remaining_qty"]
                                 svl_in_vals_list[svl_in_index]["remaining_qty"] = 0.0
                                 svl_in_vals_list[svl_in_index]["remaining_value"] = 0.0
+                                svl_in_index += 1
+                            else:
                                 svl_in_index += 1
                     if product.cost_method == 'fifo':
                         svl_vals = _prepare_out_svl_vals(

--- a/addons/stock_account/migrations/13.0.1.1/post-migration.py
+++ b/addons/stock_account/migrations/13.0.1.1/post-migration.py
@@ -161,8 +161,9 @@ def generate_stock_valuation_layer(env):
     companies = company_obj.search([])
     products = product_obj.with_context(active_test=False).search([("type", "in", ("product", "consu"))])
     all_svl_list = []
-    for product in products:
-        for company in companies:
+    for company in companies:
+        _logger.info("Doing svl for company_id {}".format(company.id))
+        for product in products:
             history_lines = []
             if product.cost_method != "fifo":
                 history_lines = get_product_price_history(env, company.id, product.id)


### PR DESCRIPTION
For some reason it is possible to have qty zero in incoming layers.
```

This prevents:
devel=# SELECT count(*) from stock_valuation_layer WHERE quantity = 0.0;
 count 
-------
     8
(1 row)
```


@MiquelRForgeFlow 