### PR TITLE
[13.0][FIX] account restrict_mode_hash_table more restrictive

### DIFF
--- a/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/account/migrations/13.0.1.1/openupgrade_analysis_work.txt
@@ -301,7 +301,7 @@ account      / account.journal          / post_at_bank_rec (boolean)    : DEL
 
 account      / account.journal          / update_posted (boolean)       : DEL
 account      / account.journal          / restrict_mode_hash_table (boolean): NEW
-# DONE: post-migration: filled restrict_mode_hash_table reusing update_posted
+# NOTHING TO DO: probably better to leave this field to be set directly after migration (see https://github.com/OCA/OpenUpgrade/pull/3086)
 
 account      / account.journal          / secure_sequence_id (many2one) : NEW relation: ir.sequence
 account      / account.journal          / website_message_ids (one2many): NEW relation: mail.message

--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -86,21 +86,6 @@ def map_account_journal_post_at_bank_rec(env):
     )
 
 
-def fill_account_journal_restrict_mode_hash_table(env):
-    openupgrade.logged_query(
-        env.cr, """
-        UPDATE account_journal
-        SET restrict_mode_hash_table = TRUE
-        WHERE {} != TRUE
-        RETURNING id
-        """.format(openupgrade.get_legacy_name('update_posted'))
-    )
-    ids = [x[0] for x in env.cr.fetchall()]
-    if ids:
-        env['account.journal'].browse(ids)._create_secure_sequence(
-            ['secure_sequence_id'])
-
-
 def archive_account_tax_type_tax_use_adjustment(env):
     openupgrade.logged_query(
         env.cr, """
@@ -1039,7 +1024,6 @@ def migrate(env, version):
     fill_account_fiscal_position_company_id(env)
     fill_account_account_type_internal_group(env)
     map_account_journal_post_at_bank_rec(env)
-    fill_account_journal_restrict_mode_hash_table(env)
     archive_account_tax_type_tax_use_adjustment(env)
     fill_account_journal_invoice_reference_type(env)
     fill_account_move_line_missing_fields(env)


### PR DESCRIPTION
Limit restrict_mode_hash_table to non cash/bank journals since this causes issues afterwards in v14 when bank journals are updated by Odoo during reconciliation (with the use of suspense account until reconciliation)

Also in v14, these fields are not displayed for bank / cash account journal types : https://github.com/odoo/odoo/blob/04396e0627fd36d28b047e0e122ffb55a3a12ebc/addons/account/views/account_journal_views.xml#L105

and you cannot remove this boolean if you have posted moves for this journal afterwards (the only way is to remove it directly in DB), so I feel it would be safer not to set this field at all in migration between v12 and v13