### PR TITLE
[FIX] dependency to openerp-client-lib

### DIFF
--- a/odoo/addons/openupgrade_records/__manifest__.py
+++ b/odoo/addons/openupgrade_records/__manifest__.py
@@ -18,6 +18,6 @@
     ],
     'installable': True,
     'external_dependencies': {
-        'python': ['openerplib', 'openupgradelib'],
+        'python': ['openerp-client-lib', 'openupgradelib'],
     },
 }


### PR DESCRIPTION
Hi. 

I try to use ``openupgrade_records`` to make diff from 10.0 to 12.0 custom module. 
I can not install the module because the dependency is incorrect.

this patch align the dependency of the module to the requirement of the main project.

see : https://github.com/OCA/OpenUpgrade/blob/10.0/requirements.txt#L18

related PR : #857

thanks.