### PR TITLE
[14.0][OU-FIX] hr_timesheet: Delete obsolete view

### DIFF
--- a/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/pre-migration.py
@@ -29,3 +29,8 @@ def migrate(env, version):
         True,
     )
     _fill_task_overtime(env)
+    # Remove obsolete view from "hr_timesheet_analysis" module that would
+    # collide with the new "timesheet_action_view_all_pivot" view
+    openupgrade.delete_records_safely_by_xml_id(
+        env, ["hr_timesheet_analysis.act_hr_timesheet_line_view_all_pivot"]
+    )


### PR DESCRIPTION
In previous `hr_timesheet_analysis` module version, a pivot view was already defined for the `hr_timesheet.timesheet_action_all` action.

In 14.0, the `hr_timesheet` module introduced its own pivot view `timesheet_action_view_all_pivot` that collides with the deprecated one from the OCA module and raise a constraint exception:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "act_window_view_unique_mode_per_action"
DETAIL:  Key (act_window_id, view_mode)=(xxx, pivot) already exists.
```