### PR TITLE
[11.0][OU-FIX] hr_timesheet: Don't insert same permission several times

### DIFF
--- a/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
+++ b/addons/hr_timesheet/migrations/11.0.1.0/post-migration.py
@@ -61,7 +61,7 @@ def add_group_hr_timesheet_user_from_analytic_lines(env):
         env.cr, """
         INSERT INTO res_groups_users_rel
             (gid, uid)
-        SELECT %s, aal.user_id
+        SELECT DISTINCT %s, aal.user_id
         FROM account_analytic_line aal
         WHERE aal.user_id IS NOT NULL AND aal.user_id NOT IN (
             SELECT uid


### PR DESCRIPTION
You can have more than one analytic line per user, and there's a 
constraint forbidding it.
This fixes res_groups_users_rel_gid_uid_key constraint error on migrate.