### PR TITLE
update apriori OCA base_geolocalize_openstreetmap merged into base_geolocalize

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -68,6 +68,8 @@ merged_modules = {
     # OCA/event
     'event_activity': 'event',
     'website_event_share': 'website_event',
+    # OCA/geospatial
+    'base_geolocalize_openstreetmap': 'base_geolocalize',
     # OCA/l10n-spain
     'l10n_es_account_invoice_sequence': 'l10n_es',
     'l10n_es_aeat_mod303_extra_data': 'l10n_es_aeat_mod303',


### PR DESCRIPTION
- the OCA / geospatial V12 module name ``base_geolocalize_openstreetmap`` PR : https://github.com/OCA/geospatial/pull/276 allows to call osm API to get lat / long based on address. see : https://github.com/OCA/geospatial/blob/12.0/base_geolocalize_openstreetmap/models/res_partner.py#L14

- Odoo ``base_geolocalize`` V13 calls the same API. https://github.com/odoo/odoo/blob/13.0/addons/base_geolocalize/models/base_geocoder.py#L88

