### PR TITLE
[OU] hr_holidays: recompute duration_display in script in order to avoid errors for changes on the selection

### DIFF
--- a/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/end-migration.py
+++ b/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/end-migration.py
@@ -1,0 +1,13 @@
+# Copyright (C) 2022 CreuBlanca
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+def recompute_duration_display(env):
+    # We need to recomupte it once all has been migrated
+    env["hr.leave"].search([])._compute_duration_display()
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    recompute_duration_display(env)

--- a/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/pre-migration.py
@@ -13,11 +13,23 @@ _field_renames = [
     ("hr.leave.type", "hr_leave_type", "validation_type", "leave_validation_type"),
 ]
 
+_field_spec = [
+    (
+        "duration_display",
+        "hr.leave",
+        "hr_leave",
+        "char",
+        False,
+        "hr_holidays",
+    )
+]
+
 
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.copy_columns(env.cr, _column_copies)
     openupgrade.rename_fields(env, _field_renames)
+    openupgrade.add_fields(env, _field_spec)
     openupgrade.set_xml_ids_noupdate_value(
         env,
         "hr_holidays",

--- a/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/hr_holidays/14.0.1.5/upgrade_analysis_work.txt
@@ -14,7 +14,11 @@ hr_holidays  / hr.leave                 / category_id (many2one)        : now a 
 hr_holidays  / hr.leave                 / date_from (datetime)          : now a function
 hr_holidays  / hr.leave                 / date_to (datetime)            : now a function
 hr_holidays  / hr.leave                 / department_id (many2one)      : now a function
+# NOTHING TO DO
+
 hr_holidays  / hr.leave                 / duration_display (char)       : is now stored
+# DONE: pre-migration: create field, end-migration: fill using the compute
+
 hr_holidays  / hr.leave                 / employee_id (many2one)        : now a function
 hr_holidays  / hr.leave                 / holiday_status_id (many2one)  : now a function
 hr_holidays  / hr.leave                 / manager_id (many2one)         : now a function


### PR DESCRIPTION
Value was computed automatically on the migration, but it might become a problem if a module modified the selection values of request_unit