### PR TITLE
[13.0][OU-FIX] website: Convert favicon

### DIFF
--- a/addons/website/migrations/13.0.1.0/post-migration.py
+++ b/addons/website/migrations/13.0.1.0/post-migration.py
@@ -14,7 +14,18 @@ def _fill_website_logo(env):
         website.logo = website.company_id.logo
 
 
+def _convert_favicon(env):
+    """Version 13 only admits for the favicon ICO files of a size of 256x256, and in
+    fact, it converts any input image to this format. We force then a write of this
+    field to convert existing favicon to the expected format.
+    """
+    env.cr.execute("SELECT id, favicon FROM website WHERE favicon IS NOT NULL")
+    for website_id, favicon in env.cr.fetchall():
+        env["website"].browse(website_id).write({"favicon": favicon.tobytes()})
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     _fill_website_logo(env)
+    _convert_favicon(env)
     openupgrade.load_data(env.cr, 'website', 'migrations/13.0.1.0/noupdate_changes.xml')


### PR DESCRIPTION
Version 13 only admits for the favicon ICO files of a size of 256x256, and in fact, it converts any input image to this format. We force then a write of this field to convert existing favicon to the expected format.

@Tecnativa