### PR TITLE
[14.0][OU-FIX] account: Populate properly per company account groups

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
@@ -134,8 +134,7 @@ account      / account.group            / code_prefix_start (char)      : NEW
 # post-migration: assigned same start values to end field
 
 account      / account.group            / company_id (many2one)         : NEW relation: res.company, required, req_default: function, hasdefault
-# DONE: post-migration: assure company is the same as the account.account
-# also duplicate family groups for each company in case of groups shared in accounts spread over several companies
+# DONE: post-migration: Unfold manual groups per company + proper company assignation
 
 account      / account.group.template   / chart_template_id (many2one)  : NEW relation: account.chart.template, required
 account      / account.group.template   / code_prefix_end (char)        : NEW


### PR DESCRIPTION
Previous approach doesn't serve, as current groups populated by localization modules have an XML-ID noupdate=0 that will be tried to be removed on regular update process, leaving main company accounts orphaned of groups. Even further, Odoo expects that the groups populated by the installation of the chart of accounts have a noupdate XML-ID with the scheme `<company_id>_<xmlid_of_the_template_record>`.

With these facts, the approach has been changed to:

* Generate per company account groups with standard population method, as if you were populating them from the CoA template.
* Only unfold and assign proper company for manually created groups.
* Launch the account group computation after of all this.

@Tecnativa TT29943