### PR TITLE
[14.0][FIX] Ask for unversioned openupgradelib in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-# We allways want to have the latest version of openupgradelib
-# more information : https://github.com/OCA/OpenUpgrade/pull/2194
-git+https://github.com/OCA/openupgradelib.git@master
+openupgradelib


### PR DESCRIPTION
FWP of https://github.com/OCA/OpenUpgrade/pull/3029

Asking for a specific `openupgradelib` version from `master` is very limiting, as installing OpenUpgrade will likely override any different version you might want to have in your environment.

Instead, we should ask for the dependency from a generic version (or, if a minimal version is necessary, use semver standards instead) and allow the user ti install another specific version if needed.

@Tecnativa

ping @pedrobaeza 