### PR TITLE
[15.0][MIG] website_sale_product_attribute_filter_visibility: Migration to v15

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -39,6 +39,8 @@ merged_modules = {
     "stock_barcode_mobile": "stock_barcode",
     # OCA/account-financial-tools
     "stock_account_prepare_anglo_saxon_out_lines_hook": "stock_account",
+    # OCA/e-commerce
+    "website_sale_product_attribute_filter_visibility": "website_sale",
     "account_menu": "account_usability",
     # OCA/account-invoicing
     "purchase_invoicing_no_zero_line": "purchase",

--- a/openupgrade_scripts/scripts/website_sale/15.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/website_sale/15.0.1.1/post-migration.py
@@ -1,6 +1,21 @@
 from openupgradelib import openupgrade
 
 
+def set_visibility_product_attribute(env):
+    # Check that website_sale_product_attribute_filter_visibility was installed
+    if not openupgrade.column_exists(env.cr, "product_attribute", "is_published"):
+        return
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE product_attribute
+        SET visibility = CASE WHEN is_published is not true THEN 'hidden'
+                              ELSE 'visible'
+                              END
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     # Load noupdate changes
@@ -16,3 +31,4 @@ def migrate(env, version):
             "mail_template_sale_cart_recovery",
         ],
     )
+    set_visibility_product_attribute(env)


### PR DESCRIPTION
Blocked by:

- [x] #3693

In version 15.0 the option to set product attributes as visible on website is set in module `website_sale`. So the module website_sale_product_attribute_filter_visibility is not necessary yet. 

By this PR we set the respective value on `visibility` field (https://github.com/odoo/odoo/blob/8e36f629ae9de37f5850bb5c0dd40acb3c04dd9f/addons/website_sale/models/product_attribute.py#L12) to show or not the product attribute depending on the value of `is_published` in last versions.

cc @Tecnativa TT36602

please @sergio-teruel @chienandalu review this