### PR TITLE
[FIX][14.0] account: process account payment transfer

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
@@ -295,7 +295,8 @@ account      / account.payment          / payment_method_id (many2one)  : now a 
 # NOTHING TO DO
 
 account      / account.payment          / payment_type (selection)      : selection_keys is now '['inbound', 'outbound']' ('['inbound', 'outbound', 'transfer']')
-# TODO: transfer records should be changed to 'inbound' or 'outbound', but if we do that, we should remove two account move lines
+# DONE post-migration: mapped payment_type from 'transfer' to 'inbound'/'outbound' for account payment tranfer
+# created new counterpart payment with account payment transfer
 # (see https://github.com/odoo/odoo/commit/a30cfee04eaf48b581d2e327c1b56e115a1c751f)
 # DONE pre-migration: filled partner_id with journal_id.company_id.partner_id to detect transfers
 


### PR DESCRIPTION
When migrating from Odoo 13.0 to Odoo 14.0, we need:
1. mapping payment_type from 'transfer' to 'inbound'/'outbound' for account payment tranfer, because key `transfer` of `payment_type` is deleted.
So we need set `is_internal_transfer` as `true` on account payment transfer to indicate that it was an account payment transfer 

2. On Odoo 13.0, when validating a account payment transfer, so 2 journal entries is created, equivalent to 1 receipt payment, and 1 send payment on Odoo 14.0
So, on Odoo 14.0, we need create new counterpart payment with account payment transfer