### PR TITLE
[15.0][OU-ADD] project_timeline_task_dependency: Merged with project_timeline

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -49,6 +49,7 @@ merged_modules = {
     # OCA/project
     "project_mail_chatter": "project",
     "project_task_dependency": "project",
+    "project_timeline_task_dependency": "project_timeline",
     # OCA/web
     "web_decimal_numpad_dot": "web",
 }


### PR DESCRIPTION
As said in this comment https://github.com/OCA/project/pull/942#discussion_r935782545 this module is deprecated in v15 as the feature is added at project_timeline level

cc @Tecnativa TT40300

ping @chienandalu @pedrobaeza 