### PR TITLE
[14.0][IMP] website_partner: Convert an html string from odoo version 13 to new definitions in version 14

### DIFF
--- a/openupgrade_scripts/scripts/website_partner/14.0.0.1/post-migration.py
+++ b/openupgrade_scripts/scripts/website_partner/14.0.0.1/post-migration.py
@@ -1,0 +1,10 @@
+from openupgradelib import openupgrade, openupgrade_140
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade_140.convert_field_html_string_13to14(
+        env,
+        "res.partner",
+        "website_description",
+    )


### PR DESCRIPTION
Convert an html string from an html field of an website from odoo version 13 to the new definitions in version 14.
Pending from:
- [ ] https://github.com/OCA/openupgradelib/pull/315
- [ ] #3707

cc @Tecnativa TT41468

@chienandalu please review