### PR TITLE
[13.0][UPD] apriori product_active_propagate is now native in product V13.

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -91,6 +91,7 @@ merged_modules = {
     'hr_payroll_account': 'payroll_account',
     # OCA/product-attribute
     'product_pricelist_show_product_ref': 'product',
+    'product_active_propagate': 'product',
     # OCA/product-variant
     'sale_order_variant_mgmt': 'sale_product_matrix',
     # OCA/purchase-reporting


### PR DESCRIPTION
The module ``product_active_propagate`` (https://github.com/OCA/product-attribute/tree/12.0/product_active_propagate) corrected a bug that was fixed in V13 by this commit https://github.com/odoo/odoo/commit/01160ee5e7f726f3035c566a13e26825236dedfd
