### PR TITLE
[12.0][ADD] apriori: account_analytic_asset -> account_asset_management

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -60,7 +60,8 @@ merged_modules = {
     # OCA/account-analytic
     # although model is defined in "analytic", logic is in "account"
     'account_analytic_distribution': 'account',
-    'account_asset_analytic': 'account_asset_management',
+    'account_analytic_asset': 'account_asset_management',
+    'account_asset_analytic': 'account_asset_management',  # (from <= v10)
     # OCA/account-financial-reporting
     'customer_activity_statement': 'partner_statement',
     'customer_outstanding_statement': 'partner_statement',


### PR DESCRIPTION
Wrong module name in https://github.com/OCA/OpenUpgrade/commit/d2643fff5e421caeac1e958529ce1a512fd4d57c.

See https://github.com/OCA/account-analytic/tree/11.0.