### PR TITLE
[13.0][FIX] Ask for unversioned openupgradelib in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,4 @@ xlrd==1.1.0
 pypiwin32 ; sys_platform == 'win32'
 # Needed for OpenUpgrade
 odoorpc==0.7.0
-git+https://github.com/OCA/openupgradelib.git@master
+openupgradelib


### PR DESCRIPTION
Asking for a specific `openupgradelib` version from `master` is very limiting, as installing OpenUpgrade will likely override any different version you might want to have in your environment.

Instead, we should ask for the dependency from a generic version (or, if a minimal version is necessary, use semver standards instead) and allow the user ti install another specific version if needed.

@Tecnativa

ping @pedrobaeza 