### PR TITLE
[16.0][MIG] mass_editing: Rename to server_action_mass_edit

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -19,6 +19,8 @@ renamed_modules = {
     "sale_coupon_taxcloud_delivery": "sale_loyalty_taxcloud_delivery",
     # OCA/knowledge
     "knowledge": "document_knowledge",
+    # OCA/server-ux
+    "mass_editing": "server_action_mass_edit",
     # OCA/...
 }
 


### PR DESCRIPTION
Rename addon, from mass_editing to server_action_mass_edit.

Related to https://github.com/OCA/server-ux/pull/544

Please @pedrobaeza can you review it?

@Tecnativa