### PR TITLE
[13.0][OU-FIX] payment: Disable test acquirers not published

### DIFF
--- a/addons/payment/migrations/13.0.1.0/pre-migration.py
+++ b/addons/payment/migrations/13.0.1.0/pre-migration.py
@@ -44,6 +44,17 @@ def map_payment_acquirer_state(cr):
             sql.Identifier(openupgrade.get_legacy_name('environment'))
         )
     )
+    openupgrade.logged_query(
+        cr,
+        sql.SQL(
+            """UPDATE payment_acquirer
+            SET state = 'disabled'
+            WHERE NOT {} AND {} = 'test'"""
+        ).format(
+            sql.Identifier(openupgrade.get_legacy_name('website_published')),
+            sql.Identifier(openupgrade.get_legacy_name('environment'))
+        )
+    )
 
 
 @openupgrade.migrate(use_env=True)


### PR DESCRIPTION
On v13, if you have an acquirer in test mode, it will be available in the website, but in such mode.

For respecting the website_published setting of v12, we have to disable the acquirer in this version.

@Tecnativa TT31959