### PR TITLE
[16.0] [ADD] apriori.py: rename knowledge module

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -1,0 +1,9 @@
+""" Encode any known changes to the database here
+to help the matching process
+"""
+
+# Renamed modules is a mapping from old module name to new module name
+renamed_modules = {
+    # OCA/knowledge
+    "knowledge": "document_knowledge",
+}


### PR DESCRIPTION
Depends on https://github.com/OCA/knowledge/pull/368