### PR TITLE
[14.0][OU-FIX] account: Switch state to cancel on dangling payments

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -588,7 +588,8 @@ def fill_account_payment_with_no_move(env):
         p_data[p_id] = {
             "journal_id": p_journal_id,
             "name": p_name,
-            "state": p_state,
+            # Switch to cancel when no linked move, but the payment was validated
+            "state": "cancelled" if p_state not in {"draft", "cancelled"} else p_state,
             "payment_date": p_payment_date,
         }
         if p_company in p_dates_by_company:


### PR DESCRIPTION
Coming from older versions of Odoo, you can have a payment with state "validated" or "reconciled", but no linked move, as it was deleted through the regular journal entry list.

On that situation, we are going to recreate the moves the same, but putting them on cancel state for not altering the accounting.

@Tecnativa TT39954