### PR TITLE
[13.0] apriori : web_widget_float_formula merged in web

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -114,6 +114,7 @@ merged_modules = {
     'web_favicon': 'base',
     'web_view_searchpanel': 'web',
     'web_widget_color': 'web',
+    'web_widget_float_formula': 'web',
     'web_widget_many2many_tags_multi_selection': 'web',
     'web_widget_one2many_product_picker_sale_stock_available_info_popup': (
         'web_widget_one2many_product_picker_sale_stock'


### PR DESCRIPTION
Trivial

web_widget_float_formula features. (computation on the fly in numeric field is native in V13).
see comment : https://github.com/OCA/web/pull/1592#issuecomment-624078632