### PR TITLE
[13.0][MIG] sale_product_classification: Renamed to product_abc_classification_sale

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -25,6 +25,7 @@ renamed_modules = {
     'quality_control_stock': 'quality_control_stock_oca',
     # OCA/product-attribute
     'product_pricelist_print_website_sale': 'product_pricelist_direct_print_website_sale',
+    'sale_product_classification': 'product_abc_classification_sale',
     # OCA/stock-logistics-warehouse
     'stock_putaway_product_form': 'stock_putaway_product_template',
 }


### PR DESCRIPTION
cc @Tecnativa TT31774

Renaming sale_product_classification to product_abc_classification_sale to use the work done in product_abc_classification

This PR depends of:

- [x] https://github.com/OCA/product-attribute/pull/1015