### PR TITLE
[REF] Add maintainers

### DIFF
--- a/openupgrade_framework/__manifest__.py
+++ b/openupgrade_framework/__manifest__.py
@@ -5,6 +5,7 @@
     "summary": """Module to integrate in the server_wide_modules
     option to make upgrades between two major revisions.""",
     "author": "Odoo Community Association (OCA)," " Therp BV, Opener B.V., GRAP",
+    "maintainers": ["legalsylvain", "StefanRijnhart"],
     "website": "https://github.com/OCA/openupgrade",
     "category": "Migration",
     "version": "14.0.1.0.0",

--- a/openupgrade_scripts/__manifest__.py
+++ b/openupgrade_scripts/__manifest__.py
@@ -6,6 +6,7 @@
         and scripts for migrate Odoo SA modules.""",
     "author": "Odoo SA, Odoo Community Association (OCA),"
     " Therp BV, Opener B.V., GRAP",
+    "maintainers": ["MiquelRForgeFlow", "StefanRijnhart", "pedrobaeza"],
     "website": "https://github.com/OCA/openupgrade",
     "category": "Migration",
     "version": "14.0.1.0.0",


### PR DESCRIPTION
Rational : 
- The ocabot has a new feature "Adopt a module", developped by @sbidoul. (Thanks to him !)
- in OpenUgprade 14.0, script and framework are contained in odoo modules, for technical and visibility reasons

So, on each PR against Openupgrade, the "Adopt a module" will be displayed, that makes no sense.

Ref : https://github.com/OCA/OpenUpgrade/pull/2882

Proposing so adding maintainers for both modules.

I proposed : 
- @StefanRijnhart and me for the framework,
- @StefanRijnhart  and @pedrobaeza and @MiquelRForgeFlow for the script.

Feel free to update the list if you are not ok with that.

thanks ! 