### PR TITLE
[14.0][FIX] Remove unixodbc package

### DIFF
--- a/.github/workflows/documentation-commit.yml
+++ b/.github/workflows/documentation-commit.yml
@@ -57,8 +57,7 @@ jobs:
               python3-serial \
               python3-simplejson \
               python3-werkzeug \
-              python3-yaml \
-              unixodbc-dev
+              python3-yaml
       - name: Requirements Installation
         run: |
           pip install -q -r odoo/requirements.txt

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,8 +56,7 @@ jobs:
               python3-serial \
               python3-simplejson \
               python3-werkzeug \
-              python3-yaml \
-              unixodbc-dev
+              python3-yaml
       - name: Requirements Installation
         run: |
           pip install -q -r odoo/requirements.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,7 @@ jobs:
               python3-serial \
               python3-simplejson \
               python3-werkzeug \
-              python3-yaml \
-              unixodbc-dev
+              python3-yaml
       - name: Requirements Installation
         run: |
           sudo npm install -g less less-plugin-clean-css


### PR DESCRIPTION
Due to the error

```
dpkg: error processing archive /tmp/apt-dpkg-install-F5P19I/09-libodbc1_2.3.11_amd64.deb (--unpack):
trying to overwrite '/usr/lib/x86_64-linux-gnu/libodbc.so.2.0.0', which is also in package libodbc2:amd64 2.3.9-5
```