### PR TITLE
[15.0][FIX] Switch Flake8 pre-commit source to GitHub

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,7 +101,7 @@ repos:
     rev: 3.1.0
     hooks:
       - id: setuptools-odoo-make-default
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
As Gitlab mirror is now offline.

@Tecnativa 