### PR TITLE
[13.0][OU-FIX] point_of_sale: update configs via SQL

### DIFF
--- a/addons/point_of_sale/migrations/13.0.1.0.1/post-migration.py
+++ b/addons/point_of_sale/migrations/13.0.1.0.1/post-migration.py
@@ -107,12 +107,21 @@ def create_pos_picking_types(env):
         env["pos.config"].browse(config_ids),
         location_ids
     ):
-        config.picking_type_id = config.picking_type_id.copy({
+        picking_type = config.picking_type_id.copy({
             "name": "[OU] {} - {}".format(
                 config.picking_type_id.name, config.name
             ),
             "default_location_src_id": location_id,
         })
+        # Update via SQL to avoid possible open sessions errors. They shouldn't be open
+        # but if only is they'd spoil the whole migration
+        env.cr.execute(
+            """
+            UPDATE pos_config
+            SET picking_type_id = %s WHERE id = %s
+            """,
+            (picking_type.id, config.id),
+        )
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
From v13, only certain fields can be updated in a pos.config with an open session. In this case we can safely override that behavior updating the values via SQL to avoid the migration break due to an unconvenient session state.

cc @Tecnativa TT23199
