### PR TITLE
[12.0][REM] l10n_nl: Stop deletion of tag 3b

### DIFF
--- a/addons/l10n_nl/migrations/12.0.3.0/post-migration.py
+++ b/addons/l10n_nl/migrations/12.0.3.0/post-migration.py
@@ -5,8 +5,4 @@ from openupgradelib import openupgrade
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.delete_records_safely_by_xml_id(
-        env, [
-            'l10n_nl.tag_nl_13',
-        ],
-    )
+    openupgrade.set_xml_ids_noupdate_value(env, 'l10n_nl', ['tag_nl_13'], True)


### PR DESCRIPTION
The `l10n_nl` module removes an old tag by xmlid, because in 12.0, it is split into two seperate tags. However, in 13.0, it is back to one tag again. Removing the tag, also removes any link to the tags (in account.tax if I'm not mistaken). That is an issue, because then it becomes impossible to migrate it to 13.0 properly.

There is another issue that causes none of the `l10n_nl` tags to be properly migrate to 13.0, but I've fixed that as well, and will be part of another PR. However, as long as the old tag 3b is deleted, a proper migration of that specific tag is impossible, because any link to it is gone.

Not sure what the reasoning behind removing this old tag was, perhaps it was a way of forcing people to 'fix' their migration by reapplying one of the new 2 different 3b tags manually everywhere.