### PR TITLE
[11.0][OUFIX] Set stock_move.created_purchase_line_id correctly

### DIFF
--- a/addons/mrp/migrations/11.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/11.0.2.0/post-migration.py
@@ -4,6 +4,18 @@ from openupgradelib import openupgrade
 from psycopg2.extensions import AsIs
 
 
+def set_stock_move_created_production_id(cr):
+    """Migrate the created production order to the destination move"""
+    openupgrade.logged_query(
+        cr, """
+        UPDATE stock_move sm
+        SET created_production_id = po.production_id
+        FROM procurement_order po
+        WHERE sm.procurement_id = po.id
+            AND po.production_id IS NOT NULL"""
+    )
+
+
 def fill_mrp_document(cr):
     cr.execute(
         """
@@ -210,6 +222,7 @@ def fill_stock_move_line_consume_rel(cr):
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     cr = env.cr
+    set_stock_move_created_production_id(cr)
     fill_mrp_document(cr)
     create_stock_move_lines_from_stock_move_lots(env)
     update_stock_move_line_production_id(env)

--- a/addons/purchase/migrations/11.0.1.2/post-migration.py
+++ b/addons/purchase/migrations/11.0.1.2/post-migration.py
@@ -13,7 +13,7 @@ def update_procurement_fields(env):
         UPDATE stock_move sm
         SET created_purchase_line_id = po.purchase_line_id
         FROM procurement_order po
-        WHERE sm.procurement_id = po.id
+        WHERE sm.id = po.move_dest_id
             AND po.purchase_line_id IS NOT NULL"""
     )
     # Update new field orderpoint_id at purchase.order.line


### PR DESCRIPTION
The created purchase line needs to be set on the destination move of the procurement, and not on the move that was created for the incoming stock of the purchase order line: https://github.com/odoo/odoo/blob/10.0/addons/purchase/models/purchase.py#L719

Relatedly, also set the created_production_id on the destination move of the procurement.