### PR TITLE
[OUFIX][14.0]account : no liquidity line created for bank statement line

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -521,6 +521,20 @@ def fill_statement_lines_with_no_move(env):
             _logger.error("Failed for statement line with id %s: %s", st_line.id, e)
             raise
         deprecated_accounts.deprecated = True
+        to_write = {
+            "line_ids": [
+                (
+                    0,
+                    0,
+                    st_line._prepare_move_line_default_vals(
+                        counterpart_account_id=False
+                    )[0],
+                )
+            ]
+        }
+        st_line.move_id.with_context(skip_account_move_synchronization=True).write(
+            to_write
+        )
 
     openupgrade.logged_query(
         env.cr,


### PR DESCRIPTION
Hi,

As reported in #3056 migration of unreconciled account bank statement lines to v14 led to creating automatically corresponding account_move with incorrect number of lines (3 lines instead of 2).

A fix was proposed in #3159 which did not solve the situation, you then only had 1 line instead of 2.

After analyzing what is happening, it turns out that 
function _synchronize_to_moves from account_bank_statement_line expects that a liquidity line already exist (https://github.com/odoo/odoo/blob/eb603056a442e5dcc57828ac75b97d66324adde7/addons/account/models/account_bank_statement.py#L995) when on the other side, it checks whether suspense line exists and updates it if it exists or create a new one if not (https://github.com/odoo/odoo/blob/eb603056a442e5dcc57828ac75b97d66324adde7/addons/account/models/account_bank_statement.py#L997-L1000)
Therefore when calling this function during migration it does create suspense line but not liquidity line (so only 1 line)
Before #3159, the lines were then created manually here: https://github.com/OCA/OpenUpgrade/blob/f96fc323e51a2ee2db8dba5d8e3fb4ee967f8229/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py#L524-L534 but _prepare_move_line_default_vals function returns both liquidity and suspense dicts so the suspense line was created a second time.

This fix applies the same behaviour as before but only for liquidity line.

Also, I have checked that #3159 was first created about payment, and there the problem seems to be solved by that PR since the  _synchronize_to_moves function from account_payment properly checks whether liquidity lines were properly created (https://github.com/OCA/OpenUpgrade/blob/f96fc323e51a2ee2db8dba5d8e3fb4ee967f8229/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py#L524-L534). This PR #3159 which was merged in 14.0 branch should therefore be kept since it fixes the move creation for payments.