### PR TITLE
[12.0] stock: fix wrong comment

### DIFF
--- a/addons/stock/migrations/12.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/stock/migrations/12.0.1.1/openupgrade_analysis_work.txt
@@ -93,7 +93,7 @@ stock        / stock.move               / push_rule_id (many2one)       : DEL re
 stock        / stock.move               / rule_id (many2one)            : relation is now 'stock.rule' ('procurement.rule')
 
 stock        / procurement.rule         / action (selection)            : selection_keys is now '['pull', 'pull_push', 'push']' ('['move']')
-# DONE: post-migration: mapped 'move' to 'pull_push'
+# DONE: post-migration: mapped 'move' to 'pull'
 
 stock        / procurement.rule         / location_id (many2one)        : now required
 ??????


### PR DESCRIPTION
The comment was wrong when you compare with the real code: https://github.com/OCA/OpenUpgrade/blob/12.0/addons/stock/migrations/12.0.1.1/post-migration.py#L14