### PR TITLE
[13.0][OU-FIX] pos_sale: map old pos.order to crm_team_id

### DIFF
--- a/addons/pos_sale/migrations/13.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/pos_sale/migrations/13.0.1.0/openupgrade_analysis_work.txt
@@ -7,7 +7,7 @@ pos_sale     / crm.team                 / team_type (False)             : DEL se
 # NOTHING TO DO: removed field, every team should be able to handle a POS or a website for example
 
 pos_sale     / pos.order                / crm_team_id (many2one)        : NEW relation: crm.team
-# NOTHING TO DO: new feature
+# DONE: post-migration: Map to config team relation. Before that relation was the one used to group in the sales report.
 
 pos_sale     / pos.order                / currency_rate (float)         : module is now 'point_of_sale' ('pos_sale')
 # NOTHING TO DO: Will be handled by ORM on module update

--- a/addons/pos_sale/migrations/13.0.1.0/post-migration.py
+++ b/addons/pos_sale/migrations/13.0.1.0/post-migration.py
@@ -3,6 +3,25 @@
 from openupgradelib import openupgrade
 
 
+def _map_crm_team_id(env):
+    """From now on, every pos.order will have stored its crm.team relation, so if it's
+    changed later, those sales don't go to the new team. Anyway we have to map it in
+    the old orders so we don't loose that info in the sales report."""
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE pos_order po
+        SET crm_team_id = pc.crm_team_id
+        FROM pos_config pc, pos_session ps
+        WHERE
+            ps.id = po.session_id
+            AND pc.id = ps.config_id
+            AND po.crm_team_id IS NULL
+            AND pc.crm_team_id IS NOT NULL
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
@@ -12,3 +31,4 @@ def migrate(env, version):
             "point_of_sale.pos_config_main",
         ]
     )
+    _map_crm_team_id(env)


### PR DESCRIPTION
From now on, every pos.order will have stored its crm.team relation, so if it's
changed later, those sales don't go to the new team. Anyway we have to map it in
the old orders so we don't loose that info in the sales report.

cc @Tecnativa TT36891

please review @MiquelRForgeFlow @pedrobaeza @sergio-teruel 