### PR TITLE
[13.0][FIX] mrp: Always define the correct company for the mrp.unbuild model.

### DIFF
--- a/addons/mrp/migrations/13.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/13.0.2.0/post-migration.py
@@ -152,7 +152,7 @@ def fill_unbuild_company_id(cr):
         SET company_id = mb.company_id
         FROM mrp_bom mb
         WHERE mu.bom_id = mb.id AND mb.company_id IS NOT NULL
-            AND mu.company_id IS NULL"""
+            AND mu.company_id IS DISTINCT FROM mb.company_id"""
     )
     # from stock_move/res_users
     openupgrade.logged_query(


### PR DESCRIPTION
Always define the correct company for the `mrp.unbuild` model.

Please @pedrobaeza can you review it?

@Tecnativa TT31747