### PR TITLE
[IMP] set web_diagram as merged into web to avoid to uninstall it manually

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/end-migration.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/end-migration.py
@@ -7,3 +7,10 @@ from openupgradelib import openupgrade
 def migrate(env, version):
     """Call disable_invalid_filters in every edition of openupgrade"""
     openupgrade.disable_invalid_filters(env)
+    # web_diagram has been remove in V14
+    # we merge into web, if no diagram are present, to avoid to
+    # have to uninstall the module manually
+    if not env["ir.ui.view"].search([("type", "=", "diagram")]):
+        openupgrade.update_module_names(
+            env.cr, [("web_diagram", "web")], merge_modules=True
+        )


### PR DESCRIPTION
**rational**

- ``web_diagram`` exists in odoo V13 and is auto_installable
- ``web_diagram`` doesn't exist in V14
(https://github.com/OCA/OpenUpgrade/blob/14.0/docsource/modules130-140.rst)

So before that patch, we should uninstall manually that module when migrating from 13 to 14.

**question**
However, I don't know if ``web_diagram`` has been dropped, or has moved into EE. If yes, is this PR OK ? I don't think that the objective of ``openupgrade`` project is to migrate EE instance, but maybe I'm wrong...

comments / alternative welcome. 