### PR TITLE
[12.0][OU-FIX] repair: correct xmlid renames

### DIFF
--- a/addons/repair/migrations/12.0.1.0/pre-migration.py
+++ b/addons/repair/migrations/12.0.1.0/pre-migration.py
@@ -20,9 +20,9 @@ _table_renames = [
 ]
 
 xmlid_renames = [
-    ('mrp_repair.mrp_repair_rule', 'repair.repair_rule'),
-    ('mrp_repair.seq_mrp_repair', 'repair.seq_repair'),
-    ('mrp_repair.mail_template_mrp_repair_quotation',
+    ('repair.mrp_repair_rule', 'repair.repair_rule'),
+    ('repair.seq_mrp_repair', 'repair.seq_repair'),
+    ('repair.mail_template_mrp_repair_quotation',
      'repair.mail_template_repair_quotation'),
 ]
 


### PR DESCRIPTION
This happens because the module rename is already done in that step, and the "module" part of the xmlid is already changed.