### PR TITLE
[13.0][OU-ADD] website_blog_excerpt_img: Merged website_blog_excerpt_img to website.

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -94,6 +94,7 @@ merged_modules = {
     'web_widget_many2many_tags_multi_selection': 'web',
     # OCA/website
     'website_adv_image_optimization': 'website',
+    'website_blog_excerpt_img': 'website',
     'website_canonical_url': 'website',
     'website_form_builder': 'website_form',
     'website_logo': 'website',


### PR DESCRIPTION
Merged `website_blog_excerpt_img` to `website` (according to https://github.com/OCA/website/issues/667#issuecomment-575215149)

@Tecnativa TT34199