### PR TITLE
[10.0][FIX] base: Merge records through SQL

### DIFF
--- a/odoo/addons/base/migrations/10.0.1.3/post-migration.py
+++ b/odoo/addons/base/migrations/10.0.1.3/post-migration.py
@@ -44,7 +44,8 @@ def clean_states_with_no_code(env):
                     'phone_code': 'min',
                     'country_group_ids': 'merge',
                     'state_ids': 'merge',
-                }
+                },
+                method="sql",
             )
 
 


### PR DESCRIPTION
On this phase of the upgrade, ORM operations are very limited, as most models are not yet loaded, so we need to perform the merge by SQL for avoiding for example missing m2o replacements if the target model is not yet loaded.

Specific problem where I have found the issue is on `product_instrastat` module that adds a country m2o in `account.invoice`, and this one is not changed and when removing the record, the fk constraint is triggered.

@Tecnativa TT30237