### PR TITLE
[14.0][OU-ADD] theme_graphene_blog: Merged into theme_graphene

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -65,6 +65,8 @@ merged_modules = {
     "pos_kitchen_printer": "pos_restaurant",
     "pos_reprint": "point_of_sale",
     "website_theme_install": "website",
+    # odoo/design-themes
+    "theme_graphene_blog": "theme_graphene",
     # OCA/event
     "website_event_questions_free_text": "website_event_questions",
     # OCA/margin-analysis


### PR DESCRIPTION
This module was adding some extra styles for the snippets "Latest posts - Big images" and "Latest posts - List", but now in v14
such styles are embedded in the core, and in fact, there's now only one snippet for both, and the type (big image/list) is an option of the snippet

@Tecnativa TT33818