### PR TITLE
[IMP][14.0] install unmet dependencies

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
@@ -4,7 +4,28 @@
 from openupgradelib import openupgrade
 
 
+def install_unmet_dependencies(env):
+    """When changing the dependency of module which is not installed on the target version,
+    this method to install the missing modules to avoid error unmet_dependencies
+    """
+    installed_modules = env['ir.module.module'].search([('state','=','installed')])
+    installed_modules.update_list()
+    modules_to_install = installed_modules.upstream_dependencies(
+        exclude_states=('uninstallable', 'installed', 'to upgrade', 'to remove', 'to install'),
+        )
+
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_module_module
+        SET state='to install'
+        WHERE id in (%s)"""
+        % (", ".join([str(m_id) for m_id in modules_to_install.ids]),)
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    install_unmet_dependencies(env)
     # Load noupdate changes
     openupgrade.load_data(env.cr, "base", "14.0.1.3/noupdate_changes.xml")


### PR DESCRIPTION
When changing the dependency of module which is not installed on the target version, this PR to install the missing modules to avoid error unmet_dependencies

ex.
on 13.0, module A that directly depend on the module B
on 14.0, module A that directly depend on the new module C, which is not installed on 14.0

Current behavior before PR: Unmet dependencies

Expect: To need to install the new module C before running migrations script 
