### PR TITLE
[REM] remove migration script from net_weight to weight

### DIFF
--- a/addons/product/migrations/9.0.1.2/pre-migration.py
+++ b/addons/product/migrations/9.0.1.2/pre-migration.py
@@ -125,11 +125,3 @@ def migrate(env, version):
     cr.execute(
         "update product_pricelist set active=False where type='purchase'"
     )
-
-    # if weight_net != 0.0 in product_template, override weight
-    # if not, do nothing
-    openupgrade.logged_query(cr, """
-            UPDATE product_template
-            SET weight = weight_net
-            WHERE weight_net != '0.0'
-            """)


### PR DESCRIPTION
the previous migration script was based on bad interpretation of the new unique ``weight`` field.

see https://github.com/OCA/product-attribute/pull/894 for the whole discussion.

CC : @mbcosta, @pedrobaeza 