### PR TITLE
update to v12 l10n-brazil module layout

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -33,6 +33,10 @@ renamed_modules = {
     'stock_pack_operation_auto_fill': 'stock_move_line_auto_fill',
     # OCA/web
     'web_advanced_filters': 'web_advanced_filter',
+    # OCA/l10n-brazil
+    'l10n_br_account_payment': 'l10n_br_account_payment_order',
+    'l10n_br_account_product': 'l10n_br_fiscal',
+    'l10n_br_data_account_product': 'l10n_br_nfe_account'
 }
 
 merged_modules = {
@@ -90,6 +94,13 @@ merged_modules = {
     'web_sheet_full_width': 'web_responsive',
     # OCA/website
     'website_form_metadata': 'website_form',
+    # OCA/l10n-brazil
+    'l10n_br_account_banking_payment': 'l10n_br_account_payment_order',
+    'l10n_br_account_product_service': 'l10n_br_fiscal',
+    'l10n_br_data_account': 'l10n_br_fiscal',
+    'l10n_br_sale_product': 'l10n_br_sale',
+    'l10n_br_data_account_service': 'l10n_br_fiscal',
+    'l10n_br_zip_correios': 'l10n_br_zip',
 }
 
 # only used here for openupgrade_records analysis:


### PR DESCRIPTION
Hello, from v7 to v10 the OCA/l10n-brazil kept roughly the same module layout, addressing only the electromic invoice document. In v12 however, while aiming at full fiscal documents support, we extracted an independent l10n_br_fiscal module encapsulating most of the fiscal logic out from the former e-invoicing l10n_br_account_product and a few other modules got renamed or merged. So far this what we are using as the apriori.py file when migrating customers from v10 to v12. Pretty much production battle tested already.

While this merge can be done safely no matter what, it's worth mentionning I recently pushed our latest OpenUpgrade script  for migrating OCA/l10n-brazil from v10 to v12:
https://github.com/OCA/l10n-brazil/pull/1101
https://github.com/OCA/l10n-brazil/pull/1353
https://github.com/OCA/l10n-brazil/pull/1354

cc @renatonlima @marcelsavegnago @mileo 




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
