### PR TITLE
[14.0][FIX] account: avoid duplicating account groups

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/end-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/end-migration.py
@@ -1,0 +1,112 @@
+# Copyright 2021 ForgeFlow S.L.  <https://www.forgeflow.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+
+from openupgradelib import openupgrade, openupgrade_merge_records
+
+_logger = logging.getLogger(__name__)
+
+
+def harmonize_groups(env):
+    """Unfold manual groups per company + proper company assignation"""
+
+    # step 1: Generate the generic account groups for each company. Later code will
+    # do it for manually created groups
+
+    companies = env["res.company"].with_context(active_test=False).search([])
+    for company in companies.filtered("chart_template_id"):
+        company.chart_template_id.generate_account_groups(company)
+
+    # step 2: For manually created groups, we check if such group is used in more than
+    # one company. If so, we unfold it. We also assure proper company for existing one
+
+    def _get_all_children(groups):
+        children = env["account.group"].search([("parent_id", "in", groups.ids)])
+        if children:
+            children |= _get_all_children(children)
+        return children
+
+    def _get_all_parents(groups):
+        parents = groups.mapped("parent_id")
+        if parents:
+            parents |= _get_all_parents(parents)
+        return parents
+
+    AccountGroup = env["account.group"]
+    AccountGroup._parent_store_compute()
+    env.cr.execute(
+        """SELECT ag.id FROM account_group ag
+        LEFT JOIN ir_model_data imd
+            ON ag.id = imd.res_id AND imd.model = 'account.group'
+                AND imd.module != '__export__'
+        WHERE imd.id IS NULL"""
+    )
+    all_groups = AccountGroup.browse([x[0] for x in env.cr.fetchall()])
+    all_groups = all_groups | _get_all_parents(all_groups)
+    relation_dict = {}
+    for group in all_groups.sorted(key="parent_path"):
+        subgroups = group | _get_all_children(group)
+        accounts = env["account.account"].search([("group_id", "in", subgroups.ids)])
+        companies = accounts.mapped("company_id").sorted()
+        for i, company in enumerate(companies):
+            if company not in relation_dict:
+                relation_dict[company] = {}
+            if i == 0:
+                if group.company_id != company:
+                    group.company_id = company.id
+                relation_dict[company][group] = group
+                continue
+            # Done by SQL for avoiding ORM derived problems
+            env.cr.execute(
+                """INSERT INTO account_group (parent_id, parent_path, name,
+                code_prefix_start, code_prefix_end, company_id,
+                create_uid, write_uid, create_date, write_date)
+            SELECT {parent_id}, parent_path, name, code_prefix_start,
+                code_prefix_end, {company_id}, create_uid,
+                write_uid, create_date, write_date
+            FROM account_group
+            WHERE id = {id}
+            RETURNING id
+            """.format(
+                    id=group.id,
+                    company_id=company.id,
+                    parent_id=group.parent_id
+                    and relation_dict[company][group.parent_id].id
+                    or "NULL",
+                )
+            )
+            new_group = AccountGroup.browse(env.cr.fetchone())
+            relation_dict[company][group] = new_group
+
+    # step 3: Merge repeated groups
+
+    env.cr.execute(
+        """SELECT array_agg(id order by id DESC), name,
+            code_prefix_start, company_id
+        FROM account_group
+        GROUP BY name, code_prefix_start, company_id
+        """
+    )
+    group_ids = [x[0] for x in env.cr.fetchall()]
+    for group in group_ids:
+        if len(group) > 1:
+            openupgrade_merge_records.merge_records(
+                env,
+                "account.group",
+                group[1:],
+                group[0],
+                field_spec=None,
+                method="sql",
+                delete=True,
+                exclude_columns=None,
+                model_table="account_group",
+            )
+
+    AccountGroup._parent_store_compute()
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    harmonize_groups(env)
+    # Launch a recomputation of the account groups after previous changes
+    env["account.account"].search([])._compute_account_group()

--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -429,6 +429,20 @@ def fill_account_payment_partner_id(env):
     )
 
 
+def delete_xmlid_existing_groups(env):
+    env.cr.execute(
+        """DELETE FROM ir_model_data imd
+        USING account_group ag
+        WHERE ag.id = imd.res_id AND imd.model = 'account.group'
+            AND imd.module != '__export__'
+        RETURNING imd.res_id"""
+    )
+    # end-migration script will:
+    # - populate account groups from the templates
+    # - unfold manual groups per company + proper company assignation
+    # - merge repeated groups
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.set_xml_ids_noupdate_value(
@@ -444,6 +458,7 @@ def migrate(env, version):
     fill_empty_partner_type_account_payment(env)
     fill_account_move_line_currency_id(env)
     fill_account_payment_partner_id(env)
+    delete_xmlid_existing_groups(env)
     openupgrade.remove_tables_fks(
         env.cr, ["account_bank_statement_import_ir_attachment_rel"]
     )

--- a/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/upgrade_analysis_work.txt
@@ -133,10 +133,10 @@ account      / account.group            / code_prefix (char)            : DEL
 account      / account.group            / code_prefix_end (char)        : NEW
 account      / account.group            / code_prefix_start (char)      : NEW
 # DONE: pre-migration: renamed code_prefix to code_prefix_start
-# post-migration: assigned same start values to end field
+# DONE: post-migration: assigned same start values to end field
 
 account      / account.group            / company_id (many2one)         : NEW relation: res.company, required, req_default: function, hasdefault
-# DONE: post-migration: Unfold manual groups per company + proper company assignation
+# DONE: end-migration: Unfold manual groups per company + proper company assignation
 
 account      / account.group.template   / chart_template_id (many2one)  : NEW relation: account.chart.template, required
 account      / account.group.template   / code_prefix_end (char)        : NEW


### PR DESCRIPTION
NOTE: If some group has been tweaked from v13 to v14, this script will treat both versions (v13 and v14) of this group as different groups. Then, the merge of them should be done in the corresponding `l10n_*` module.