### PR TITLE
[9.0][IMP] account type mapping logging and consistency

### DIFF
--- a/addons/account/migrations/9.0.1.1/noupdate_changes.xml
+++ b/addons/account/migrations/9.0.1.1/noupdate_changes.xml
@@ -72,5 +72,14 @@
       <field name="note">Payment term: 30 Net Days</field>
       <field name="line_ids" eval="[(5, ), (0, 0, {'value': 'balance', 'value_amount': 0.0, 'sequence': 500, 'days': 30, 'option': 'day_after_invoice_date'})]"/>
     </record>
+    <record model="account.account.type" id="data_account_type_liquidity">
+        <field name="name">Bank and Cash</field>
+    </record>
+    <record model="account.account.type" id="data_account_type_current_assets">
+        <field name="name">Current Assets</field>
+    </record>
+    <record model="account.account.type" id="data_account_type_current_liabilities">
+        <field name="name">Current Liabilities</field>
+    </record>
   </data>
 </openerp>


### PR DESCRIPTION
In Odoo 8.0, account.account's `type` is configurable separate from `user_type` (referring to account.account.type). After 9.0, the `type` field (renamed to internal_type) is a stored, related field on the `user_type_id.type`.

The existing migration code will group accounts by their type and assign them to existing types, or create new account types if necessary. It may be a matter of opinion, but the creation of account types should probably be avoided it as it leads to problems later on where account types not defined in any module are not assigned an internal group in 12.0 so that they are misconfigured for reporting, and in other reports and modules it is assumed that there is no variation in the set of account types at all across different Odoo installations. This is why I propose to log the creation of these account types with some severity.

I also noticed that in some (most) cases the original account type defined in account's data gets assigned the non-standard type and the copied account type gets the original type, leading to even more problems. That is fixed by taking the standard type into account when mapping accounts to types.

Because the account types were managed in the code, their noupdate data is not reloaded in the migration. I propose to load their names so that migrated databases will have a 'Bank and Cash' type and not just a 'Bank' type after the migration.
