### PR TITLE
[11.0][OU-FIX] mrp: fix wrong creation of stock move lines #2737

### DIFF
--- a/addons/mrp/migrations/11.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/11.0.2.0/post-migration.py
@@ -148,7 +148,7 @@ def create_stock_move_lines_from_stock_move_lots(env):
             sml.workorder_id"""
     from_ = """stock_move sm
         INNER JOIN mrp_production mp ON sm.production_id = mp.id
-        INNER JOIN stock_move_lots sml ON sml.move_id = sm.id
+        LEFT JOIN stock_move_lots sml ON sml.move_id = sm.id
         LEFT JOIN stock_production_lot spl ON sml.lot_id = spl.id"""
     openupgrade.logged_query(
         env.cr, """
@@ -157,7 +157,7 @@ def create_stock_move_lines_from_stock_move_lots(env):
         SELECT %(select)s
         FROM %(from)s
         WHERE sm.state NOT IN ('cancel') AND (sml.lot_id IS NOT NULL OR
-            sm.state NOT IN ('confirmed'))
+            sm.state = 'done')
             AND sm.id NOT IN (SELECT sq.reservation_id
                               FROM stock_quant sq
                               WHERE sq.reservation_id IS NOT NULL)


### PR DESCRIPTION
In the fix in #2737 I oversee that for finished moves the stock move lots are only created when the product has some form of tracking (https://github.com/OCA/OpenUpgrade/blob/10.0/addons/mrp/wizard/mrp_product_produce.py#L105), which is weird as it does not perform this distinction with raw moves (https://github.com/OCA/OpenUpgrade/blob/10.0/addons/mrp/models/stock_move.py#L163).

With the previous fix, for products that do not have tracking the stock move lines for finished moves are not generated. However, in these cases, the stock move lines should only be created when the move has been done.




--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
