### PR TITLE
[13.0][OU] base: fix translation term states

### DIFF
--- a/odoo/addons/base/migrations/13.0.1.3/end-migration.py
+++ b/odoo/addons/base/migrations/13.0.1.3/end-migration.py
@@ -18,8 +18,30 @@ def delete_obsolete_model_relations(env):
             WHERE model IN %s""", (tuple(wrong_model_ids),))
 
 
+def fix_translation_terms(env):
+    """There is an unresolved bug in versions <=12 (probably coming from web_editor)
+    that causes wrong translation states. This causes crashes when those terms
+    get edited in v13. We also want to normalize states to the expected ones when
+    they are null."""
+    openupgrade.logged_query(
+        env.cr,
+        "UPDATE ir_translation SET state = NULL WHERE state = 'false'"
+    )
+    openupgrade.logged_query(
+        env.cr,
+        "UPDATE ir_translation SET state = 'translated' "
+        "WHERE state IS NULL and value IS NOT NULL"
+    )
+    openupgrade.logged_query(
+        env.cr,
+        "UPDATE ir_translation SET state = 'to_translate' "
+        "WHERE state IS NULL and value IS NULL"
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     """ Call disable_invalid_filters in every edition of openupgrade """
     openupgrade.disable_invalid_filters(env)
     delete_obsolete_model_relations(env)
+    fix_translation_terms(env)


### PR DESCRIPTION
There is an unresolved bug in versions <=12 (probably coming from web_editor)
that causes wrong translation states. This causes crashes when those terms
get edited in v13. We also want to normalize states to the expected ones when
they are null.

cc @Tecnativa TT36678

please review @pedrobaeza 