### PR TITLE
[14.0][OU-FIX] account: Fill account.payment>move_id from amls

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -314,14 +314,14 @@ def add_move_id_field_account_payment(env):
             AND am.payment_id IS NULL
         """,
     )
-    # 1. set move_id from moves where payment_id is defined
+    # 1. set move_id from move lines where payment_id is defined
     openupgrade.logged_query(
         env.cr,
         """
         UPDATE account_payment ap
-        SET move_id = am.id
-        FROM account_move am
-        WHERE am.payment_id = ap.id AND ap.move_id IS NULL""",
+        SET move_id = aml.move_id
+        FROM account_move_line aml
+        WHERE aml.payment_id = ap.id AND ap.move_id IS NULL""",
     )
     # 2. try to match on payment move_name or payment_reference (if move_name empty)
     openupgrade.logged_query(


### PR DESCRIPTION
Steps to do on v13:

* Create 2 expenses paid by company.
* Group both on the same expense report.
* Submit to manager the report.
* Approve the report.
* Put "Bank" as the bank journal.
* Post journal entries of the report.

Result: one account.move record is created containing 4 lines, and 2 account.payment records, one for each expense.

With the current code, only one payment is linked to the move, as taking the previously filled account_move>payment_id field for this task discards all expenses except one.

We take instead the payment_id linked on each expense aml for avoiding this problem.

FYI, on v14, no account.payment records are yet generated with the same operation.

@Tecnativa TT39116