### PR TITLE
[14.0][FIX] digest: delete not-null constraint

### DIFF
--- a/openupgrade_scripts/scripts/digest/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/digest/14.0.1.1/pre-migration.py
@@ -1,0 +1,8 @@
+# Copyright 2021 ForgeFlow S.L.  <https://www.forgeflow.com>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.lift_constraints(env.cr, "digest_digest", "template_id")

--- a/openupgrade_scripts/scripts/digest/14.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/digest/14.0.1.1/upgrade_analysis_work.txt
@@ -4,6 +4,8 @@ digest       / digest.digest            / periodicity (selection)       : select
 # NOTHING TO DO: New daily option available, but no need to change existing ones.
 
 digest       / digest.digest            / template_id (many2one)        : DEL relation: mail.template, required, req_default: function
+# DONE: pre-migration: delete required constraint
+
 digest       / digest.tip               / name (char)                   : NEW
 # NOTHING TO DO
 


### PR DESCRIPTION
Otherwise when the related mail is removed odoo fails because there's a digest.digest record that still references the old template.

cc @MiquelRForgeFlow @Chanakya-OSI 