### PR TITLE
[14.0][IMP] website_blog: html string from version 13 to 14

### DIFF
--- a/openupgrade_scripts/scripts/website_blog/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website_blog/14.0.1.0/post-migration.py
@@ -1,6 +1,11 @@
-from openupgradelib import openupgrade
+from openupgradelib import openupgrade, openupgrade_140
 
 
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env.cr, "website_blog", "14.0.1.0/noupdate_changes.xml")
+    openupgrade_140.convert_field_html_string_13to14(
+        env,
+        "blog.post",
+        "content",
+    )


### PR DESCRIPTION
Convert an html string from an html field of an website from odoo version 13 to the new definitions in version 14.
Pending from: 
- [ ] https://github.com/OCA/openupgradelib/pull/315
- [ ] #3707

cc @Tecnativa TT41471

@chienandalu please review