### PR TITLE
[FIX][14.0]hr_timesheet: fix noupdate rule

### DIFF
--- a/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/noupdate_changes.xml
@@ -37,9 +37,9 @@
                     ('project_id.allowed_internal_user_ids', 'in', user.ids),
                     ('task_id.allowed_user_ids', 'in', user.ids)
             ]</field>
-    <!-- <field name="perm_create"/>
+    <!-- <field name="perm_create"/> -->
     <field name="perm_read"/>
-    <field name="perm_unlink"/>
+    <!-- <field name="perm_unlink"/>
     <field name="perm_write"/> -->
   </record>
 </odoo>


### PR DESCRIPTION
Because noupdate rules has been changed from False to True, so we need migration it in post instead of pre.