### PR TITLE
[15.0][FIX] ci: adapt regular expression that select modules to new column in table

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,7 +102,7 @@ jobs:
               openupgrade/docsource/modules140-150.rst \
               | grep "Done\|Partial\|Nothing" \
               | grep -v "theme_" \
-              | sed -rn 's/((^\| *\|del\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' \
+              | sed -rn 's/((^\| *\|del\| *)|^\| *)([0-9a-z_]*)[ \|].*/\3/g p' \
               | sed '/^\s*$/d' \
               | paste -d, -s)
           MODULES_NEW=base,$(\
@@ -110,7 +110,7 @@ jobs:
               openupgrade/docsource/modules140-150.rst \
               | grep "Done\|Partial\|Nothing" \
               | grep -v "theme_" \
-              | sed -rn 's/((^\| *\|new\| *)|^\|)([0-9a-z_]*) *\|.*$/\3/g p' \
+              | sed -rn 's/((^\| *\|new\| *)|^\| *)([0-9a-z_]*)[ \|].*/\3/g p' \
               | sed '/^\s*$/d' \
               | paste -d, -s)
           psql $DB -c "update ir_module_module set state='uninstalled' \


### PR DESCRIPTION
Currently, only 'base' is upgraded even when other modules are set to Done (see https://github.com/OCA/OpenUpgrade/pull/3273)

-- edit -- Now merged in #3273, so maybe that one can be merged sooner rather than later, and rather than this one.