### PR TITLE
[FIX] product: Detect fixed prices correctly

### DIFF
--- a/addons/product/migrations/9.0.1.2/post-migration.py
+++ b/addons/product/migrations/9.0.1.2/post-migration.py
@@ -110,7 +110,7 @@ def update_product_pricelist_item(cr):
         cr,
         "update product_pricelist_item "
         "set compute_price='fixed', fixed_price=price_surcharge "
-        "where compute_price='formula' and price_discount=100 and "
+        "where compute_price='formula' and price_discount=-1 and "
         "price_surcharge > 0 and coalesce(price_min_margin, 0)=0 and "
         "coalesce(price_max_margin, 0)=0"
     )


### PR DESCRIPTION
In v8, the discount is just a float added to `1.0`: https://github.com/OCA/OCB/blob/8.0/addons/product/pricelist.py#L345, so a fixed price is a discount of `-1.0` and no margins