### PR TITLE
[14.0][OU-FIX] website: Allow cookiebar in multi-websites

### DIFF
--- a/openupgrade_scripts/scripts/website/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website/14.0.1.0/post-migration.py
@@ -7,7 +7,8 @@ def website_cookie_notice_post_migration(env):
     cookie_message = env.ref("website.cookie_message", raise_if_not_found=False)
     if cookie_message:
         websites = env["website"].search([])
-        websites.write({"cookies_bar": True})
+        for website in websites:
+            website.write({"cookies_bar": True})
         env.cr.execute(
             """WITH keys AS (
                 SELECT key


### PR DESCRIPTION
On a multisite it can raise a expected singleton when doing the write {"cookies_bar": True}
Fixed by doing a for loop.