### PR TITLE
[FIX] Avoid relation does not exist error message

### DIFF
--- a/addons/sale_product_matrix/migrations/13.0.1.0/post-migration.py
+++ b/addons/sale_product_matrix/migrations/13.0.1.0/post-migration.py
@@ -13,7 +13,7 @@ def set_product_template_matrix_add_mode(env):
         env.cr,
         """
         UPDATE product_template pt
-        SET pt.product_add_mode = 'matrix'
+        SET product_add_mode = 'matrix'
         WHERE 2 = (
             SELECT COUNT(*)
             FROM product_template_attribute_line ptal


### PR DESCRIPTION
This is not necessary and avoid this message to be thrown on upgrade:
`
ERROR: column "pt" of relation "product_template" does not exist`