### PR TITLE
[13.0][OU-FIX] delivery: invoice_policy should be 'estimated' instead

### DIFF
--- a/addons/delivery/migrations/13.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/delivery/migrations/13.0.1.0/openupgrade_analysis_work.txt
@@ -8,16 +8,14 @@ delivery     / delivery.carrier         / return_label_on_delivery (boolean): NE
 # NOTHING TO DO: New feature for allowing to print the return label. Default False value is OK for preserving previous behavior (no return label).
 
 delivery     / delivery.carrier         / invoice_policy (selection)    : NEW required, selection_keys: ['estimated', 'real'], req_default: function, hasdefault
-# DONE: post-migration: Fill all delivery.carrier records to have `real` value in invoice_policy, as this is the most similar one to the v12 behavior
+delivery     / sale.order               / invoice_shipping_on_delivery (boolean): DEL
+# DONE: post-migration: Set delivery.carrier.invoice_policy to 'real' only if invoice_shipping_on_delivery was True. Records by default should have `estimated` value in invoice_policy, as this is the most similar one to the v12 behavior (just compare _create_delivery_line method)
 
 delivery     / delivery.carrier         / margin (integer)              : type is now 'float' ('integer')
 # NOTHING TO DO: ORM/PG does the switch automatically
 
 delivery     / sale.order               / delivery_price (float)        : DEL
 # NOTHING TO DO: There's no carrier selection now in sale.order, only via wizard, so no computed price is shown in header
-
-delivery     / sale.order               / invoice_shipping_on_delivery (boolean): DEL
-# NOTHING TO DO: The control for adding delivery line on picking is done with delivery.carrier.invoice_policy
 
 delivery     / sale.order               / recompute_delivery_price (boolean): NEW
 # DONE: post-migration: marked as True if it has carrier and still quotation, for having the button "Update shipping cost" as highlighted

--- a/addons/delivery/migrations/13.0.1.0/post-migration.py
+++ b/addons/delivery/migrations/13.0.1.0/post-migration.py
@@ -3,12 +3,23 @@
 from openupgradelib import openupgrade
 
 
-def fill_delivery_carrier_invoice_policy(env):
-    """Fill all delivery.carrier records to have `real` value in invoice_policy,
-    as this is the most similar one to the v12 behavior.
+def update_delivery_carrier_invoice_policy(env):
+    """Update delivery.carrier records to have `real` value in invoice_policy
+    only if all its sale orders have invoice_shipping_on_delivery = True.
     """
     openupgrade.logged_query(
-        env.cr, "UPDATE delivery_carrier SET invoice_policy = 'real'"
+        env.cr, """
+        WITH carriers_to_real AS (
+            SELECT dc.id
+            FROM sale_order so
+            JOIN delivery_carrier dc ON so.carrier_id = dc.id
+            GROUP by dc.id
+            HAVING bool_and(so.invoice_shipping_on_delivery)
+        )
+        UPDATE delivery_carrier dc
+        SET invoice_policy = 'real'
+        FROM carriers_to_real
+        WHERE carriers_to_real.id = dc.id"""
     )
 
 
@@ -24,7 +35,7 @@ def fill_sale_order_recompute_delivery_price(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
-    fill_delivery_carrier_invoice_policy(env)
+    update_delivery_carrier_invoice_policy(env)
     fill_sale_order_recompute_delivery_price(env)
     openupgrade.load_data(
         env.cr, "delivery", "migrations/13.0.1.0/noupdate_changes.xml")


### PR DESCRIPTION
The `_create_delivery_line` method of sale.order (in delivery module) in v12 was using the unit_price, so it was as if the v13 invoice_policy was 'estimated'.

v12:

```python
values = {
            'order_id': self.id,
            'name': so_description,
            'product_uom_qty': 1,
            'product_uom': carrier.product_id.uom_id.id,
            'product_id': carrier.product_id.id,
            'price_unit': price_unit,
            'tax_id': [(6, 0, taxes_ids)],
            'is_delivery': True,
        }
```

v13:
```python
        values = {
            'order_id': self.id,
            'name': so_description,
            'product_uom_qty': 1,
            'product_uom': carrier.product_id.uom_id.id,
            'product_id': carrier.product_id.id,
            'tax_id': [(6, 0, taxes_ids)],
            'is_delivery': True,
        }
        if carrier.invoice_policy == 'real':
            values['price_unit'] = 0
            values['name'] += _(' (Estimated Cost: %s )') % self._format_currency_amount(price_unit)
        else:
            values['price_unit'] = price_unit
```



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr