### PR TITLE
[11.0][FIX] project: Fix project_issue uninstalled bug.

### DIFF
--- a/addons/project/migrations/11.0.1.1/post-migration.py
+++ b/addons/project/migrations/11.0.1.1/post-migration.py
@@ -223,7 +223,7 @@ def remove_mail_subtypes(env):
 @openupgrade.migrate()
 def migrate(env, version):
     set_default_values(env)
-    if openupgrade.table_exists(env.cr, 'project_issue'):
+    if openupgrade.is_module_installed(env.cr, 'project_issue'):
         convert_issues(env)
     openupgrade.load_data(
         env.cr, 'project', 'migrations/11.0.1.1/noupdate_changes.xml'


### PR DESCRIPTION
This may seem like an insignificant change at first. However, I came across this because I was trying to upgrade a database that once had module `project_issue` installed, but not anymore. The migration script of `project` check for the existence of table `project_issue` to decide whether it will do something with these issues: https://github.com/OCA/OpenUpgrade/blob/4fa1430655c68300cb046f96e2943e6ff7ac2fe3/addons/project/migrations/11.0.1.1/post-migration.py#L226

However, if the module is not installed, column `label_issues` wil not exist on table `project_project`, and that will cause an error.

So in short, if you had module `project_issue` installed once but not anymore, you would get an error. This fixes it.