### PR TITLE
[13.0][FIX][account]Don't use name from invoice as it doesn't correspond

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -190,7 +190,7 @@ def migration_invoice_moves(env):
         invoice_partner_display_name, invoice_cash_rounding_id, old_invoice_id,
         create_uid, create_date, write_uid, write_date)
         SELECT message_main_attachment_id, access_token,
-        COALESCE(NULLIF(number, ''), NULLIF(move_name, ''), NULLIF(name, ''), '/'),
+        COALESCE(NULLIF(number, ''), NULLIF(move_name, ''), '/'),
         COALESCE(date, date_invoice, write_date),
         CASE WHEN type IN ('in_invoice', 'in_refund') THEN reference ELSE name END,
         CASE WHEN type = 'in_refund' THEN COALESCE(comment, name)


### PR DESCRIPTION
## Module

Account module

## Describe the bug
 
As you can see, the cancel and draft move (ex invoice) have bad names : ![image](https://user-images.githubusercontent.com/1043935/145657913-a7f4ead3-0a1c-4709-b9b1-ea143b0c6eaf.png)

## To Reproduce

migrate from v12 with no validated invoices

**Expected behavior** 

Use '/' as default names for those invoices


FIX #3004