### PR TITLE
[14.0][FIX] fix odoobot_state field not find in parent view

### DIFF
--- a/openupgrade_scripts/scripts/hr/14.0.1.1/pre-migrate.py
+++ b/openupgrade_scripts/scripts/hr/14.0.1.1/pre-migrate.py
@@ -1,0 +1,29 @@
+# Copyright 2022 Marcin Żurawski
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM ir_ui_view
+        WHERE inherit_id=(
+            SELECT res_id
+            FROM ir_model_data
+            WHERE name='res_users_view_form_profile' AND module='hr'
+        );
+        """
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM ir_ui_view
+        WHERE id=(
+            SELECT res_id
+            FROM ir_model_data
+            WHERE name='res_users_view_form_profile' AND module='hr'
+        );
+        """
+    )


### PR DESCRIPTION
odoobot_state not used in new odoo 14 'res.users.preferences.form.inherit' view. 

PR solves problem in https://github.com/OCA/OpenUpgrade/pull/2789 comments