### PR TITLE
[14.0][FIX] mail: small correction in upgrade_analysis_work

### DIFF
--- a/openupgrade_scripts/scripts/mail/14.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/mail/14.0.1.0/upgrade_analysis_work.txt
@@ -10,7 +10,7 @@ new model mail.blacklist.remove [transient]
 
 ---Fields in module 'mail'---
 mail         / ir.ui.view               / type (False)                  : selection_keys is now '['activity', 'calendar', 'form', 'gantt', 'graph', 'kanban', 'pivot', 'qweb', 'search', 'tree']' ('['activity', 'calendar', 'diagram', 'form', 'gantt', 'graph', 'kanban', 'pivot', 'qweb', 'search', 'tree']')
-# NOTHING TO DO: Add new view type diagram
+# NOTHING TO DO: Deleted view type 'diagram' as module web_diagram is removed
 
 mail         / mail.activity            / request_partner_id (many2one) : NEW relation:
 # NOTHING TO DO: New feature only used for now by website_slides (or maybe enterprise) modules, for a kind of tier validation workflow


### PR DESCRIPTION
Diagram view type is not added, is deleted. It came from the module web_diagram which is actually removed in v14
https://github.com/odoo/odoo/pull/36638
