### PR TITLE
[14.0][FIX] hr_timesheet: Add missing group in the rule

### DIFF
--- a/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/noupdate_changes.xml
@@ -22,12 +22,15 @@
   <!-- <record id="project.group_project_manager" model="res.groups"> -->
     <!-- <field name="implied_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_approver'))]"/> -->
   <!-- </record> -->
-  <!-- <record id="timesheet_line_rule_manager" model="ir.rule">
+  <record id="timesheet_line_rule_manager" model="ir.rule">
+    <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
+  <!--
     <field name="perm_create"/>
     <field name="perm_read"/>
     <field name="perm_unlink"/>
     <field name="perm_write"/>
-  </record> -->
+  -->
+  </record>
   <record id="timesheet_line_rule_user" model="ir.rule">
     <field name="domain_force">[
                 ('user_id', '=', user.id),


### PR DESCRIPTION
In 13.0, there's only one group linked to this noupdate rule:

https://github.com/odoo/odoo/blob/affc9abbcf596e025af0fd33654af3fca709b2ed/addons/hr_timesheet/security/hr_timesheet_security.xml#L54

But in 14.0, there are two:

https://github.com/odoo/odoo/blob/23a18bc17ebf076000e68fdea4ab9ac8cefe46ba/addons/hr_timesheet/security/hr_timesheet_security.xml#L63

so we need to link the missing one.

It seems the noupdate changes extractor is not analyzing the attribute `eval`.

@Tecnativa