### PR TITLE
[13.0][OU-FIX] survey: Change noupdate data on renamed records + no rename

### DIFF
--- a/addons/survey/migrations/13.0.3.0/noupdate_changes.xml
+++ b/addons/survey/migrations/13.0.3.0/noupdate_changes.xml
@@ -11,4 +11,27 @@
   <record id="group_survey_user" model="res.groups">
     <field name="category_id" ref="base.module_category_marketing_survey"/>
   </record>
+  <record id="survey_survey_rule_survey_user_read" model="ir.rule">
+    <field name="name">Survey: officer: read all</field>
+    <field name="domain_force">[(1, '=', 1)]</field>
+  </record>
+  <record id="survey_survey_rule_survey_manager" model="ir.rule">
+    <field name="name">Survey: manager: all</field>
+  </record>
+  <record id="survey_user_input_rule_survey_user_cw" model="ir.rule">
+    <field name="name">Survey user input: officer: create/write/unlink linked to own survey only</field>
+    <field name="domain_force">[('survey_id.create_uid', '=', user.id)]</field>
+    <field name="perm_unlink" eval="1"/>
+    <field name="perm_write" eval="1"/>
+    <field name="perm_read" eval="0"/>
+    <field name="perm_create" eval="1"/>
+  </record>
+  <record id="survey_user_input_rule_survey_user_read" model="ir.rule">
+    <field name="name">Survey user input: officer: read all</field>
+    <field name="domain_force">[(1, '=', 1)]</field>
+    <field name="groups" eval="[(5, 0), (4, ref('group_survey_user'))]"/>
+  </record>
+  <record id="survey_user_input_rule_survey_manager" model="ir.rule">
+    <field name="name">Survey user input: manager: all</field>
+  </record>
 </odoo>

--- a/addons/survey/migrations/13.0.3.0/post-migration.py
+++ b/addons/survey/migrations/13.0.3.0/post-migration.py
@@ -9,6 +9,7 @@ _unlink_by_xmlid = [
     'survey.stage_draft',
     'survey.stage_in_progress',
     'survey.stage_permanent',
+    'survey.email_template_survey',
 ]
 
 

--- a/addons/survey/migrations/13.0.3.0/pre-migration.py
+++ b/addons/survey/migrations/13.0.3.0/pre-migration.py
@@ -54,8 +54,6 @@ _xmlid_renames = [
     ('survey.survey_input_users_access', 'survey.survey_user_input_rule_survey_user_cw'),
     ('survey.survey_manager_access', 'survey.survey_survey_rule_survey_manager'),
     ('survey.survey_users_access', 'survey.survey_survey_rule_survey_user_read'),
-    # mail.template
-    ('survey.email_template_survey', 'survey.mail_template_user_input_invite'),
 ]
 
 


### PR DESCRIPTION
We renamed certain noupdate rules on the migration scripts:

https://github.com/OCA/OpenUpgrade/blob/3d8e1431a6c2843586653f32cf4b1b5a6c3d5d9c/addons/survey/migrations/13.0.3.0/pre-migration.py#L51-L56

but there was no update on the data inside the records, that change as well.

Let's fix it.

There's also a renaming on a mail template that it's very different, so let's simply not rename it and remove the old one.


@Tecnativa