### PR TITLE
[14.0][IMP] website_sale: Convert an html string from odoo version 13 to new definitions in version 14

### DIFF
--- a/openupgrade_scripts/scripts/website_sale/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website_sale/14.0.1.0/post-migration.py
@@ -2,7 +2,7 @@
 # Copyright 2021 ForgeFlow S.L.  <https://www.forgeflow.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from openupgradelib import openupgrade
+from openupgradelib import openupgrade, openupgrade_140
 
 
 @openupgrade.migrate()
@@ -56,4 +56,12 @@ def migrate(env, version):
         DELETE FROM ir_model_data
         WHERE module = 'website_sale' and name = 'image_full'
         """,
+    )
+    openupgrade_140.convert_field_html_string_13to14(
+        env, "product.template", "website_description"
+    )
+    openupgrade_140.convert_field_html_string_13to14(
+        env,
+        "product.public.category",
+        "website_description",
     )


### PR DESCRIPTION
Convert an html string from an html field of an website from odoo version 13 to the new definitions in version 14.
Pending from:
- [ ] https://github.com/OCA/openupgradelib/pull/315
- [ ] #3707

cc @Tecnativa TT41466

@chienandalu please review