### PR TITLE
[15.0][MIG] sale_coupon_mass_mailing: Rename to coupon_mass_mailing

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -14,6 +14,8 @@ renamed_modules = {
     "website_sale_attribute_filter_order": "website_sale_product_attribute_filter_order",
     # OCA/project
     "project_stage_state": "project_task_stage_state",
+    # OCA/sale-promotion
+    "sale_coupon_mass_mailing": "coupon_mass_mailing",
     # OCA/stock-logistics-worehouse
     "stock_inventory_cost_info": "stock_quant_cost_info",
     # OCA/...


### PR DESCRIPTION
@Tecnativa

Rename addon, from sale_coupon_mass_mailing to coupon_mass_mailing.

Related to https://github.com/OCA/sale-promotion/pull/93

@pedrobaeza check that everything is correct, please

ping @chienandalu @victoralmau 