### PR TITLE
[12.0][FIX] base,sale_management: rename module in rename_models

### DIFF
--- a/addons/sale_management/migrations/12.0.1.0/pre-migration.py
+++ b/addons/sale_management/migrations/12.0.1.0/pre-migration.py
@@ -142,4 +142,6 @@ def migrate(env, version):
         put_in_correct_module(cr, _white_list_fields)
         openupgrade.rename_models(cr, _model_renames)
         openupgrade.rename_tables(cr, _table_renames)
+        for _old, model in _model_renames:
+            openupgrade.update_module_moved_models(cr, model, 'sale_quotation_builder', 'sale_management')
         fill_sale_order_template_line_sections(cr)

--- a/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
@@ -225,9 +225,13 @@ def migrate(env, version):
     if openupgrade.table_exists(env.cr, 'product_uom'):
         openupgrade.rename_models(env.cr, model_renames_product)
         openupgrade.rename_tables(env.cr, table_renames_product)
+        for _old, model in model_renames_product:
+            openupgrade.update_module_moved_models(env.cr, model, 'product', 'uom')
     if openupgrade.table_exists(env.cr, 'stock_incoterms'):
         openupgrade.rename_models(env.cr, model_renames_stock)
         openupgrade.rename_tables(env.cr, table_renames_stock)
+        for _old, model in model_renames_stock:
+            openupgrade.update_module_moved_models(env.cr, model, 'stock', 'account')
     openupgrade.rename_xmlids(env.cr, xmlid_renames)
     switch_noupdate_flag(env)
     eliminate_duplicate_translations(env.cr)


### PR DESCRIPTION
Make us of https://github.com/OCA/openupgradelib/pull/281 to avoid case like:
![Selection_244](https://user-images.githubusercontent.com/25005517/156358979-ba280f12-4f78-4afe-b73b-a1de355ac25b.png)
 