### PR TITLE
[13.0][OU-ADD] web_widget_one2many_product_picker_sale_stock_available_info_popup

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -97,6 +97,9 @@ merged_modules = {
     'web_view_searchpanel': 'web',
     'web_widget_color': 'web',
     'web_widget_many2many_tags_multi_selection': 'web',
+    'web_widget_one2many_product_picker_sale_stock_available_info_popup': (
+        'web_widget_one2many_product_picker_sale_stock'
+    ),
     # OCA/website
     'website_adv_image_optimization': 'website',
     'website_canonical_url': 'website',


### PR DESCRIPTION
Merged into web_widget_one2many_product_picker_sale_stock as the info
popup is already in the core.

cc @Tecnativa TT31783

ping @pedrobaeza @Tardo 