### PR TITLE
[14.0][FIX] account: take payment_ref only if move_name is NULL (or '')

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -245,11 +245,13 @@ def add_move_id_field_account_bank_statement_line(env):
         UPDATE account_bank_statement_line absl
         SET move_id = ap.move_id
         FROM account_payment ap
+        JOIN account_move am ON ap.move_id = am.id
         JOIN account_journal aj ON ap.journal_id = aj.id,
             account_bank_statement bs
         WHERE absl.statement_id = bs.id AND aj.company_id = bs.company_id
             AND absl.move_id IS NULL AND absl.payment_ref NOT IN ('', '/')
-            AND absl.payment_ref = ap.communication AND ap.move_id IS NOT NULL
+            AND absl.payment_ref = ap.communication
+            AND am.statement_line_id IS NULL
         """,
     )
     # 4. match on statement account number and move ref

--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -233,7 +233,8 @@ def add_move_id_field_account_bank_statement_line(env):
         WHERE absl.statement_id = bs.id
             AND absl.move_id IS NULL
             AND am.name NOT IN ('', '/')
-            AND COALESCE(NULLIF(absl.move_name, ''), absl.payment_ref) = am.name
+            AND COALESCE(NULLIF(COALESCE(absl.move_name, ''), ''),
+                absl.payment_ref) = am.name
             AND am.company_id = bs.company_id
         """,
     )
@@ -330,7 +331,8 @@ def add_move_id_field_account_payment(env):
         WHERE ap.journal_id = aj.id
             AND ap.move_id IS NULL
             AND am.name NOT IN ('', '/')
-            AND COALESCE(NULLIF(ap.move_name, ''), ap.payment_reference) = am.name
+            AND COALESCE(NULLIF(COALESCE(ap.move_name, ''), ''),
+                ap.payment_reference) = am.name
             AND am.company_id = aj.company_id""",
     )
     # 3. match on payment communication with move payment_reference, ref or name


### PR DESCRIPTION
As said in the point: `# 2. try to match on statement move_name or payment_ref (if move_name empty)`

That means we should avoid case where move_name is null, i.e, the statement line is not reconciled.