### PR TITLE
[14.0][OU-ADD] website_form_recaptcha: Merged in website_form

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -101,6 +101,8 @@ merged_modules = {
     "web_editor_background_color": "web_editor",
     # OCA/website
     "website_cookie_notice": "website",
+    "website_form_recaptcha": "website_form",
+    "website_crm_recaptcha": "website_form",
     # OCA/...
 }
 


### PR DESCRIPTION
The features of this module has been integrated in core.

Migration tips:

- Generate recaptcha v3 keys in advance and set them in their correspondant `ir.config_parameters` so that they'll be available on the fresh migration See https://github.com/odoo/odoo/blob/14.0/addons/google_recaptcha/models/res_config_settings.py#L11-L12
- The recaptcha v3 will be applied directly to the form enabled models forms (it is possible to enable the license and terms in every form from the form editor settings but it works anyway).


cc @Tecnativa TT34839

please review @CarlosRoca13 @pedrobaeza 