### PR TITLE
[13.0][OU-IMP] account: Recompute totals for regular entries

### DIFF
--- a/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt
@@ -80,6 +80,7 @@ account      / account.invoice          / amount_total_signed (float)   : DEL
 account      / account.move             / amount_total_signed (float)   : NEW isfunction: function, stored
 # DONE: pre-migration: pre-created
 # DONE: post-migration: mapped
+# DONE: post-migration: Compute them for entry type
 
 account      / account.invoice          / amount_tax (float)            : DEL
 account_voucher / account.voucher          / tax_amount (float)            : DEL


### PR DESCRIPTION
Regular journal entries inform as well the totals, although not being invoices, so we need to recompute them, using the equivalent SQL.

@Tecnativa TT30528