### PR TITLE
[13.0][FIX] account: add same name condition for invoice line matching

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -258,10 +258,23 @@ def migration_invoice_moves(env):
         env.cr,
         query.format(
             where=(sql.SQL(minimal_where + """
+            AND ail.name = aml.name
             AND ail.account_id = aml.account_id
             AND ai.commercial_partner_id = aml.partner_id
             AND ((ail.account_analytic_id IS NULL AND aml.analytic_account_id IS NULL)
                 OR ail.account_analytic_id = aml.analytic_account_id)"""))
+        ),
+    )
+    openupgrade.logged_query(
+        env.cr,
+        query.format(
+            where=(sql.SQL(minimal_where + """
+            AND substring(split_part(ail.name, chr(10), 1) from 1 for 64) = aml.name
+            AND ail.account_id = aml.account_id
+            AND ai.commercial_partner_id = aml.partner_id
+            AND ((ail.account_analytic_id IS NULL AND aml.analytic_account_id IS NULL)
+                OR ail.account_analytic_id = aml.analytic_account_id)
+            AND aml.old_invoice_line_id IS NULL"""))
         ),
     )
     # Try now with a more relaxed criteria, as it's possible that users change some data on amls


### PR DESCRIPTION
I have detected some mismatching in a client database. It seems the conditions are not enough. Let's hope that adding the `name` condition is enough.

![Selection_286](https://user-images.githubusercontent.com/25005517/160459376-75184d83-ff53-4ea7-9a06-1866930512ab.png)

I was also considering adding a comparison between `aml.balance` and `ail.price_subtotal`, but it's tricky, as the currency may not match and thus a conversion and round maybe needed.
