### PR TITLE
[OU-FIX] calendar: Fix possible invalid recursive settings

### DIFF
--- a/openupgrade_scripts/scripts/calendar/14.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/calendar/14.0.1.0/pre-migration.py
@@ -3,6 +3,39 @@
 from openupgradelib import openupgrade
 
 
+def fix_empty_end_type(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE calendar_event
+        SET end_type = 'count'
+        WHERE end_type is NULL AND recurrency is True
+        """,
+    )
+
+
+def fix_negative_interval(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE calendar_event
+        SET interval = 1
+        WHERE interval<=0 AND recurrency is True
+        """,
+    )
+
+
+def fix_negative_count(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE calendar_event
+        SET count = 1
+        WHERE count<=0 AND recurrency is True
+        """,
+    )
+
+
 def delete_empty_event_id_partner_id_records(env):
     openupgrade.logged_query(
         env.cr,
@@ -34,6 +67,9 @@ def fill_empty_privacy_and_show_as_fields(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
+    fix_empty_end_type(env)
+    fix_negative_interval(env)
+    fix_negative_count(env)
     delete_empty_event_id_partner_id_records(env)
     fill_empty_privacy_and_show_as_fields(env)
     openupgrade.copy_columns(env.cr, {"calendar_event": [("byday", None, None)]})


### PR DESCRIPTION
When coming from a very old odoo/openerp version, some calendar recursive events might have invalid settings (no `end_type`, or `count/interval <= 0`.

Having one of these invalid values mislead the `_rrule_parse` return and implies an infinite loop in `_get_ranges`. So `create_recurrent_events` is stuck and will never end.