### PR TITLE
[14.0][OU-FIX] account: Fill amount_residual_currency as well

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -397,7 +397,8 @@ def fill_account_move_line_currency_id(env):
         env.cr,
         """
         UPDATE account_move_line
-        SET currency_id = company_currency_id
+        SET currency_id = company_currency_id,
+            amount_residual_currency = amount_residual
         WHERE currency_id IS NULL
         """,
     )


### PR DESCRIPTION
Currency is now mandatory for all the `account.move.line` records, so there's certain part of the reconcile logic that relies on
`amount_residual_currency` when `currency_id` is set (independently of which currency it is). Example:

https://github.com/odoo/odoo/blob/1569441f15adb0b6b2920483ba8a43ccc7845e61/addons/account/models/account_move.py#L4401

so we copy the residual amount as well as the currency on the filling.

@Tecnativa TT35896