### PR TITLE
[FIX] 12.0 openupgrade_records : make possible to call oldier version of odoo. (10.0 for instance)

### DIFF
--- a/odoo/addons/openupgrade_records/lib/compare.py
+++ b/odoo/addons/openupgrade_records/lib/compare.py
@@ -57,14 +57,14 @@ def compare_records(dict_old, dict_new, fields):
         elif field == 'model':
             if model_rename_map(dict_old['model']) != dict_new['model']:
                 return False
-        elif field == 'other_prefix':
+        elif field == 'other_prefix' and 'prefix' in dict_old:
             if dict_old['module'] != dict_old['prefix'] or \
                     dict_new['module'] != dict_new['prefix']:
                 return False
             if dict_old['model'] == 'ir.ui.view':
                 # basically, to avoid the assets_backend case
                 return False
-        elif dict_old[field] != dict_new[field]:
+        elif field in dict_old and dict_old[field] != dict_new[field]:
             return False
     return True
 
@@ -116,7 +116,7 @@ def report_generic(new, old, attrs, reprs):
                     text += ', req_default: %s' % new['req_default']
                 fieldprint(old, new, '', text, reprs)
         elif attr == 'stored':
-            if old[attr] != new[attr]:
+            if attr in old and old[attr] != new[attr]:
                 if new['stored']:
                     text = "is now stored"
                 else:
@@ -148,7 +148,7 @@ def report_generic(new, old, attrs, reprs):
                not new.get('isproperty'):
                 text = 'was renamed to %s [nothing to do]' % new['field']
                 fieldprint(old, new, '', text, reprs)
-        elif old[attr] != new[attr]:
+        elif attr in old and old[attr] != new[attr]:
             fieldprint(old, new, attr, '', reprs)
 
 
@@ -232,7 +232,7 @@ def compare_sets(old_records, new_records):
         ]
     for column in old_records:
         # we do not care about removed non stored function fields
-        if not column['stored'] and (
+        if not column.get("stored", True) and (
                 column['isfunction'] or column['isrelated']):
             continue
         if column['mode'] == 'create':
@@ -296,7 +296,8 @@ def compare_xml_sets(old_records, new_records):
                     found['new'] = True
                     column[match_type] = found['module']
                     found[match_type] = column['module']
-                found['domain'] = column['domain'] != found['domain'] and \
+                found['domain'] = 'domain' in column and\
+                    column['domain'] != found['domain'] and \
                     column['domain'] != '[]' and found['domain'] is False
                 column['domain'] = False
                 column['noupdate_switched'] = False

--- a/odoo/addons/openupgrade_records/models/analysis_wizard.py
+++ b/odoo/addons/openupgrade_records/models/analysis_wizard.py
@@ -73,7 +73,7 @@ class AnalysisWizard(models.TransientModel):
         remote_xml_record_ids = remote_record_obj.search(
             [('type', '=', 'xmlid')])
         remote_xml_records = [
-            dict([(field, record[field]) for field in flds])
+            dict([(field, record[field]) for field in flds if field in record])
             for record in remote_record_obj.read(
                 remote_xml_record_ids, flds)
         ]


### PR DESCRIPTION
Hi. 

I'm working on a migration from 10.0 to 12.0. In that context, I'd like to analyze differencies between code regarding custom addons. I so wanted to use ``openupgrade_records`` to generate analysis file. the modules doesn't exist in V11. So I made an old instance with openupgrade 10.0 and a new instance with openupgrade 12.0 (and openupgrade_records installed on both). 
(see : https://oca.github.io/OpenUpgrade/analyse.html)

However, openupgrade_records V12 seems to only work with openupgrade_rercords V11. when calling V10, some fields / data are missing.

this patch make such analysis possible, skipping missing keys to avoid errors. I guess that the final analysis is maybe not the exact one, but it allows to have a good overview of the diff (and so the workload).

What do you think regarding that patch ? do you have similar needs ? In my opinion, the patches don't hurt the current algorigthm.

CC : original author : @StefanRijnhart 

regards.