### PR TITLE
[14.0][FIX] base: assure module category parents are correct

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
@@ -4,7 +4,48 @@
 from openupgradelib import openupgrade
 
 
+def fix_module_category_parent_id(env):
+    # due to renames, we need to correct the parent_id
+    openupgrade.logged_query(
+        env.cr,
+        """
+        WITH wrong AS (
+            SELECT imc.id
+            FROM ir_module_category imc
+            JOIN ir_module_category parent_imc ON parent_imc.id = imc.parent_id
+            JOIN ir_model_data imd ON (
+                imd.module = 'base' AND
+                imd.model = 'ir.module.category' AND imd.res_id = imc.id)
+            JOIN ir_model_data parent_imd ON (
+                parent_imd.model = 'ir.module.category' AND
+                parent_imd.res_id = parent_imc.id)
+            WHERE imd.name NOT LIKE (parent_imd.name || '%')
+        ), to_update AS (
+            SELECT imc.id, max(parent_imd.name) as parent_name
+            FROM wrong imc
+            JOIN ir_model_data imd ON (
+                imd.model = 'ir.module.category' AND imd.res_id = imc.id)
+            LEFT JOIN ir_model_data parent_imd ON (
+                parent_imd.module = 'base' AND
+                parent_imd.model = 'ir.module.category' AND
+                parent_imd.id != imd.id AND
+                parent_imd.name != 'module_category_' AND
+                imd.name LIKE (parent_imd.name || '%'))
+            LEFT JOIN ir_module_category parent_imc ON parent_imd.res_id = parent_imc.id
+            GROUP BY imc.id
+        )
+        UPDATE ir_module_category imc
+        SET parent_id = parent_imd.res_id
+        FROM to_update
+        LEFT JOIN ir_model_data parent_imd ON (
+            parent_imd.model = 'ir.module.category' AND
+            parent_imd.name = to_update.parent_name)
+        WHERE to_update.id = imc.id""",
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    fix_module_category_parent_id(env)
     # Load noupdate changes
     openupgrade.load_data(env.cr, "base", "14.0.1.3/noupdate_changes.xml")

--- a/openupgrade_scripts/scripts/base/14.0.1.3/pre-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/pre-migrate.py
@@ -30,6 +30,10 @@ module_category_xmlid_renames = [
     ),
     ("base.module_category_discuss", "base.module_category_productivity_discuss"),
     (
+        "base.module_category_localization",
+        "base.module_category_accounting_localizations",
+    ),
+    (
         "base.module_category_localization_account_charts",
         "base.module_category_accounting_localizations_account_charts",
     ),
@@ -96,7 +100,7 @@ def migrate(cr, version):
             "recommended to run the Odoo with --load=openupgrade_framework "
             "when migrating your database."
         )
-    # Rename xmlids of module categies with allow_merge
+    # Rename xmlids of module categories with allow_merge
     openupgrade.rename_xmlids(cr, module_category_xmlid_renames, allow_merge=True)
     # Update ir_model_data timestamps from obsolete columns
     openupgrade.logged_query(


### PR DESCRIPTION
In pre-migration, some categories are renamed and thus their parent should also change correspondingly. As ORM don't automatically update the parents, we do it in post-migration.