### PR TITLE
[13.0][FIX] product: move product_variant_combination logic from post to pre-migration

### DIFF
--- a/addons/product/migrations/13.0.1.2/openupgrade_analysis_work.txt
+++ b/addons/product/migrations/13.0.1.2/openupgrade_analysis_work.txt
@@ -39,7 +39,7 @@ product      / product.template.attribute.value / ptav_product_variant_ids (many
 product      / product.product          / product_template_attribute_value_ids (many2many): is now stored
 product      / product.product          / product_template_attribute_value_ids (many2many): not a function anymore
 product      / product.product          / product_template_attribute_value_ids (many2many): table is now 'product_variant_combination' ('False')
-# DONE: post-migration: filled table 'product_variant_combination' using the old many2many
+# DONE: pre-migration: created and filled table 'product_variant_combination' using the old relations
 
 product      / product.template         / can_image_1024_be_zoomed (boolean): NEW isfunction: function, stored
 product      / product.product          / can_image_variant_1024_be_zoomed (boolean): NEW isfunction: function, stored

--- a/addons/product/migrations/13.0.1.2/post-migration.py
+++ b/addons/product/migrations/13.0.1.2/post-migration.py
@@ -5,25 +5,6 @@ from openupgradelib import openupgrade
 from odoo.tools import sql
 
 
-def fill_product_variant_combination_table(env):
-    openupgrade.logged_query(
-        env.cr, """
-        INSERT INTO product_variant_combination
-        (product_product_id, product_template_attribute_value_id)
-        SELECT pavppr.product_product_id, ptav.id
-        FROM product_attribute_value_product_product_rel pavppr
-        JOIN product_attribute_value pav
-            ON pav.id = pavppr.product_attribute_value_id
-        JOIN product_product pp
-            ON pp.id = pavppr.product_product_id
-        JOIN product_template_attribute_value ptav
-            ON ptav.product_attribute_value_id = pav.id
-                AND pp.product_tmpl_id = ptav.product_tmpl_id
-                AND ptav.attribute_id = pav.attribute_id
-        GROUP BY pavppr.product_product_id, ptav.id""",
-    )
-
-
 def convert_image_attachments(env):
     mapping = {
         'product.product': "image_variant",
@@ -67,7 +48,6 @@ def empty_template_pricelist_company(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
-    fill_product_variant_combination_table(env)
     openupgrade.load_data(
         env.cr, "product", "migrations/13.0.1.2/noupdate_changes.xml")
     convert_image_attachments(env)


### PR DESCRIPTION
Supersedes https://github.com/OCA/OpenUpgrade/pull/2984.