### PR TITLE
[13.0][OU-FIX] mass_mailing: prevent deleting mailing list

### DIFF
--- a/addons/mass_mailing/migrations/13.0.2.0/openupgrade_analysis_work.txt
+++ b/addons/mass_mailing/migrations/13.0.2.0/openupgrade_analysis_work.txt
@@ -242,7 +242,7 @@ ir.ui.view: mass_mailing.mass_mailing_mail_layout (noupdate) (noupdate switched)
 # DONE: pre-migration noupdate enabled
 
 DEL mail.mass_mailing.list: mass_mailing.mass_mail_list_1 (noupdate)
-# DONE: post-migration
+# DONE: pre-migration delete ir.model.data to avoid deleting the actual mailing list record
 
 DEL mail.mass_mailing.stage: mass_mailing.campaign_stage_1 [renamed to utm module] (noupdate)
 DEL mail.mass_mailing.stage: mass_mailing.campaign_stage_2 [renamed to utm module] (noupdate)

--- a/addons/mass_mailing/migrations/13.0.2.0/post-migration.py
+++ b/addons/mass_mailing/migrations/13.0.2.0/post-migration.py
@@ -2,11 +2,6 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
-_unlink_by_xmlid = [
-    # mail.mass_mailing.list
-    'mass_mailing.mass_mail_list_1',
-]
-
 
 def fill_several_campaign_id(env):
     tables = ["mailing_mailing", "mailing_trace", "link_tracker", "link_tracker_click"]
@@ -23,5 +18,4 @@ def fill_several_campaign_id(env):
 @openupgrade.migrate(use_env=True)
 def migrate(env, version):
     fill_several_campaign_id(env)
-    openupgrade.delete_records_safely_by_xml_id(env, _unlink_by_xmlid)
     openupgrade.load_data(env.cr, 'mass_mailing', 'migrations/13.0.2.0/noupdate_changes.xml')

--- a/addons/mass_mailing/migrations/13.0.2.0/pre-migration.py
+++ b/addons/mass_mailing/migrations/13.0.2.0/pre-migration.py
@@ -110,3 +110,8 @@ def migrate(env, version):
         True,
     )
     fill_mailing_subject(env)
+    # This xml_id dissapears. Prevent deleting the linked mailing list
+    env["ir.model.data"].search([
+        ("module", "=", "mass_mailing"),
+        ("name", "=", "mass_mail_list_1"),
+    ]).unlink()


### PR DESCRIPTION
In <13 Odoo create a mailing list by default with the xml_id
mass_mailing.mass_mail_list_1, but now in 13.0 it doesn't exist
anymore so if we don't get rid of the former ir.model.data we
could be missing our mailing list and its records.

cc @Tecnativa TT37037

ping @pedrobaeza @MiquelRForgeFlow 