### PR TITLE
[IMP] apriori file odoo/account_budget renamed into OCA/account-budgeting/account_budget_oca

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -7,6 +7,8 @@ renamed_modules = {
     'base_vat_autocomplete': 'partner_autocomplete',
     'mrp_repair': 'repair',
     'product_extended': 'mrp_bom_cost',
+    # OCA/account-budgeting
+    'account_budget': 'account_budget_oca',
     # OCA/account-payment
     'account_payment_return_import_sepa_pain': (
         'account_payment_return_import_iso20022'

--- a/odoo/openupgrade/doc/source/modules110-120.rst
+++ b/odoo/openupgrade/doc/source/modules110-120.rst
@@ -31,7 +31,7 @@ missing in the new release are marked with |del|.
 +--------------------------------------------+-------------------------------------------------+
 |account_bank_statement_import               | Nothing to do                                   |
 +--------------------------------------------+-------------------------------------------------+
-| |del| account_budget                       |                                                 |
+| |del| account_budget                       | Replaced by OCA module [#account_budget_oca]_   |
 +--------------------------------------------+-------------------------------------------------+
 |account_cancel                              | Nothing to do                                   |
 +--------------------------------------------+-------------------------------------------------+
@@ -655,6 +655,10 @@ missing in the new release are marked with |del|.
 .. [#account_asset] 'Account Asset' module is replaced by the Odoo Community Association module
     'Account Asset Management' (not exactly the same but does the same):
     See : https://github.com/OCA/account-financial-tools/tree/12.0/account_asset_management
+
+.. [#account_budget_oca] 'Account Budget' module moved into Enterprise Edition and is replaced
+    by the Odoo Community Association module 'Account Budget OCA':
+    See : https://github.com/OCA/account-budgeting/tree/12.0/account_budget_oca
 
 OCA modules
 ===========


### PR DESCRIPTION
Hi.

Currently migrating a database from 10.0 to 12.0 with account_budget (Odoo/odoo) installed on the initial instance.
found OCA/account-budgeting/account_budget_oca module. It seems the same module with minor differences.


CC : @oihane (Ref : https://github.com/OCA/account-budgeting/pull/22)  : do you agree ?

