### PR TITLE
[12.0][FIX] mrp: only fill new data pickings pbm_type_id and sam_type_id

### DIFF
--- a/addons/mrp/migrations/12.0.2.0/openupgrade_analysis_work.txt
+++ b/addons/mrp/migrations/12.0.2.0/openupgrade_analysis_work.txt
@@ -58,7 +58,7 @@ mrp          / stock.warehouse          / pbm_type_id (many2one)        : NEW re
 mrp          / stock.warehouse          / sam_loc_id (many2one)         : NEW relation: stock.location
 mrp          / stock.warehouse          / sam_rule_id (many2one)        : NEW relation: stock.rule
 mrp          / stock.warehouse          / sam_type_id (many2one)        : NEW relation: stock.picking.type
-# DONE: post-migration: called the post_init_hook to fill the values
+# DONE: post-migration: call the post_init_hook to fill the values (only if manufacture_to_resupply = True)
 
 ---XML records in module 'mrp'---
 NEW ir.actions.act_window: mrp.action_mrp_unbuild_move_line

--- a/addons/mrp/migrations/12.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/12.0.2.0/post-migration.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Eficent <http://www.eficent.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
-from odoo.addons.mrp import _create_warehouse_data
 
 
 def fill_mrp_workcenter_resource_calendar_id(cr):
@@ -27,13 +26,28 @@ def fill_mrp_workcenter_productivity_loss_loss_id(cr):
 
 
 def fill_stock_warehouse_picking_types(env):
+    def _get_picking_type_update_values(self):
+        data = _get_picking_type_update_values._original_method(self)
+        return {'pbm_type_id': data['pbm_type_id'], 'sam_type_id': data['sam_type_id']}
+
+    # create hook
+    _get_picking_type_update_values._original_method = env['stock.warehouse']._get_picking_type_update_values
+    env['stock.warehouse']._get_picking_type_update_values = _get_picking_type_update_values
+
     # It breaks in purchase_stock if we do this in an end-migration instead.
-    # We need to fill the new pbm_type_id field to assure calling in
+    # We need to fill the new pbm_type_id and sam_type_id fields to assure calling in
     # _create_or_update_global_routes_rules() in other modules doesn't break.
     warehouses = env['stock.warehouse'].with_context(active_test=False).search([])
     for warehouse in warehouses:
         warehouse.write(
             warehouse._create_or_update_sequences_and_picking_types())
+    # do similar to post_init_hook _create_warehouse_data:
+    warehouse_ids = warehouses.filtered(lambda w: w.manufacture_to_resupply and not w.manufacture_pull_id)
+    for warehouse_id in warehouse_ids:
+        warehouse_id.write({'manufacture_to_resupply': True})
+
+    # delete hook
+    env['stock.warehouse']._get_picking_type_update_values = _get_picking_type_update_values._original_method
 
 
 @openupgrade.migrate()
@@ -44,7 +58,6 @@ def migrate(env, version):
         cr, 'mrp', 'migrations/12.0.2.0/noupdate_changes.xml')
     fill_mrp_workcenter_productivity_loss_loss_id(cr)
     fill_stock_warehouse_picking_types(env)
-    _create_warehouse_data(cr, env.registry)
     openupgrade.delete_records_safely_by_xml_id(
         env, [
             'mrp.sequence_mrp_prod',


### PR DESCRIPTION
We should touch the rest of the existing picking types, as clients may have different configurations for them.