### PR TITLE
[13.0][OU-IMP] point_of_sale: stock_location_id

### DIFF
--- a/addons/point_of_sale/migrations/13.0.1.0.1/openupgrade_analysis_work.txt
+++ b/addons/point_of_sale/migrations/13.0.1.0.1/openupgrade_analysis_work.txt
@@ -53,8 +53,10 @@ point_of_sale / pos.config               / iface_available_categ_ids (many2many)
 point_of_sale / pos.config               / iface_payment_terminal (boolean): DEL
 point_of_sale / pos.config               / limit_categories (boolean)    : NEW
 point_of_sale / pos.config               / other_devices (boolean)       : NEW
-point_of_sale / pos.config               / stock_location_id (many2one)  : DEL relation: stock.location, required, req_default: function
 # NOTHING TO DO
+
+point_of_sale / pos.config               / stock_location_id (many2one)  : DEL relation: stock.location, required, req_default: function
+# DONE: post-migration: for pos configs with picking types which default location is different from the former location, create new picking types with those default locations
 
 point_of_sale / pos.order                / payment_ids (one2many)        : NEW relation: pos.payment
 point_of_sale / pos.order                / statement_ids (one2many)      : DEL relation: account.bank.statement.line


### PR DESCRIPTION
In v13 the deafault location of the picking type is used to take the stock in the picking operations of the pos configs. In the migration, this can lead to pickings that were using a common operation type taking the stock from the wrong locations. We prevent it creating new picking types for that configs.

cc @Tecnativa TT23199