### PR TITLE
[FIX] hr_timesheet: missing val in noupdate changes

### DIFF
--- a/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/noupdate_changes.xml
@@ -37,9 +37,7 @@
                     ('project_id.allowed_internal_user_ids', 'in', user.ids),
                     ('task_id.allowed_user_ids', 'in', user.ids)
             ]</field>
-    <!-- <field name="perm_create"/>
+    <!-- perm_read was False in v13 and is True in v14 -->
     <field name="perm_read"/>
-    <field name="perm_unlink"/>
-    <field name="perm_write"/> -->
   </record>
 </odoo>


### PR DESCRIPTION
The rule `hr_timesheet.timesheet_line_rule_user` was with perm_read as False in v13 in is with perm_read as True in v14. So, we need to specify perm_read in noupdate changes to reflect the change.