### PR TITLE
[13.0][MIG] delivery_carrier_label_ups: Rename to delivery_ups_oca

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -7,6 +7,8 @@ renamed_modules = {
     'crm_reveal': 'crm_iap_lead',
     'document': 'attachment_indexation',
     'payment_ogone': 'payment_ingenico',
+    # OCA/delivery-carrier
+    'delivery_carrier_label_ups': 'delivery_ups_oca',
     # OCA/event
     'website_event_filter_selector': 'website_event_filter_city',
     # OCA/hr


### PR DESCRIPTION
Rename addon, from delivery_carrier_label_ups to delivery_ups_oca.

Related to https://github.com/OCA/delivery-carrier/pull/401

Locked by:
- [x] `delivery_ups_oca` https://github.com/OCA/delivery-carrier/pull/401

Please @pedrobaeza can you review it?

@Tecnativa TT30668