### PR TITLE
[13.0][OU-FIX] base,hr,product,website_slides: Protect image conversion

### DIFF
--- a/addons/hr/migrations/13.0.1.1/post-migration.py
+++ b/addons/hr/migrations/13.0.1.1/post-migration.py
@@ -1,6 +1,10 @@
 # Copyright 2020 Payam Yasaie <https://www.tashilgostar.com>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+import logging
+
+
+_logger = logging.getLogger(__name__)
 
 
 def convert_image_attachments(env):
@@ -15,9 +19,16 @@ def convert_image_attachments(env):
             ('res_id', '!=', False),
         ])
         for attachment in attachments:
-            # for not having dangling attachments
-            attachment.res_field = "image_1920"
-            Model.browse(attachment.res_id).image_1920 = attachment.datas
+            try:
+                Model.browse(attachment.res_id).image_1920 = attachment.datas
+            except Exception as e:
+                _logger.error(
+                    "Error while recovering %s>%s for %s: %s",
+                    model,
+                    field,
+                    attachment.res_id,
+                    repr(e),
+                )
 
 
 @openupgrade.migrate()

--- a/addons/product/migrations/13.0.1.2/post-migration.py
+++ b/addons/product/migrations/13.0.1.2/post-migration.py
@@ -3,6 +3,10 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 from odoo.tools import sql
+import logging
+
+
+_logger = logging.getLogger(__name__)
 
 
 def convert_image_attachments(env):
@@ -18,7 +22,16 @@ def convert_image_attachments(env):
             ('res_id', '!=', False),
         ])
         for attachment in attachments:
-            Model.browse(attachment.res_id).image_1920 = attachment.datas
+            try:
+                Model.browse(attachment.res_id).image_1920 = attachment.datas
+            except Exception as e:
+                _logger.error(
+                    "Error while recovering %s>%s for %s: %s",
+                    model,
+                    field,
+                    attachment.res_id,
+                    repr(e),
+                )
 
 
 @openupgrade.logging()

--- a/addons/website_slides/migrations/13.0.2.0/post-migration.py
+++ b/addons/website_slides/migrations/13.0.2.0/post-migration.py
@@ -2,6 +2,10 @@
 from openupgradelib import openupgrade
 from psycopg2 import sql
 import uuid
+import logging
+
+
+_logger = logging.getLogger(__name__)
 
 _unlink_by_xmlid = [
     # ir.actions.act_url
@@ -28,7 +32,16 @@ def convert_image_attachments(env):
             ('res_id', '!=', False),
         ])
         for attachment in attachments:
-            Model.browse(attachment.res_id).image_1920 = attachment.datas
+            try:
+                Model.browse(attachment.res_id).image_1920 = attachment.datas
+            except Exception as e:
+                _logger.error(
+                    "Error while recovering %s>%s for %s: %s",
+                    model,
+                    field,
+                    attachment.res_id,
+                    repr(e),
+                )
 
 
 def fill_slide_sequence(env):

--- a/odoo/addons/base/migrations/13.0.1.3/post-migration.py
+++ b/odoo/addons/base/migrations/13.0.1.3/post-migration.py
@@ -8,6 +8,10 @@ from psycopg2 import sql
 from datetime import datetime
 from openupgradelib import openupgrade
 from odoo import fields
+import logging
+
+
+_logger = logging.getLogger(__name__)
 
 
 def fix_res_partner_image(env):
@@ -18,7 +22,14 @@ def fix_res_partner_image(env):
         ('res_id', '!=', False),
     ])
     for attachment in attachments:
-        ResPartner.browse(attachment.res_id).image_1920 = attachment.datas
+        try:
+            ResPartner.browse(attachment.res_id).image_1920 = attachment.datas
+        except Exception as e:
+            _logger.error(
+                "Error while recovering res.partner>image for %s: %s",
+                attachment.res_id,
+                repr(e),
+            )
 
 
 def res_lang_week_start_map_values(env):


### PR DESCRIPTION
There can be dangling attachments that belong to non existing records. There are also another possibilities of the write operation fails.

Protecting this conversion, we avoid unneeded crashes.

NOTE: This method may be put as openupgradelib function.

@Tecnativa