### PR TITLE
[MIG] Bootstrapping 16.0 + analysis

### DIFF
--- a/.github/workflows/documentation-commit.yml
+++ b/.github/workflows/documentation-commit.yml
@@ -25,9 +25,9 @@ jobs:
       PGUSER: "odoo"
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Check out Odoo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,9 +24,9 @@ jobs:
       PGUSER: "odoo"
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Check out Odoo
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           # The pylint-odoo version we use here does not support python 3.10
           # https://github.com/OCA/oca-addons-repo-template/issues/80

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,13 @@ jobs:
       OPENUPGRADE_USE_DEMO: "yes"
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.10'
       - name: Configure Postgres
         uses: harmon758/postgresql-action@v1
         with:
-          postgresql version: "10"
+          postgresql version: "14"
           postgresql user: ${DB_USERNAME}
           postgresql password: ${DB_PASSWORD}
       - name: Wait / Sleep
@@ -44,20 +44,7 @@ jobs:
         run: createdb $DB
       - name: DB Restore
         run: |
-          psql -d $DB -c "DROP SCHEMA IF EXISTS PUBLIC;"
           wget -q -O- $DOWNLOADS/15.0.psql | pg_restore -d $DB --no-owner
-          # TODO: create test data in Odoo 15.0 which does not support yml
-          # anymore
-          # Roundtrip to previous release to update the test database with
-          # additional test data
-          # - git fetch --depth 2 origin 15.0
-          # - git reset --hard `git ls-remote \
-          #       | grep refs/heads/15.0 \
-          #       | awk '{print $1}'`
-          # - pip install -q -r requirements.txt
-          # Line below may fail quite often due to Travis bug:
-          # - git reset -q --hard $TRAVIS_COMMIT
-          # Install Python requirements of target release
       - name: Check out Odoo
         uses: actions/checkout@v2
         with:
@@ -100,7 +87,7 @@ jobs:
         run: |
           MODULES_OLD=base,$(\
               sed -n '/^+========/,$p' \
-              openupgrade/docsource/modules140-150.rst \
+              openupgrade/docsource/modules150-160.rst \
               | grep "Done\|Partial\|Nothing" \
               | grep -v "theme_" \
               | sed -rn 's/((^\| *\|del\| *)|^\| *)([0-9a-z_]*)[ \|].*/\3/g p' \
@@ -108,7 +95,7 @@ jobs:
               | paste -d, -s)
           MODULES_NEW=base,$(\
               sed -n '/^+========/,$p' \
-              openupgrade/docsource/modules140-150.rst \
+              openupgrade/docsource/modules150-160.rst \
               | grep "Done\|Partial\|Nothing" \
               | grep -v "theme_" \
               | sed -rn 's/((^\| *\|new\| *)|^\| *)([0-9a-z_]*)[ \|].*/\3/g p' \


### PR DESCRIPTION
I pushed current 15.0 to 16.0 and started this branch by purged the 15.0 related files. I hope that's alright.

Added some documentation to https://github.com/OCA/OpenUpgrade/wiki/Set-up-the-branch-for-a-new-Odoo-release.

Also slightly updated:
* https://github.com/OCA/OpenUpgrade/wiki/Crude-script-to-create-the-full-analysis-between-two-versions-of-Odoo
* https://github.com/OCA/OpenUpgrade/wiki/How-to-create-a-reference-database