### PR TITLE
[14.0][OU-FIX] fleet: Proper link to included services

### DIFF
--- a/openupgrade_scripts/scripts/fleet/14.0.0.1/post-migration.py
+++ b/openupgrade_scripts/scripts/fleet/14.0.0.1/post-migration.py
@@ -54,7 +54,8 @@ def fill_fleet_vehicle_log_contract_service_ids(env):
         (fleet_vehicle_log_contract_id, fleet_service_type_id)
         SELECT fvlc.id, fvc.cost_subtype_id
         FROM fleet_vehicle_log_contract fvlc
-        JOIN fleet_vehicle_cost fvc ON fvc.contract_id = fvlc.id
+        JOIN fleet_vehicle_cost fvc ON fvc.parent_id = fvlc.cost_id
+        WHERE fvc.cost_subtype_id IS NOT NULL
         """,
     )
 


### PR DESCRIPTION
The field selected for filling the included services was not correct, as there are 2 one2many to fleet.vehicle.cost, one for the periodically genereted costs (through the inverse `contract_id`), and another due to the inherited by delegation one2many through the inverse `parent_id`.

We need to use the second one, which is the correct.

@Tecnativa