### PR TITLE
[13.0][FIX] account: Have taxes that have children have their tags migrated too.

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -750,14 +750,12 @@ def try_to_fill_account_account_tag_country_id(env):
 def create_account_tax_repartition_lines(env):
     # account_tax_repartition_line
     all_taxes = env['account.tax'].with_context(active_test=False).search([])
-    taxes_with_children = env['account.tax'].with_context(active_test=False).search(
-        [('children_tax_ids', '!=', False)])
     # taxes_children = taxes_with_children.mapped('children_tax_ids')
     complete_taxes = env['account.tax.repartition.line'].search(
         [('invoice_tax_id', '!=', False)]).mapped('invoice_tax_id') | env[
         'account.tax.repartition.line'].search(
         [('refund_tax_id', '!=', False)]).mapped('refund_tax_id')
-    tax_ids = (all_taxes - taxes_with_children - complete_taxes).ids
+    tax_ids = (all_taxes - complete_taxes).ids
     if tax_ids:
         openupgrade.logged_query(
             env.cr, """
@@ -818,14 +816,12 @@ def create_account_tax_repartition_lines(env):
     # account_tax_repartition_line_template
     all_taxes = env['account.tax.template'].with_context(
         active_test=False).search([])
-    taxes_with_children = env['account.tax.template'].with_context(
-        active_test=False).search([('children_tax_ids', '!=', False)])
     # taxes_children = taxes_with_children('children_tax_ids')
     complete_taxes = env['account.tax.repartition.line.template'].search(
         [('invoice_tax_id', '!=', False)]).mapped('invoice_tax_id') | env[
         'account.tax.repartition.line.template'].search(
         [('refund_tax_id', '!=', False)]).mapped('refund_tax_id')
-    tax_ids = (all_taxes - taxes_with_children - complete_taxes).ids
+    tax_ids = (all_taxes - complete_taxes).ids
     if tax_ids:
         openupgrade.logged_query(
             env.cr, """


### PR DESCRIPTION
The migration script of the `account` module does something where it creates `account.tax.repartition.line`'s for each `account.tax`. However, for some reason I could not deduce, it only does so for the `account.tax` records that don't have children. This effectively means that not **all** `account.tax` records will get repartition lines. Again, I don't know what the reasoning behind this was, but if someone has some input on this it is much appreciated.

However, as for now, I'm of the opinion that this is unnecessary. If not all tax records get repartition lines, than not all tags (`account.account.tag`) will be migrated either, as they will be connected to the repartition lines from 13.0 and onwards. 