### PR TITLE
[12.0][FIX] mrp: make the hook in migration work

### DIFF
--- a/addons/mrp/migrations/12.0.2.0/post-migration.py
+++ b/addons/mrp/migrations/12.0.2.0/post-migration.py
@@ -28,11 +28,29 @@ def fill_mrp_workcenter_productivity_loss_loss_id(cr):
 def fill_stock_warehouse_picking_types(env):
     def _get_picking_type_update_values(self):
         data = _get_picking_type_update_values._original_method(self)
-        return {'pbm_type_id': data['pbm_type_id'], 'sam_type_id': data['sam_type_id']}
+        data_return = {'pbm_type_id': data['pbm_type_id'], 'sam_type_id': data['sam_type_id']}
+        if self.manufacture_to_resupply and not self.manufacture_pull_id:
+            data_return.update({'manu_type_id': data['manu_type_id']})
+        return data_return
 
-    # create hook
-    _get_picking_type_update_values._original_method = env['stock.warehouse']._get_picking_type_update_values
-    env['stock.warehouse']._get_picking_type_update_values = _get_picking_type_update_values
+    def _get_routes_values(self):
+        data = _get_routes_values._original_method(self)
+        return {'pbm_route_id': data['pbm_route_id']}
+
+    def _get_global_route_rules_values(self):
+        data = _get_global_route_rules_values._original_method(self)
+        data_return = {'pbm_mto_pull_id': data['pbm_mto_pull_id'], 'sam_rule_id': data['sam_rule_id']}
+        if self.manufacture_to_resupply and not self.manufacture_pull_id:
+            data_return.update({'manufacture_pull_id': data['manufacture_pull_id']})
+        return data_return
+
+    # create hooks
+    _get_picking_type_update_values._original_method = type(env['stock.warehouse'])._get_picking_type_update_values
+    type(env['stock.warehouse'])._get_picking_type_update_values = _get_picking_type_update_values
+    _get_routes_values._original_method = type(env['stock.warehouse'])._get_routes_values
+    type(env['stock.warehouse'])._get_routes_values = _get_routes_values
+    _get_global_route_rules_values._original_method = type(env['stock.warehouse'])._get_global_route_rules_values
+    type(env['stock.warehouse'])._get_global_route_rules_values = _get_global_route_rules_values
 
     # It breaks in purchase_stock if we do this in an end-migration instead.
     # We need to fill the new pbm_type_id and sam_type_id fields to assure calling in
@@ -41,13 +59,15 @@ def fill_stock_warehouse_picking_types(env):
     for warehouse in warehouses:
         warehouse.write(
             warehouse._create_or_update_sequences_and_picking_types())
-    # do similar to post_init_hook _create_warehouse_data:
-    warehouse_ids = warehouses.filtered(lambda w: w.manufacture_to_resupply and not w.manufacture_pull_id)
+    # here we do similar to post_init_hook _create_warehouse_data:
+    warehouse_ids = warehouses.filtered(lambda w: w.manufacture_to_resupply)
     for warehouse_id in warehouse_ids:
         warehouse_id.write({'manufacture_to_resupply': True})
 
-    # delete hook
-    env['stock.warehouse']._get_picking_type_update_values = _get_picking_type_update_values._original_method
+    # delete hooks
+    type(env['stock.warehouse'])._get_picking_type_update_values = _get_picking_type_update_values._original_method
+    type(env['stock.warehouse'])._get_routes_values = _get_routes_values._original_method
+    type(env['stock.warehouse'])._get_global_route_rules_values = _get_global_route_rules_values._original_method
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
We needed to use `type()` in order to make the hook work.

After fixing it, then I did a migration where a warehouse didn't have a manufacture_pull_id, thus I realized more hooks were needed. Now it works like a charm.