### PR TITLE
[14.0][FIX] account.partial.reconcile compute missing fields

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -91,13 +91,13 @@ def fill_partial_reconcile_debit_and_credit_amounts(env):
         .filtered(lambda line: line.credit_currency_id != line.debit_currency_id)
     )
     for line in partial_reconcile_lines:
-        line.debit_amount_currency = line.credit_currency_id._convert(
+        line.debit_amount_currency = line.company_currency_id._convert(
             line.amount,
             line.debit_currency_id,
             line.company_id,
             line.credit_move_id.date,
         )
-        line.credit_amount_currency = line.debit_currency_id._convert(
+        line.credit_amount_currency = line.company_currency_id._convert(
             line.amount,
             line.credit_currency_id,
             line.company_id,

--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -68,6 +68,19 @@ def fill_payment_id_and_statement_line_id_fields(env):
     )
 
 
+def fill_partial_reconcile_debit_and_credit_amounts(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_partial_reconcile
+        SET debit_amount_currency = amount, credit_amount_currency = amount
+        WHERE debit_amount_currency IS NULL AND credit_amount_currency is NULL
+            AND credit_currency_id = debit_currency_id
+       """,
+    )
+    # TODO: compute debit and credit amount when currencies are different
+
+
 def create_account_reconcile_model_lines(env):
     openupgrade.logged_query(
         env.cr,
@@ -728,6 +741,7 @@ def migrate(env, version):
     fill_code_prefix_end_field(env)
     fill_default_account_id_field(env)
     fill_payment_id_and_statement_line_id_fields(env)
+    fill_partial_reconcile_debit_and_credit_amounts(env)
     create_account_reconcile_model_lines(env)
     create_account_reconcile_model_template_lines(env)
     create_account_tax_report_lines(env)

--- a/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
@@ -231,7 +231,7 @@ account      / account.move.line        / tax_tag_ids (many2many)       : NEW re
 account      / account.partial.reconcile / amount_currency (float)       : DEL
 account      / account.partial.reconcile / credit_amount_currency (float): NEW
 account      / account.partial.reconcile / debit_amount_currency (float) : NEW
-# PARTIALLY DONE: post-migration set new fields when same currencies. TODO : add script when currencies are different
+# DONE: post-migration set new fields.
 
 account      / account.partial.reconcile / credit_currency_id (many2one) : NEW relation: res.currency, isfunction: function, stored
 account      / account.partial.reconcile / debit_currency_id (many2one)  : NEW relation: res.currency, isfunction: function, stored

--- a/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
@@ -231,7 +231,7 @@ account      / account.move.line        / tax_tag_ids (many2many)       : NEW re
 account      / account.partial.reconcile / amount_currency (float)       : DEL
 account      / account.partial.reconcile / credit_amount_currency (float): NEW
 account      / account.partial.reconcile / debit_amount_currency (float) : NEW
-# NOTHING TO DO
+# PARTIALLY DONE: post-migration set new fields when same currencies. TODO : add script when currencies are different
 
 account      / account.partial.reconcile / credit_currency_id (many2one) : NEW relation: res.currency, isfunction: function, stored
 account      / account.partial.reconcile / debit_currency_id (many2one)  : NEW relation: res.currency, isfunction: function, stored


### PR DESCRIPTION
Compute debit_currency_amount and credit_currency_amount for account.partial.reconcile table.

See #3055 