### PR TITLE
[11.0][FIX] hr_recruitment: Delete the action defined in previous versions.

### DIFF
--- a/addons/hr_recruitment/migrations/11.0.1.0/post-migration.py
+++ b/addons/hr_recruitment/migrations/11.0.1.0/post-migration.py
@@ -32,6 +32,8 @@ def fill_applicant_activities(env):
 @openupgrade.migrate()
 def migrate(env, version):
     fill_applicant_activities(env)
+    # Delete the action defined in previous versions
+    env.ref("hr_recruitment.menu_crm_case_categ0_act_job").action_id = False
     openupgrade.load_data(
         env.cr, 'hr_recruitment', 'migrations/11.0.1.0/noupdate_changes.xml',
     )


### PR DESCRIPTION
Delete the action defined in previous versions.
In v11 Odoo has removed the action from this menu. 
**v11**
https://github.com/odoo/odoo/blob/0eccd3973e056b4ac6fcd6754a8b6af2818aac4f/addons/hr_recruitment/views/hr_recruitment_views.xml#L582-L586

**v10**
https://github.com/odoo/odoo/blob/28c3f51c4878fbcd79b2e819948465fcf2160ebc/addons/hr_recruitment/views/hr_recruitment_views.xml#L549-L552

Please @pedrobaeza can you review it?

@Tecnativa TT33144