### PR TITLE
[15.0][MIG] website_sale_cart_no_redirect: Migration to 15.0

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -35,6 +35,8 @@ merged_modules = {
     # OCA/account-financial-tools
     "stock_account_prepare_anglo_saxon_out_lines_hook": "stock_account",
     "account_menu": "account_usability",
+    # OCA/e-commerce
+    "website_sale_cart_no_redirect": "website_sale",
     # OCA/hr
     "hr_recruitment_notification": "hr_recruitment",
     # OCA/hr-attendance


### PR DESCRIPTION
This module was backported from this version and the fields does not need any kind of conversion. So is a module to be merged.

Field created on `website` model: https://github.com/odoo/odoo/blob/8986330a14000da7f88d2787ff54965d71ca02b7/addons/website_sale/models/website.py#L53

cc @Tecnativa TT39018

please @pedrobaeza @chienandalu review this