### PR TITLE
[11.0][FIX] sale_stock: fill sale_id of procurement groups without moves

### DIFF
--- a/addons/sale_stock/migrations/11.0.1.0/pre-migration.py
+++ b/addons/sale_stock/migrations/11.0.1.0/pre-migration.py
@@ -20,8 +20,16 @@ def update_procurement_field_from_sale(env):
         UPDATE procurement_group pg
         SET sale_id = sol.order_id
         FROM stock_move sm
-        INNER JOIN sale_order_line sol ON sm.sale_line_id = sol.id
+        JOIN sale_order_line sol ON sm.sale_line_id = sol.id
         WHERE sm.group_id = pg.id""",
+    )
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE procurement_group pg
+        SET sale_id = sol.order_id
+        FROM procurement_order po
+        JOIN sale_order_line sol ON po.sale_line_id = sol.id
+        WHERE po.group_id = pg.id AND pg.sale_id IS NULL""",
     )
 
 


### PR DESCRIPTION
If some procurement groups don't have linked moves, then happens `sale_id` is not filled. We use old procurement order in those cases.