### PR TITLE
[FIX] account : drop constraint on obsolete table wizard_multi_charts_accounts to avoid not null error

### DIFF
--- a/addons/account/migrations/12.0.1.1/pre-migration.py
+++ b/addons/account/migrations/12.0.1.1/pre-migration.py
@@ -120,6 +120,18 @@ def prefill_account_chart_template_transfer_account_prefix(env):
                 "SET transfer_account_code_prefix = 'OUB'")
 
 
+def drop_obsolete_constraint_wizard_multi_charts_accounts(env):
+    """We remove the constraints on wizard_multi_charts_accounts
+    to avoid not null error if account chart changed and account template has
+    been removed.
+    For exemple l10n_fr.pcg_58 has been removed between 11.0 and 12.0
+    and is used as default transfer_account_id.
+    Note : wizard_multi_charts_accounts is an obsolete table. Model
+    has been removed in V12.0
+    """
+    openupgrade.remove_tables_fks(env.cr, ['wizard_multi_charts_accounts'])
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     cr = env.cr
@@ -143,5 +155,6 @@ def migrate(env, version):
             ALTER TABLE res_company ADD COLUMN incoterm_id INTEGER""",
         )
     prefill_account_chart_template_transfer_account_prefix(env)
+    drop_obsolete_constraint_wizard_multi_charts_accounts(env)
     openupgrade.set_xml_ids_noupdate_value(
         env, 'account', ['account_analytic_line_rule_billing_user'], False)


### PR DESCRIPTION
**rational**
 
- ``wizard_multi_charts_accounts`` exists in V11 and disappeared in V12.
- during migration (11->12) the table still exists with the existing constraint. (``transfer_account_id`` should be not null) [V11 Ref.](https://github.com/odoo/odoo/blob/11.0/addons/account/models/chart_template.py#L697)
- some account.account.template disappeared from 11.0 to 12.0. for instance : ``l10n_fr.pcg_58`` [V12 file](https://github.com/odoo/odoo/blob/12.0/addons/l10n_fr/data/account.account.template.csv#L398). 
-  The template is used as ``transfer_account_id``. here : https://github.com/odoo/odoo/blob/11.0/addons/l10n_fr/data/l10n_fr_chart_data.xml#L17

this patch avoid the following error : 
```
2022-01-18 21:33:43,199 8900 INFO db odoo.addons.base.models.ir_model: Deleting 1@account.account.template (l10n_fr.pcg_58) 
2022-01-18 21:33:43,201 8900 ERROR db odoo.sql_db: bad query: DELETE FROM account_account_template WHERE id IN (1)
ERROR: null value in column "transfer_account_id" violates not-null constraint
DETAIL:  Failing row contains (1, 512, 53, 2021-12-03 00:04:29.997042, 1, 1, f, 1, t, null, 1, 15, 2021-12-03 00:04:29.997042, 15, 6, 1, 1, 11).
CONTEXT:  SQL statement "UPDATE ONLY "public"."wizard_multi_charts_accounts" SET "transfer_account_id" = NULL WHERE $1 OPERATOR(pg_catalog.=) "transfer_account_id""
```