### PR TITLE
[13.0][FIX] l10n_es: parent taxes should not be manually added ones (fixup)

### DIFF
--- a/addons/l10n_es/migrations/13.0.4.0/post-migration.py
+++ b/addons/l10n_es/migrations/13.0.4.0/post-migration.py
@@ -95,8 +95,8 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
             JOIN account_tax at ON rel.account_tax_id = at.id
             JOIN account_tax_filiation_rel fil ON fil.child_tax = at.id
             JOIN account_tax at2 ON fil.parent_tax = at2.id
-            WHERE at.id IN %s
-            ON CONFLICT DO NOTHING""", (tuple(children_tax_ids), ),
+            WHERE at.id IN %s AND at2.id IN %s
+            ON CONFLICT DO NOTHING""", (tuple(children_tax_ids), tuple(taxes_with_children.ids)),
         )
         openupgrade.logged_query(
             env.cr, """
@@ -119,9 +119,9 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
                     atrl2.{column} = at2.id
                     AND atrl2.repartition_type = atrl.repartition_type
                     AND SIGN(at.amount) = SIGN(atrl2.factor_percent))
-                WHERE aml.tax_repartition_line_id = atrl.id AND at.id IN %s
+                WHERE aml.tax_repartition_line_id = atrl.id AND at.id IN %s AND at2.id IN %s
                 """).format(column=sql.Identifier(tax_column)),
-                (tuple(children_tax_ids), ),
+                (tuple(children_tax_ids), tuple(taxes_with_children.ids)),
             )
         # update amount of parent taxes:
         for company_id in companies_ids:


### PR DESCRIPTION
In previous PR https://github.com/OCA/OpenUpgrade/pull/3170, I filtered the parent taxes to find their children. Children are used later in the queries, but forgotten to filter their parents in the queries.