### PR TITLE
[14.0][IMP] openupgrade_framework: avoid AttributeError in view validation

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
@@ -47,7 +47,16 @@ def handle_view_error(
             self.write({"active": False})
 
 
+def _postprocess_view(self, node, model, validate=True, editable=True):
+    """ Don't validate views, handle_view_error is mutted"""
+    return View._postprocess_view._original_method(
+        self, node, model, validate=False, editable=editable
+    )
+
+
 _check_xml._original_method = View._check_xml
 View._check_xml = _check_xml
 handle_view_error._original_method = View.handle_view_error
 View.handle_view_error = handle_view_error
+_postprocess_view._original_method = View._postprocess_view
+View._postprocess_view = _postprocess_view


### PR DESCRIPTION
If corresponding_field is None, we need to avoid the "AttributeError: 'NoneType' object has no attribute 'get'" error.

See https://github.com/odoo/odoo/pull/77739