### PR TITLE
[15.0][OU-IMP] base: Spanish address format

### DIFF
--- a/openupgrade_scripts/scripts/base/15.0.1.3/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/base/15.0.1.3/noupdate_changes.xml
@@ -600,4 +600,7 @@
     <field name="company_ids" eval="[Command.link(ref('main_company'))]"/>
   </record>
 -->
+  <record id="es" model="res.country">
+    <field eval="'%(street)s\n%(street2)s\n%(zip)s %(city)s (%(state_name)s)\n%(country_name)s'" name="address_format"/>
+  </record>
 </odoo>


### PR DESCRIPTION
After odoo/odoo#110918, we put this new format on migrated v15 DBs for those not containing the new format as they were populated in v14 before the commit.

Same as #3703 but for v15

@Tecnativa