### PR TITLE
[14.0][FIX] account: correct move's currency

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -275,6 +275,16 @@ def add_move_id_field_account_bank_statement_line(env):
 
 
 def add_move_id_field_account_payment(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_payment ap
+        SET currency_id = COALESCE(aj.currency_id, rc.currency_id)
+        FROM account_journal aj
+        JOIN res_company rc ON aj.company_id = rc.id
+        WHERE ap.journal_id = aj.id
+        """,
+    )
     if not openupgrade.column_exists(env.cr, "account_payment", "move_id"):
         openupgrade.logged_query(
             env.cr,


### PR DESCRIPTION
First commit is cherry-picked from https://github.com/OCA/OpenUpgrade/pull/3180.

Second commit adds a deleted part in the first commit. Overall, what we are fixing is not the payment's currency, but move's currency.