### PR TITLE
[11.0][OU-FIX] mrp: fix wrong creation of stock move lines

### DIFF
--- a/addons/mrp/migrations/11.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/11.0.2.0/post-migration.py
@@ -100,7 +100,7 @@ def create_stock_move_lines_from_stock_move_lots(env):
         )
         SELECT %(select)s
         FROM %(from)s
-        WHERE sm.state NOT IN ('cancel', 'confirmed')
+        WHERE sm.state NOT IN ('cancel', 'confirmed', 'waiting')
             AND sm.id NOT IN (SELECT sq.reservation_id
                               FROM stock_quant sq
                               WHERE sq.reservation_id IS NOT NULL)
@@ -148,7 +148,7 @@ def create_stock_move_lines_from_stock_move_lots(env):
             sml.workorder_id"""
     from_ = """stock_move sm
         INNER JOIN mrp_production mp ON sm.production_id = mp.id
-        LEFT JOIN stock_move_lots sml ON sml.move_id = sm.id
+        INNER JOIN stock_move_lots sml ON sml.move_id = sm.id
         LEFT JOIN stock_production_lot spl ON sml.lot_id = spl.id"""
     openupgrade.logged_query(
         env.cr, """


### PR DESCRIPTION
In V10, when the stock moves in a manufacturing order are assigned, stock move lots are always created for them (https://github.com/OCA/OpenUpgrade/blob/10.0/addons/mrp/models/stock_move.py#L140).

However, these stock move lots are only linked to a stock production lot if the quants are related to one (https://github.com/OCA/OpenUpgrade/blob/10.0/addons/mrp/models/stock_move.py#L174).

Currently, the migration script is inserting lines for stock moves in manufacturing orders that don't have a stock production lot related, which does not make sense as the stock move lots are not related to a lot. We should prevent considering these stock moves when no lots are used by taking only the ones related to one.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
