### PR TITLE
[13.0][OU-IMP] l10n_es: Handle food taxes renaming

### DIFF
--- a/addons/l10n_es/migrations/13.0.4.0/pre-migration.py
+++ b/addons/l10n_es/migrations/13.0.4.0/pre-migration.py
@@ -1,4 +1,5 @@
 # Copyright 2020 ForgeFlow <http://www.forgeflow.com>
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
@@ -46,8 +47,37 @@ def set_account_move_number_to_invoice_number(env):
     )
 
 
+def rename_food_taxes_xmlids(env):
+    renames = [
+        ("account_tax_template_p_iva0_a", "account_tax_template_p_iva0_s_bc"),
+        ("account_tax_template_p_iva5_a", "account_tax_template_p_iva5_bc"),
+        ("account_tax_template_p_iva0_ic_a", "account_tax_template_p_iva0_ic_bc"),
+        ("account_tax_template_p_iva5_ic_a", "account_tax_template_p_iva5_ic_bc"),
+        ("account_tax_template_p_iva0_ia", "account_tax_template_p_iva0_ibc"),
+        ("account_tax_template_p_iva5_ia", "account_tax_template_p_iva5_ibc"),
+        ("account_tax_template_p_req0625", "account_tax_template_p_req062"),
+        ("account_tax_template_s_iva0_a", "account_tax_template_s_iva0b"),
+        ("account_tax_template_s_iva5_a", "account_tax_template_s_iva5b"),
+        ("account_tax_template_s_req0625", "account_tax_template_s_req062"),
+    ]
+    companies = env["res.company"].with_context(active_test=False).search([])
+    for old, new in renames:
+        openupgrade.rename_xmlids(env.cr, [("l10n_es." + old, "l10n_es." + new)])
+        for company in companies:
+            openupgrade.rename_xmlids(
+                env.cr,
+                [
+                    (
+                        "l10n_es.%s_" % company.id + old,
+                        "l10n_es.%s_" % company.id + new,
+                    ),
+                ],
+            )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     if openupgrade.column_exists(
             env.cr, "account_invoice", "invoice_number"):
         set_account_move_number_to_invoice_number(env)
+    rename_food_taxes_xmlids(env)


### PR DESCRIPTION
We created the tax mapping for <=13.0 before Odoo reacts, assigning several XML-IDs. Later, Odoo created another PR adding such taxes with different XML-IDs.

We have homogenized such XML-IDs till 13.0, but on previous versions, on `l10n_es_extra_data` (already merged into `l10n_es` in apriori), old XML-IDs were preserved.

With this addition, we rename both tax templates and company taxes for avoiding an error on duplicated tax names + incorrect tax mappings.

@Tecnativa