### PR TITLE
[13.0][FIX] mrp, repair: map locations

### DIFF
--- a/addons/repair/migrations/13.0.1.0/post-migration.py
+++ b/addons/repair/migrations/13.0.1.0/post-migration.py
@@ -51,13 +51,78 @@ def update_repair_order_user_id(env):
     )
 
 
+def _get_main_company(cr):
+    cr.execute("""SELECT id, name FROM res_company ORDER BY id""")
+    return cr.fetchone()
+
+
+def map_repair_locations(env, main_company):
+    openupgrade.logged_query(
+        env.cr, """
+        ALTER TABLE repair_line
+        ADD COLUMN IF NOT EXISTS company_id integer""",
+    )
+    # is added later in v14, so no problem by adding it now.
+    openupgrade.logged_query(
+        env.cr, """
+        UPDATE repair_line rl
+        SET company_id = ro.company_id
+        FROM repair_order ro
+        WHERE rl.repair_id = ro.id AND rl.company_id IS NULL
+            AND ro.company_id IS NOT NULL""",
+    )
+    conditions = {
+        'location_inventory':
+            "sl2.usage = 'inventory' AND sl2.scrap_location IS NOT TRUE",
+        'location_production': "sl2.usage = 'production'",
+        'stock_location_scrapped':
+            "sl2.usage = 'inventory' AND sl2.scrap_location IS TRUE",
+    }
+    affected_models = {
+        'repair.order': ['location_id'],
+        'repair.line': ['location_id', 'location_dest_id'],
+    }
+    for model, locations in affected_models.items():
+        table = env[model]._table
+        for location in locations:
+            for xmlid_name, condition in conditions.items():
+                openupgrade.logged_query(
+                    env.cr, """
+            UPDATE {table} tab
+            SET {location} = (
+                SELECT sl2.id
+                FROM stock_location sl2
+                LEFT JOIN ir_model_data imd2 ON (imd2.module = 'stock' and
+                    imd2.model = 'stock.location' and imd2.res_id = sl2.id)
+                LEFT JOIN res_users ru2 ON ru2.id = sl2.create_uid
+                WHERE {condition}
+                    AND imd2.name IS NULL AND
+                    COALESCE(sl2.company_id, ru2.company_id) =
+                        COALESCE(tab.company_id, ru.company_id)
+                LIMIT 1
+                )
+            FROM stock_location sl
+            JOIN ir_model_data imd ON (imd.module = 'stock' and
+                imd.model = 'stock.location' and imd.res_id = sl.id)
+            LEFT JOIN res_users ru ON sl.create_uid = ru.id
+            WHERE tab.{location} = sl.id AND
+                tab.company_id != {main_company_id} AND
+                imd.name = '{xmlid_name}'
+                        """.format(table=table, main_company_id=main_company[0],
+                                   location=location,
+                                   xmlid_name=xmlid_name, condition=condition)
+                )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.load_data(
-        env.cr, "repair",
-        "migrations/13.0.1.0/noupdate_changes.xml"
-    )
+    main_company = _get_main_company(env.cr)
+    map_repair_locations(env, main_company)
     update_repair_fee_invoice_relation(env)
     update_repair_line_invoice_relation(env)
     update_repair_order_invoice_relation(env)
     update_repair_order_user_id(env)
+    openupgrade.load_data(
+        env.cr, "repair",
+        "migrations/13.0.1.0/noupdate_changes.xml"
+    )

--- a/addons/stock/migrations/13.0.1.1/end-migration.py
+++ b/addons/stock/migrations/13.0.1.1/end-migration.py
@@ -1,0 +1,15 @@
+# Copyright 2022 ForgeFlow <https://www.forgeflow.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # xmlids are deprecated in v13
+    openupgrade.logged_query(env.cr, """
+    DELETE FROM ir_model_data imd
+    WHERE imd.module = 'stock' AND imd.name IN (
+        'property_stock_inventory', 'property_stock_production',
+        'stock_location_scrapped', 'location_inventory', 'location_production',
+        'location_procurement')
+    """)

--- a/addons/stock/migrations/13.0.1.1/openupgrade_analysis_work.txt
+++ b/addons/stock/migrations/13.0.1.1/openupgrade_analysis_work.txt
@@ -273,4 +273,4 @@ DEL stock.location: stock.location_production (noupdate)
 DEL stock.location: stock.stock_location_scrapped (noupdate)
 DEL stock.location: stock.location_procurement (noupdate)
 # DONE: post-migration: mapped them to new locations
-# DONE: post-migration: delete their ir model data
+# DONE: end-migration: delete their ir model data

--- a/addons/stock/migrations/13.0.1.1/post-migration.py
+++ b/addons/stock/migrations/13.0.1.1/post-migration.py
@@ -343,15 +343,6 @@ def map_stock_locations(env, main_company):
         WHERE sq.location_id = sl.id""")
     env["stock.quant.package"].search([])._compute_package_info()
 
-    # xmlids are deprecated in v13
-    openupgrade.logged_query(env.cr, """
-    DELETE FROM ir_model_data imd
-    WHERE imd.module = 'stock' AND imd.name IN (
-        'property_stock_inventory', 'property_stock_production',
-        'stock_location_scrapped', 'location_inventory', 'location_production',
-        'location_procurement')
-    """)
-
 
 def stock_production_lot_multi_company_migration(env):
     rule = env.ref("stock.stock_production_lot_rule", raise_if_not_found=False)


### PR DESCRIPTION
The deletion of the stock obsolete xmlids should be done in end-migration, this way some modules will be able to use those xmlids in their migrations scripts. 