### PR TITLE
[FIX] Remove documentation source links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
-docs/_sources/
 docs/.doctrees
 docsource/modules50-60.rst
 docsource/modules60-61.rst

--- a/docsource/conf.py
+++ b/docsource/conf.py
@@ -135,7 +135,10 @@ html_last_updated_fmt = "%b %d, %Y"
 # html_split_index = False
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
-# html_copy_source = True
+html_copy_source = False
+
+# Hide the Page source link in each documentation page's footer.
+html_show_sourcelink = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
Fixes #2871

To make the links work, the copy of the sources that Spinx creates in `docs/_sources` would have to be committed into the branch by the Github workflow. Having this second copy of the sources would be confusing, I think.
