### PR TITLE
[13.0][FIX] base: Don't rename category if hierarchy exists

### DIFF
--- a/odoo/addons/base/migrations/13.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/13.0.1.3/pre-migration.py
@@ -760,6 +760,15 @@ def rename_ir_module_category(env):
         old_row = env.cr.fetchone()
         if old_row:
             if new_row:
+                query = "SELECT parent_id FROM ir_module_category WHERE id = %s"
+                env.cr.execute(query, (new_row[0], ))
+                new_parent_row = env.cr.fetchone()
+                if new_parent_row and new_parent_row[0] == old_row[0]:
+                    # When we already have recursive categories with same name
+                    # (example: Manufacturing/Manufacturing), doing a merge let
+                    # the akward situation where the parent points to itself,
+                    # so we avoid it checking this condition
+                    continue
                 openupgrade_merge_records.merge_records(
                     env, "ir.module.category", [old_row[0]], new_row[0],
                     method="sql", model_table="ir_module_category")


### PR DESCRIPTION
Coming from previous versions, you can already have `Manufacturing/Manufacturing` in module category, and with current
renaming scheme, the parent category is merged in the child, but the parent_id field points then to itself.

We avoid the problem not doing anything in this case.

@Tecnativa TT28427