### PR TITLE
[14.0][OU] product_expiry: Fill expiration_date

### DIFF
--- a/openupgrade_scripts/scripts/product_expiry/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/product_expiry/14.0.1.0/post-migration.py
@@ -29,12 +29,9 @@ def migrate(env, version):
         """
         UPDATE stock_move_line sml
         SET expiration_date = spl.expiration_date
-        FROM stock_production_lot spl, product_product pp
-        JOIN product_template pt ON pp.product_tmpl_id = pt.id, stock_picking sp
-        JOIN stock_picking_type spt ON sp.picking_type_id = spt.id
-        WHERE spl.id = sml.lot_id AND sml.picking_id = sp.id
-            AND spt.use_existing_lots AND sml.product_id = pp.id
-            AND pt.use_expiration_date""",
+        FROM stock_production_lot spl
+        WHERE spl.id = sml.lot_id AND spl.expiration_date IS NOT NULL
+        """,
     )
     openupgrade.logged_query(
         # use sml.create_date
@@ -46,7 +43,11 @@ def migrate(env, version):
         FROM product_product pp
         JOIN product_template pt ON pp.product_tmpl_id = pt.id, stock_picking sp
         JOIN stock_picking_type spt ON sp.picking_type_id = spt.id
-        WHERE (sml.lot_id IS NULL OR sml.expiration_date IS NULL) AND
-            sml.picking_id = sp.id AND spt.use_existing_lots AND sml.product_id = pp.id
-            AND pt.use_expiration_date AND pt.expiration_time IS NOT NULL""",
+        WHERE
+            sml.product_id = pp.id
+            AND sml.picking_id = sp.id
+            AND spt.use_create_lots
+            AND pt.use_expiration_date
+            AND pt.expiration_time IS NOT NULL
+            AND sml.expiration_date IS NULL""",
     )

--- a/openupgrade_scripts/scripts/product_expiry/14.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/product_expiry/14.0.1.0/pre-migration.py
@@ -6,8 +6,19 @@ _field_renames = [
     ("product.template", "product_template", "life_time", "expiration_time"),
     ("stock.production.lot", "stock_production_lot", "life_date", "expiration_date"),
 ]
+_field_creates = [
+    (
+        "expiration_date",
+        "stock.move.line",
+        "stock_move_line",
+        "datetime",
+        False,
+        "stock",
+    )
+]
 
 
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_fields(env, _field_renames)
+    openupgrade.add_fields(env, _field_creates)


### PR DESCRIPTION
When reviewing product_expiry results I found that the query was not following the same logic from odoo function

https://github.com/odoo/odoo/blob/14.0/addons/product_expiry/models/stock_move_line.py#L18-L27

I might be wrong, but function uses use_create_lots for the second function, but the migration one used use_existing_lots

Also, I removed unnecessary filters that were not present on the original function :thinking: 