### PR TITLE
[12.0][MIG] web_tree_image: Rename to web_tree_image_tooltip

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -35,6 +35,7 @@ renamed_modules = {
     'stock_pack_operation_auto_fill': 'stock_move_line_auto_fill',
     # OCA/web
     'web_advanced_filters': 'web_advanced_filter',
+    'web_tree_image': 'web_tree_image_tooltip',
     # OCA/l10n-brazil
     'l10n_br_account_payment': 'l10n_br_account_payment_order',
     'l10n_br_account_product': 'l10n_br_fiscal',


### PR DESCRIPTION
Rename addon, from `web_tree_image` to `web_tree_image_tooltip`.

Related to https://github.com/OCA/web/pull/1100

Please @pedrobaeza can you review it?

@Tecnativa TT33439