### PR TITLE
[FIX][14.0] calendar: an KeyError occurred while creating recurrent events

### DIFF
--- a/openupgrade_scripts/scripts/calendar/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/calendar/14.0.1.0/post-migration.py
@@ -70,9 +70,10 @@ def fill_calendar_recurrence_table(env):
 def create_recurrent_events(env):
     """In v14, now all occurrences of recurrent events are created as real records, not
     virtual ones, so we need to regenerate them for all the existing ones.
+    But we do not create an activity on the real records.
     """
     recs = env["calendar.recurrence"].search([("base_event_id", "!=", False)])
-    recs._apply_recurrence()
+    recs.with_context(default_activity_ids=[(6, 0, [])])._apply_recurrence()
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
Steps:
1. Create an meeting activity that link to recurrent event on project.task
2. Run migration
3. An KeyError occurred while creating recurrent events

Because In v14, now all occurrences of recurrent events are created as real records, not virtual ones, so we need to regenerate them for all the existing ones.
But while creating real records, Odoo will try to create an activity on the related record. But project.task is not in self.env because the module calendar doesn't depend on the module project, so models not installed (is not in self.env)

Solution: we do not create an activity on the real records. An activity that has been link to real record.