### PR TITLE
[12.0][OUFIX] Don't replace system user on queue.job

### DIFF
--- a/odoo/addons/base/migrations/12.0.1.3/end-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/end-migration.py
@@ -88,7 +88,9 @@ def fork_off_system_user(env):
             AND kcu.column_name IN ('create_uid', 'write_uid')
         """)
     exclude_columns = env.cr.fetchall() + [
-        ('ir_cron', 'user_id'), ('res_groups_users_rel', 'uid'),
+        ('ir_cron', 'user_id'),
+        ('queue_job', 'user_id'),
+        ('res_groups_users_rel', 'uid'),
         ('res_company_users_rel', 'user_id'),
     ]
 


### PR DESCRIPTION
The jobs we created during the migration ran into the company barrier because they were run as the Administrator user instead of the superuser.