### PR TITLE
[14.0][OU-FIX] mrp: Update context from action according to 14.0

### DIFF
--- a/openupgrade_scripts/scripts/mrp/14.0.2.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/mrp/14.0.2.0/noupdate_changes.xml
@@ -27,4 +27,9 @@
   <record id="mrp_workorder_rule" model="ir.rule">
     <field name="global"/>
   </record> -->
+  <!--We need to update the context to the correct value because in v14 the context
+    is not defined in the xml definition.!-->
+  <record id="action_mrp_production_form" model="ir.actions.act_window">
+    <field name="context">{}</field>
+  </record>
 </odoo>


### PR DESCRIPTION
We need to update the context to the correct value because in v14 the context is not defined in the xml definition.

v13: https://github.com/odoo/odoo/blob/13.0/addons/mrp/views/mrp_production_views.xml#L421
v14: https://github.com/odoo/odoo/blob/14.0/addons/mrp/views/mrp_production_views.xml#L588-L593

Please @pedrobaeza can you review it?

@Tecnativa TT38623