### PR TITLE
[13.0][IMP] account: null zip range fiscal position

### DIFF
--- a/addons/account/migrations/13.0.1.1/pre-migration.py
+++ b/addons/account/migrations/13.0.1.1/pre-migration.py
@@ -71,8 +71,7 @@ def type_change_account_fiscal_position_zips(env):
             env.cr,
             "UPDATE %(table)s "
             "SET zip_from = NULL, zip_to = NULL "
-            "WHERE country_id IS NOT NULL AND zip_from = '0' "
-            "AND zip_to = '0'" % {
+            "WHERE zip_from = '0' AND zip_to = '0'" % {
                 'table': table,
             })
 


### PR DESCRIPTION
Oversight. As the field goes from `int` to `char`, the case of `country_id IS NULL` also gets affected.

Fine-tuning of https://github.com/OCA/OpenUpgrade/pull/2601.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr