### PR TITLE
[FIX][14.0]rating: fix update rating value

### DIFF
--- a/openupgrade_scripts/scripts/rating/14.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/rating/14.0.1.0/pre-migration.py
@@ -10,7 +10,7 @@ def update_rating_value(env):
         env.cr,
         """
         UPDATE rating_rating
-        SET rating = round(rating / 2)
+        SET rating = round(rating / 2.0)
         WHERE rating IS NOT NULL""",
     )
 


### PR DESCRIPTION
Expect rating value after migration: 10->5, 5->3, 1->1
Old migration code: 10->5, 5->2, 1->0

Because Postgres convert value to integer type before rounding.