### PR TITLE
[13.0][FIX] account: use old customer/supplier fields for ranks

### DIFF
--- a/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt
@@ -550,7 +550,7 @@ account      / res.users                / invoice_ids (one2many)        : relati
 account      / res.partner              / customer_rank (integer)       : NEW hasdefault
 account      / res.partner              / supplier_rank (integer)       : NEW hasdefault
 # DONE: pre-migration: precreated columns with default
-# DONE: post-migration: refilled
+# DONE: post-migration: refilled using heuristic and also using old customer/supplier fields
 
 account_voucher / account.voucher          / account_date (date)           : DEL
 account_voucher / account.voucher          / account_id (many2one)         : DEL relation: account.account, required

--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -650,6 +650,13 @@ def fill_res_partner_ranks(env):
             GROUP BY am.partner_id) rel
         WHERE rel.partner_id = rp.id""",
     )
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE res_partner rp
+        SET customer_rank = 1
+        WHERE rp.customer_rank = 0 AND rp.{}""".format(
+            openupgrade.get_legacy_name("customer")),
+    )
     # supplier_rank
     openupgrade.logged_query(
         env.cr, """
@@ -662,6 +669,13 @@ def fill_res_partner_ranks(env):
                 am.partner_id IS NOT NULL
             GROUP BY am.partner_id) rel
         WHERE rel.partner_id = rp.id""",
+    )
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE res_partner rp
+        SET supplier_rank = 1
+        WHERE rp.supplier_rank = 0 AND rp.{}""".format(
+            openupgrade.get_legacy_name("supplier")),
     )
 
 


### PR DESCRIPTION
If in v12 some partners were flagged as customer or supplier but they were not in any move line, then they will have a customer_rank/supplier_rank = 0, which is not expected.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr