### PR TITLE
[10.0][FIX] Ask for unversioned openupgradelib in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ vatnumber==1.2
 vobject==0.9.3
 Werkzeug==0.11.11
 wsgiref==0.1.2
-git+https://github.com/OCA/openupgradelib.git@master
+openupgradelib
 XlsxWriter==0.9.3
 xlwt==1.1.2
 xlrd==1.0.0


### PR DESCRIPTION
Backport of https://github.com/OCA/OpenUpgrade/pull/3029

Asking for a specific `openupgradelib` version from `master` is very limiting, as installing OpenUpgrade will likely override any different version you might want to have in your environment.

Instead, we should ask for the dependency from a generic version (or, if a minimal version is necessary, use semver standards instead) and allow the user ti install another specific version if needed.

@Tecnativa