### PR TITLE
[13.0][FIX] account: generic journal is required

### DIFF
--- a/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt
@@ -323,7 +323,7 @@ account      / account.move             / reverse_date (date)           : DEL
 
 account      / account.move             / currency_id (many2one)        : not a function anymore
 account      / account.move             / currency_id (many2one)        : now required, req_default: function
-# DONE: post-migration: filled empty cases
+# DONE: pre-migration: filled empty cases and add required constraint
 
 account      / account.move             / matched_percentage (float)    : DEL
 # NOTHING TO DO: obsolete fields, replaced by _get_cash_basis_matched_percentage() method

--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -669,20 +669,6 @@ def fill_account_move_type(env):
     )
 
 
-def fill_account_move_currency_id(env):
-    openupgrade.logged_query(
-        env.cr, """
-        UPDATE account_move am
-        SET currency_id = COALESCE(am_rel.cur1, am_rel.cur2)
-        FROM (SELECT am1.id, aj.currency_id as cur1, rc.currency_id as cur2
-          FROM account_move am1
-          LEFT JOIN account_journal aj ON aj.id = am1.journal_id
-          LEFT JOIN res_company rc ON rc.id = aj.company_id) am_rel
-        WHERE am.id = am_rel.id AND am.currency_id IS NULL
-        """,
-    )
-
-
 def fill_res_partner_ranks(env):
     # customer_rank
     openupgrade.logged_query(
@@ -1070,7 +1056,6 @@ def migrate(env, version):
         migration_voucher_moves(env)
     fill_account_move_reversed_entry_id(env)
     fill_account_move_type(env)
-    fill_account_move_currency_id(env)
     fill_res_partner_ranks(env)
     try_to_fill_account_account_tag_country_id(env)
     create_account_tax_repartition_lines(env)


### PR DESCRIPTION
During the load of the `account` module, the new `journal_id` field of `account.move` model is filled by a default journal of type 'general'. If your company doesn't have any journal of that type, then the following UserError of https://github.com/OCA/OpenUpgrade/blob/13.0/addons/account/models/account_move.py#L70 is blocking.