### PR TITLE
[9.0][IMP] migrate bic numbers

### DIFF
--- a/addons/account/migrations/9.0.1.1/pre-migration.py
+++ b/addons/account/migrations/9.0.1.1/pre-migration.py
@@ -370,6 +370,41 @@ def set_date_maturity(env):
     )
 
 
+def migrate_bic_numbers(env):
+    """ BIC numbers migrated in supplier bank details """
+    # if no bank exists with a matching BIC, automatically create a new bank, with the new BIC;
+    # if the bank account details do not specify the bank name, use the BIC as bank name.
+    openupgrade.logged_query(
+        env.cr, """
+        WITH banks AS (
+            SELECT ARRAY_AGG(bank_name order by bank_name is null) AS names, bank_bic
+            FROM res_partner_bank
+            WHERE bank_id IS NULL AND bank_bic IS NOT NULL AND bank_bic NOT IN (
+                SELECT bic
+                FROM res_bank
+                WHERE bic IS NOT NULL
+            )
+            GROUP BY bank_bic
+        )
+        INSERT INTO res_bank(name, bic)
+        SELECT COALESCE(names[1], bank_bic), bank_bic FROM banks
+        """
+    )
+    # if a bank object with a matching BIC exists, link the bank account to that bank
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE res_partner_bank rpb
+        SET bank_id = subquery.id
+        FROM (
+            SELECT rb.id, rb.bic
+            FROM res_bank rb
+            WHERE rb.bic IS NOT NULL
+        ) AS subquery
+        WHERE rpb.bank_id IS NULL AND rpb.bank_bic = subquery.bic
+        """
+    )
+
+
 def fast_create(env, settings):
     for setting in settings:
         (table_name, field_name, sql_type, sql_request) = setting
@@ -421,6 +456,7 @@ def migrate(env, version):
     merge_supplier_invoice_refs(env)
     openupgrade.rename_fields(env, field_renames)
     set_date_maturity(env)
+    migrate_bic_numbers(env)
 
     # Fast Create new fields
     fast_create(env, FAST_CREATIONS)


### PR DESCRIPTION
When migrating bank accounts that are not linked to an existing bank, but do include a Bank Name and/or Bank Identifier Code (BIC):

- if a bank with a matching BIC exists, link the bank account to that bank;

- if no bank exists with a matching BIC, automatically create a new bank, with the new BIC; use the BIC as bank name.


NOTE In case of inconsistencies to be fixed manually: some bank accounts have BIC different than the linked bank. To find them:

```SQL
	select rpb.bank_bic, rb.bic, rb.name, rb.id
	from res_partner_bank rpb
	  join res_bank rb on rpb.bank = rb.id
	where rpb.bank_bic <> rb.bic
```
