### PR TITLE
[13.0][FIX] delivery: invoice_policy

### DIFF
--- a/addons/delivery/migrations/13.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/delivery/migrations/13.0.1.0/openupgrade_analysis_work.txt
@@ -8,7 +8,7 @@ delivery     / delivery.carrier         / return_label_on_delivery (boolean): NE
 # NOTHING TO DO: New feature for allowing to print the return label. Default False value is OK for preserving previous behavior (no return label).
 
 delivery     / delivery.carrier         / invoice_policy (selection)    : NEW required, selection_keys: ['estimated', 'real'], req_default: function, hasdefault
-# DONE: post-migration: Fill all delivery.carrier records to have `real` value in invoice_policy, as this is the most similar one to the v12 behavior
+# NOTHING TO DO: Default `estimated` value has is the less conflicting one according the new Odoo rules. Users can't choose 'real' on the core standard methods and the behavior change isn't that intuitive.
 
 delivery     / delivery.carrier         / margin (integer)              : type is now 'float' ('integer')
 # NOTHING TO DO: ORM/PG does the switch automatically

--- a/addons/delivery/migrations/13.0.1.0/post-migration.py
+++ b/addons/delivery/migrations/13.0.1.0/post-migration.py
@@ -3,15 +3,6 @@
 from openupgradelib import openupgrade
 
 
-def fill_delivery_carrier_invoice_policy(env):
-    """Fill all delivery.carrier records to have `real` value in invoice_policy,
-    as this is the most similar one to the v12 behavior.
-    """
-    openupgrade.logged_query(
-        env.cr, "UPDATE delivery_carrier SET invoice_policy = 'real'"
-    )
-
-
 def fill_sale_order_recompute_delivery_price(env):
     openupgrade.logged_query(
         env.cr, """
@@ -24,7 +15,6 @@ def fill_sale_order_recompute_delivery_price(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
-    fill_delivery_carrier_invoice_policy(env)
     fill_sale_order_recompute_delivery_price(env)
     openupgrade.load_data(
         env.cr, "delivery", "migrations/13.0.1.0/noupdate_changes.xml")


### PR DESCRIPTION
Odoo changed the behavior of delivery charges from v12 to v13 delegating
the mode check into the new `invoice_policy` field in
`delivery.carrier`.

Initially, it was decided to keep the behavior in v12 that recomputes
the price when the picking is validated, but there's no accurate flow
translation between versions and some issues raise with this default:

- Core UI forbids users changing this value in the standard shipping methods.
  Only extra carriers can choose it and the default `estimated` value
  remains.
- The eCommerce behaves weirdly with "Real cost" methods, leading the
  customers to think that they get free delivery orders.

For that reasons, a sane default must be Estimated cost for the majority
of cases.

cc @Tecnativa TT31975

please review @pedrobaeza @victoralmau 