### PR TITLE
[12.0][IMP] mrp: Pre-compute mrp.production>product_uom_qty by SQL

### DIFF
--- a/addons/mrp/migrations/12.0.2.0/openupgrade_analysis_work.txt
+++ b/addons/mrp/migrations/12.0.2.0/openupgrade_analysis_work.txt
@@ -13,8 +13,10 @@ mrp          / mrp.production           / message_main_attachment_id (many2one):
 # NOTHING TO DO: computed on mail end-migration script
 
 mrp          / mrp.production           / product_uom_id (many2one)     : relation is now 'uom.uom' ('product.uom') [nothing to do]
+# NOTHING TO DO
+
 mrp          / mrp.production           / product_uom_qty (float)       : NEW isfunction: function, stored
-# NOTHING TO DO: computed field
+# DONE: pre-migration: Speed up this computation doing it by SQL
 
 mrp          / mrp.unbuild              / activity_date_deadline (date) : not related anymore
 mrp          / mrp.unbuild              / activity_date_deadline (date) : not stored anymore


### PR DESCRIPTION
It can take a lot of time when you have a considerable number of production orders.

There's an assumption here when a conversion must be done to round to 4 decimals, as UoM expresses rounding through the rounding precision instead, but the selected fixed precision should be OK for most cases.

@Tecnativa