### PR TITLE
[13.0][OU-IMP] account: remove fks from obsolete table

### DIFF
--- a/addons/account/migrations/13.0.1.1/pre-migration.py
+++ b/addons/account/migrations/13.0.1.1/pre-migration.py
@@ -309,6 +309,7 @@ def migrate(env, version):
             WHERE key = 'sale.use_sale_note'"""
         )
     openupgrade.rename_models(cr, _model_renames)
+    openupgrade.remove_tables_fks(env.cr, ["account_invoice_payment_rel"])
     openupgrade.rename_tables(cr, _table_renames)
     openupgrade.add_fields(env, _field_adds)
     type_change_account_fiscal_position_zips(env)


### PR DESCRIPTION
In pre-migration, table `account_invoice_payment_rel` is renamed to `old_account_invoice_payment_rel`

Due to https://github.com/OCA/OpenUpgrade/commit/6c4b6cbcf3e0d9cbdaf9ff2a287c29476e40640e.