### PR TITLE
[14.0] account: keep account_journal fields sequence_id and refund_sequence_id

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -132,6 +132,11 @@ def copy_fields(env):
             "account_journal": [
                 ("default_credit_account_id", None),
                 ("default_debit_account_id", None),
+                # We keep the M2O ir.sequence fields for those who
+                # want to use the OCA v14 module 'account_move_name_sequence'
+                # from OCA/account-financial-tools
+                ("sequence_id", None),
+                ("refund_sequence_id", None),
             ],
         },
     )


### PR DESCRIPTION
Useful for those who want to use the OCA v14 module account_move_name_sequence https://github.com/OCA/account-financial-tools/tree/14.0/account_move_name_sequence

If this PR is accepted, I plan to update the module account_move_name_sequence so that the modules initializes the fields sequence_id and refund_sequence_id from openupgrade_legacy_14_0_sequence_id and openupgrade_legacy_14_0_refund_sequence_id