### PR TITLE
[IMP][14.0]account: correct account type

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/end-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/end-migration.py
@@ -1,0 +1,38 @@
+from openupgradelib import openupgrade
+
+
+def _make_correct_account_type(env):
+    query = """
+        UPDATE account_account as ac
+            SET user_type_id=aat.user_type_id
+        FROM account_account_template as aat
+            JOIN account_chart_template as act
+                        ON aat.chart_template_id = act.id
+            JOIN res_company as c
+                        ON c.chart_template_id = act.id
+        WHERE ac.code =
+                CASE
+                    WHEN
+                        act.code_digits < LENGTH(aat.code) THEN aat.code
+                    ELSE
+                        CONCAT(aat.code,
+                            REPEAT('0',act.code_digits - LENGTH(aat.code)))
+                END
+            AND ac.user_type_id != aat.user_type_id
+            AND ac.company_id = c.id;
+        UPDATE account_account as ac
+            SET internal_type=at.type,
+                internal_group=at.internal_group
+        FROM account_account_type as at
+        WHERE ac.user_type_id=at.id AND (ac.internal_type != at.type OR
+                                    ac.internal_group != at.internal_group);
+        """
+    openupgrade.logged_query(
+        env.cr,
+        query,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _make_correct_account_type(env)


### PR DESCRIPTION
Because some account templates type have changed in version 14, so i think we should change the account type to match the account template type.
Ex: module l10n_vn, file data account.account.template.csv
in v13:
`"chart141","Tạm ứng","141","account.data_account_type_current_assets","l10n_vn.vn_template","True"
`
in v14:
`"chart141","Advances",141,"account.data_account_type_receivable","vn_template","True"
`
In Odoo, account.account data is generated from account.account.template data by method 'generate_account', they are not automatically updated following account.account.template, so we need update them using sql.