### PR TITLE
[13.0][OU-FIX] website_slides: categories migration

### DIFF
--- a/addons/website_slides/migrations/13.0.2.0/post-migration.py
+++ b/addons/website_slides/migrations/13.0.2.0/post-migration.py
@@ -63,12 +63,14 @@ def convert_slide_categories(env):
     openupgrade.logged_query(
         env.cr, sql.SQL("""
         INSERT INTO slide_slide (
-            create_date, create_uid, write_date, write_uid, is_category,
-            name, channel_id, old_category_id, sequence, slide_type
+            active, create_date, create_uid, write_date, write_uid, is_category,
+            name, channel_id, old_category_id, sequence, slide_type, is_published,
+            is_preview
         )
         SELECT
-            sc.create_date, sc.create_uid, sc.write_date, sc.write_uid, True,
-            sc.name, sc.channel_id, sc.id, min(ss.sequence) - 1 as sequence, 'document'
+            True, sc.create_date, sc.create_uid, sc.write_date, sc.write_uid, True,
+            sc.name, sc.channel_id, sc.id, min(ss.sequence) - 1 as sequence, 'document',
+            True, True
         FROM slide_slide ss
         JOIN slide_category sc ON sc.id = ss.{category_id}
         WHERE ss.channel_id IN (


### PR DESCRIPTION
The fields `is_preview` and `is_published` are values expected be `True` as default when the category is created. It can be seen how in the `create()` and in the `write()` this is explicitly evaluated as long as in the controller, which is the main way to create categories now. Also, we must ensure that those categories are active. Al should be as the old specific model didn't have the field itself.

cc @Tecnativa TT32244

We should also decide what to do with public slides. In v12, they were public or not. In v13 with the eLearing orientation  they're visible only if:

- They are free previews (field `is_preview` set to `True`)
- The user is subscribed to the channel.

So to translate that from one version to the other we should either:

- Set `is_preview` on (then an ugly `Free preview` badge is shown.
- Autosubscribe public and portal users.

What's would be the better way?