### PR TITLE
[11.0][FIX] hr_timesheet: Migrate the users of the timesheets' old "Officer"…

### DIFF
--- a/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
+++ b/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
@@ -36,6 +36,23 @@ def migrate_project_issue_sheet(env):
     )
 
 
+def migrate_timesheet_managers(env):
+    """The group with xmlid group_hr_timesheet_user used to be "Officer"
+    group in 10.0. This is now replaced with the "Manager" group, while
+    the xmlid group_hr_timesheet_user is now used for the "User" group.
+    This moves all users of the "Officer" to the "Manager" group.
+    """
+    user_group_id = env.ref('hr_timesheet.group_hr_timesheet_user').id
+    manager_group_id = env.ref('hr_timesheet.group_timesheet_manager').id
+    root_user_id = env.ref('base.user_root').id
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE res_groups_users_rel SET gid = %s
+        WHERE gid = %s AND uid != %s""",
+        (manager_group_id, user_group_id, root_user_id)
+    )
+
+
 def recompute_tasks_from_issues_fields(env):
     """This module adds several computed stored fields to project.task (for
     example, effective_hours and remaining_hours). Issues converted to tasks,
@@ -59,4 +76,5 @@ def migrate(env, version):
     )
     update_employee_id(env)
     migrate_project_issue_sheet(env)
+    migrate_timesheet_managers(env)
     recompute_tasks_from_issues_fields(env)


### PR DESCRIPTION
… group to the new "Manager" group.

In odoo 10 xmlid group_hr_timesheet_user is the timesheet "Officer" group, while in Odoo 11 the same xmlid is used to represent a regular user, The new xmlid group_timesheet_manager is from then on used as the timesheet "Manager" group.

However, this causes the users that were assigned to group group_hr_timesheet_user in 10.0, to remain assigned to the new group_hr_timesheet_user in 11.0. I believe the manager group in 11.0 is what replaces the old officer group. Nothing is currently being done to assign them to the new group_timesheet_manager group, so that is what this PR does.