### PR TITLE
[14.0][OU-IMP] account: Don't copy useless fields

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -529,14 +529,14 @@ def create_new_counterpart_account_payment_transfer(env):
         INSERT INTO account_payment (move_id, is_internal_transfer, partner_type,
             payment_type,
             amount, currency_id,
-            destination_account_id, partner_id, journal_id,
+            destination_account_id, partner_id,
             create_uid, create_date, write_uid, write_date)
         SELECT move.id, true, ap.partner_type,
             CASE
             WHEN journal.id = ap.destination_journal_id THEN 'inbound' ELSE 'outbound'
             END,
             ap.amount, ap.currency_id,
-            ap.destination_account_id, ap.partner_id, move.journal_id,
+            ap.destination_account_id, ap.partner_id,
             ap.create_uid, ap.create_date, ap.write_uid, ap.write_date
         FROM account_payment ap
         JOIN account_move move
@@ -567,13 +567,14 @@ def fill_account_payment_with_no_move(env):
         """
         SELECT ap.id, ap.%s, ap.%s, ap.%s, ap.state, aj.company_id
         FROM account_payment ap
-        JOIN account_journal aj ON ap.journal_id = aj.id
+        JOIN account_journal aj ON ap.%s = aj.id
         WHERE ap.move_id IS NULL
         """
         % (
             openupgrade.get_legacy_name("journal_id"),
             openupgrade.get_legacy_name("name"),
             openupgrade.get_legacy_name("payment_date"),
+            openupgrade.get_legacy_name("journal_id"),
         )
     )
     for (


### PR DESCRIPTION
Both account.payment and account.bank.statement.line are now inherited by delegation over move_id, which means that all the fields in the parent object are related non stored by default, and thus, there are no columns in the DB.

Copying the old columns instead of renaming them doesn't have sense then, as it will confuse any DB reader.