### PR TITLE
[14.0][FIX] base: assure existing users can export

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
@@ -44,8 +44,26 @@ def fix_module_category_parent_id(env):
     )
 
 
+def users_should_export(env):
+    # maintain same behavior as previous versions
+    export_group = env.ref("base.group_allow_export").id
+    user_group = env.ref("base.group_user").id
+    openupgrade.logged_query(
+        env.cr,
+        """
+        INSERT INTO res_groups_users_rel (uid, gid)
+        SELECT rel.uid, %s
+        FROM res_groups_users_rel rel
+        WHERE rel.gid = %s
+        ON CONFLICT DO NOTHING
+        """,
+        (export_group, user_group),
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     fix_module_category_parent_id(env)
+    users_should_export(env)
     # Load noupdate changes
     openupgrade.load_data(env.cr, "base", "14.0.1.3/noupdate_changes.xml")

--- a/openupgrade_scripts/scripts/base/14.0.1.3/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/upgrade_analysis_work.txt
@@ -117,7 +117,9 @@ DEL ir.ui.view: base.view_base_document_layout
 DEL ir.ui.view: base.view_menu
 DEL ir.ui.view: base.view_partner_short_form
 NEW res.country.group: base.sepa_zone (noupdate)
-NEW res.groups: base.group_allow_export
 NEW res.lang: base.lang_en_IN
 DEL res.lang: base.lang_fil
 # Done: switch partners to Tagalog
+
+NEW res.groups: base.group_allow_export
+# DONE: post-migration: put all users in this group to maintain previous behavior


### PR DESCRIPTION
To maintain same behavior as previous versions.

Also, one expect users be in this export group due to:
![Selection_282](https://user-images.githubusercontent.com/25005517/160158395-39cddc07-8842-4054-83d0-ea9c34430f02.png)

