### PR TITLE
[13.0][FIX] l10n_es: more fixes

### DIFF
--- a/addons/l10n_es/migrations/13.0.4.0/post-migration.py
+++ b/addons/l10n_es/migrations/13.0.4.0/post-migration.py
@@ -93,6 +93,17 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
             WHERE rel.parent_tax IN %s
             """, (tuple(children_tax_ids), ),
         )
+        # update account move line tax_line_id
+        openupgrade.logged_query(
+            env.cr, """
+            UPDATE account_move_line aml
+            SET tax_line_id = at2.id
+            FROM account_tax at
+            JOIN account_tax_filiation_rel fil ON fil.child_tax = at.id
+            JOIN account_tax at2 ON fil.parent_tax = at2.id
+            WHERE aml.tax_line_id = at.id AND at.id IN %s AND at2.id IN %s
+            """, (tuple(children_tax_ids), tuple(parent_taxes.ids)),
+        )
         # update account move line tax_ids
         openupgrade.logged_query(
             env.cr, """

--- a/addons/l10n_es/migrations/13.0.4.0/post-migration.py
+++ b/addons/l10n_es/migrations/13.0.4.0/post-migration.py
@@ -43,7 +43,8 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
         [('children_tax_ids', '!=', False), ('company_id', 'in', companies_ids)]
     ).filtered(lambda t: not t.invoice_repartition_line_ids
                and not t.refund_repartition_line_ids)
-    tax_ids = taxes_with_children.ids
+    domain = [('model', '=', 'account.tax'), ('res_id', 'in', taxes_with_children.ids), ('module', '=', 'l10n_es')]
+    tax_ids = env['account.tax'].browse(env['ir.model.data'].search(domain).mapped('res_id')).ids
     # create tax repartition lines
     if tax_ids:
         refund_account_query = (

--- a/addons/l10n_es/migrations/13.0.4.0/post-migration.py
+++ b/addons/l10n_es/migrations/13.0.4.0/post-migration.py
@@ -37,6 +37,14 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
     companies_ids = [x[0] for x in env.cr.fetchall()]
     if not companies_ids:
         return
+    # assure update amount_type for cases where 'group' -> something else
+    for company_id in companies_ids:
+        for tax_xmlid in xmlid_names:
+            tax = env.ref('l10n_es.' + str(company_id) + '_' + tax_xmlid, raise_if_not_found=False)
+            tax_template = env.ref('l10n_es.' + tax_xmlid, raise_if_not_found=False)
+            if tax and tax_template:
+                tax.amount = tax_template.amount
+                tax.amount_type = tax_template.amount_type
     # select taxes with children that don't have repartition lines
     taxes_with_children = env['account.tax'].with_context(
         active_test=False).search(
@@ -74,7 +82,8 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
                 WHERE id IN %%s""" % column, (tuple(tax_ids), ),
             )
     domain = [('model', '=', 'account.tax'), ('res_id', 'in', taxes_with_children.ids), ('module', '!=', '__export__')]
-    taxes_with_children = env['account.tax'].browse(env['ir.model.data'].search(domain).mapped('res_id'))
+    parent_taxes = env['account.tax'].browse(env['ir.model.data'].search(domain).mapped('res_id')).filtered(
+        lambda t: t.amount_type != 'group')
     children_tax_ids = taxes_with_children.mapped('children_tax_ids').ids
     if children_tax_ids:
         # assure children taxes are not parent taxes
@@ -97,10 +106,11 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
             JOIN account_tax_filiation_rel fil ON fil.child_tax = at.id
             JOIN account_tax at2 ON fil.parent_tax = at2.id
             WHERE at.id IN %s AND at2.id IN %s
-            ON CONFLICT DO NOTHING""", (tuple(children_tax_ids), tuple(taxes_with_children.ids)),
+            ON CONFLICT DO NOTHING""", (tuple(children_tax_ids), tuple(parent_taxes.ids)),
         )
         other_parents = env["account.tax"].with_context(active_test=False).search(
-            [("children_tax_ids", "in", children_tax_ids)]).filtered(lambda t: t not in taxes_with_children)
+            [("children_tax_ids", "in", children_tax_ids)]).filtered(
+            lambda t: t in taxes_with_children and t not in parent_taxes)
         obsolete_children = [x for x in children_tax_ids if x not in other_parents.mapped(
             'children_tax_ids').filtered(lambda t: t.id in children_tax_ids).ids]
         if obsolete_children:
@@ -127,16 +137,8 @@ def use_new_taxes_and_repartition_lines_on_move_lines(env):
                     AND SIGN(at.amount) = SIGN(atrl2.factor_percent))
                 WHERE aml.tax_repartition_line_id = atrl.id AND at.id IN %s AND at2.id IN %s
                 """).format(column=sql.Identifier(tax_column)),
-                (tuple(children_tax_ids), tuple(taxes_with_children.ids)),
+                (tuple(children_tax_ids), tuple(parent_taxes.ids)),
             )
-        # update amount of parent taxes:
-        for company_id in companies_ids:
-            for tax_xmlid in xmlid_names:
-                tax = env.ref('l10n_es.' + str(company_id) + '_' + tax_xmlid, raise_if_not_found=False)
-                tax_template = env.ref('l10n_es.' + tax_xmlid, raise_if_not_found=False)
-                if tax and tax_template:
-                    tax.amount = tax_template.amount
-                    tax.amount_type = tax_template.amount_type
 
 
 def update_account_tags(env):


### PR DESCRIPTION
More fine-tuning.

- Only fill account_tax_repartition_line table for taxes in `l10n_es`
- Only remove from account move lines truly obsolete taxes