### PR TITLE
[14.0][OU-IMP] base: Spanish address format

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/noupdate_changes.xml
@@ -86,4 +86,7 @@
   <record id="vn" model="res.country">
     <field name="zip_required">0</field>
   </record>
+  <record id="es" model="res.country">
+    <field eval="'%(street)s\n%(street2)s\n%(zip)s %(city)s (%(state_name)s)\n%(country_name)s'" name="address_format"/>
+  </record>
 </odoo>


### PR DESCRIPTION
After odoo/odoo#110918, we put this new format on migrated v14 DBs.

This is needed also on OU 15 and OU 16, as the change has been made after version release, so there can be DBs without it.

@Tecnativa