### PR TITLE
[11.0][FIX] hr_timesheet: Migrate the users of the timesheets' old "Officer" group to the new "Manager" group.

### DIFF
--- a/addons/hr_timesheet/migrations/11.0.1.0/pre-migration.py
+++ b/addons/hr_timesheet/migrations/11.0.1.0/pre-migration.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Tecnativa - Vicent Cubells
+# Copyright 2023 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
@@ -6,6 +7,10 @@ from openupgradelib import openupgrade
 _xmlid_renames = [
     ('website_project_timesheet.portal_task_timesheet_rule',
      'hr_timesheet.timesheet_rule_portal'),
+    (
+        "hr_timesheet.group_hr_timesheet_user",
+        "hr_timesheet.group_timesheet_manager"
+    )
 ]
 
 


### PR DESCRIPTION
Superseed by: https://github.com/OCA/OpenUpgrade/pull/3189 + Suggested changes in https://github.com/OCA/OpenUpgrade/pull/3189#issuecomment-1157250863

Migrate the users of the timesheets' old "Officer" group to the new "Manager" group.

Please @pedrobaeza can you review it?

@Tecnativa TT41822