### PR TITLE
[12.0][FIX] crm: Remove calendar.event obsolete record rule

### DIFF
--- a/addons/crm/migrations/12.0.1.0/post-migration.py
+++ b/addons/crm/migrations/12.0.1.0/post-migration.py
@@ -46,5 +46,6 @@ def migrate(env, version):
             'crm.opp_report_multi_company',
             'crm.email_template_opportunity_reminder_mail',
             'crm.mail_template_data_module_install_crm',
+            'crm.calendar_event_global',
         ],
     )


### PR DESCRIPTION
This record rule has disappeared in this version and it was no update, so it should be removed.

https://github.com/OCA/OpenUpgrade/blob/4fa1430655c68300cb046f96e2943e6ff7ac2fe3/addons/crm/security/crm_security.xml#L37

@Tecnativa