### PR TITLE
[13.0][FIX] l10n_es: parent taxes should be of l10n_es module

### DIFF
--- a/addons/l10n_es/migrations/13.0.4.0/post-migration.py
+++ b/addons/l10n_es/migrations/13.0.4.0/post-migration.py
@@ -43,7 +43,6 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
         [('children_tax_ids', '!=', False), ('company_id', 'in', companies_ids)]
     ).filtered(lambda t: not t.invoice_repartition_line_ids
                and not t.refund_repartition_line_ids)
-    children_tax_ids = taxes_with_children.mapped('children_tax_ids').ids
     tax_ids = taxes_with_children.ids
     # create tax repartition lines
     if tax_ids:
@@ -73,6 +72,9 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
                 FROM account_tax
                 WHERE id IN %%s""" % column, (tuple(tax_ids), ),
             )
+    domain = [('model', '=', 'account.tax'), ('res_id', 'in', taxes_with_children.ids), ('module', '!=', '__export__')]
+    taxes_with_children = env['account.tax'].browse(env['ir.model.data'].search(domain).mapped('res_id'))
+    children_tax_ids = taxes_with_children.mapped('children_tax_ids').ids
     if children_tax_ids:
         # assure children taxes are not parent taxes
         openupgrade.logged_query(


### PR DESCRIPTION
I just found a rare case where a client had custom parent taxes, so this PR is just to avoid having errors.