### PR TITLE
[9.0][FIX] project: Migrated date fields from account.analytic.account to …

### DIFF
--- a/addons/project/migrations/9.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/project/migrations/9.0.1.1/openupgrade_analysis_work.txt
@@ -1,6 +1,6 @@
 ---Fields in module 'project'---
-project      / project.project          / date (date)                   : NEW
-project      / project.project          / date_start (date)             : NEW
+project      / project.project          / date (date)                   : DONE: post-migration: Obtained from analytic account if any.
+project      / project.project          / date_start (date)             : DONE: post-migration: Obtained from analytic account if any.
 project      / project.project          / label_tasks (char)            : NEW
 # New fields ---> Nothing to do
 

--- a/addons/project/migrations/9.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/project/migrations/9.0.1.1/openupgrade_analysis_work.txt
@@ -1,6 +1,7 @@
 ---Fields in module 'project'---
-project      / project.project          / date (date)                   : DONE: post-migration: Obtained from analytic account if any.
-project      / project.project          / date_start (date)             : DONE: post-migration: Obtained from analytic account if any.
+project      / project.project          / date (date)                   : NEW
+project      / project.project          / date_start (date)             : NEW
+# DONE: post-migration: Obtained from analytic account if any.
 project      / project.project          / label_tasks (char)            : NEW
 # New fields ---> Nothing to do
 

--- a/addons/project/migrations/9.0.1.1/post-migration.py
+++ b/addons/project/migrations/9.0.1.1/post-migration.py
@@ -33,6 +33,7 @@ def copy_user_id(cr):
         WHERE a.id = p.analytic_account_id
         """)
 
+
 def copy_dates(cr):
     openupgrade.logged_query(cr, """
         UPDATE project_project p

--- a/addons/project/migrations/9.0.1.1/post-migration.py
+++ b/addons/project/migrations/9.0.1.1/post-migration.py
@@ -33,12 +33,21 @@ def copy_user_id(cr):
         WHERE a.id = p.analytic_account_id
         """)
 
+def copy_dates(cr):
+    openupgrade.logged_query(cr, """
+        UPDATE project_project p
+        SET date = a.date, date_start = a.openupgrade_legacy_9_0_date_start
+        FROM account_analytic_account a
+        WHERE a.id = p.analytic_account_id
+        """)
+
 
 @openupgrade.migrate()
 def migrate(cr, version):
     map_priority(cr)
     map_template_state(cr)
     copy_user_id(cr)
+    copy_dates(cr)
     openupgrade.convert_field_to_html(
         cr, 'project_task', openupgrade.get_legacy_name('description'),
         'description'


### PR DESCRIPTION
…roject.

It seems the date and date_start fields are moved from account.analytic.account  to project.project with 8.0->9.0. However, the values of these fields were never copied. So I updated the post-migration.py script to do this.