### PR TITLE
[FIX][13.0]: Fix ambiguity in column

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -913,7 +913,7 @@ def assign_tax_repartition_line_to_move_lines(env):
         FROM account_move_line aml2
         JOIN account_move am ON aml2.move_id = am.id
         JOIN account_tax_repartition_line atrl ON (
-            balance >= 0
+            aml2.balance >= 0
             AND atrl.invoice_tax_id = aml2.tax_line_id
             AND atrl.repartition_type = 'tax')
         WHERE aml.id = aml2.id"""
@@ -925,7 +925,7 @@ def assign_tax_repartition_line_to_move_lines(env):
         FROM account_move_line aml2
         JOIN account_move am ON aml2.move_id = am.id
         JOIN account_tax_repartition_line atrl ON (
-            balance < 0
+            aml2.balance < 0
             AND atrl.refund_tax_id = aml2.tax_line_id
             AND atrl.repartition_type = 'tax')
         WHERE aml.id = aml2.id"""


### PR DESCRIPTION
Trace:
```
File "/ocb/addons/account/migrations/13.0.1.1/post-migration.py", line 1061, in migrate
    assign_tax_repartition_line_to_move_lines(env)
  File "/ocb/addons/account/migrations/13.0.1.1/post-migration.py", line 919, in assign_tax_repartition_l
    WHERE aml.id = aml2.id"""
  File "/python3.6/site-packages/openupgradelib/openupgrade.py", line 1353, in logged_query
    cr.execute(query, args)
  File "/ocb/odoo/sql_db.py", line 173, in wrapper
    return f(self, *args, **kwargs)
  File "/ocb/odoo/sql_db.py", line 250, in execute
    res = self._obj.execute(query, params)
psycopg2.ProgrammingError: column reference "balance" is ambiguous
LINE 7:             balance >= 0
```