### PR TITLE
[FIX] base: Uninstall l10n_it_edi to avoid conflict with l10n_it_fatturapa

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/end-migration.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/end-migration.py
@@ -3,6 +3,20 @@
 from openupgradelib import openupgrade
 
 
+def uninstall_conflicting_it_edi(cr):
+    it_edi_conflicting_modules = ("l10n_it_edi", "l10n_it_fatturapa")
+    if all(
+        openupgrade.is_module_installed(cr.cr, m) for m in it_edi_conflicting_modules
+    ):
+        it_edi_module = cr["ir.module.module"].search(
+            [
+                ("name", "=", "l10n_it_edi"),
+            ],
+            limit=1,
+        )
+        it_edi_module.button_uninstall()
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     """Call disable_invalid_filters in every edition of openupgrade"""
@@ -14,3 +28,4 @@ def migrate(env, version):
         openupgrade.update_module_names(
             env.cr, [("web_diagram", "web")], merge_modules=True
         )
+    uninstall_conflicting_it_edi(env)


### PR DESCRIPTION
From version `14.0`, module `l10n_it_fatturapa` conflicts with `l10n_it_edi`: https://github.com/OCA/l10n-italy/blob/bb780459361ad45900ccfb74aea22ca99b958d75/l10n_it_fatturapa/__manifest__.py#L16.

We assume that if `l10n_it_fatturapa` is installed, then `l10n_it_edi` is not to be installed: this is the accepted solution when this same error happens while installing the modules manually, see https://github.com/OCA/l10n-italy/blame/a5bb1352e155dd1e5d81feea5e631ad76543559e/l10n_it_fatturapa/README.rst#L70-L75.

Without this fix, when upgrading from `13.0` to `14.0`, the following is raised during the migration of `base`:
> odoo.exceptions.UserError: I moduli "ITA - Fattura elettronica - Base" e "Italy - E-invoicing" non sono compatibili.

(It means that mentioned modules are incompatible)