### PR TITLE
[9.0][FIX] hr: delete safely constraint

### DIFF
--- a/addons/account/migrations/9.0.1.1/post-migration.py
+++ b/addons/account/migrations/9.0.1.1/post-migration.py
@@ -7,7 +7,6 @@
 import logging
 import operator
 from openupgradelib import openupgrade, openupgrade_90
-from openerp.modules.registry import RegistryManager
 from psycopg2.extensions import AsIs
 
 _logger = logging.getLogger('account.migrations.9.0.1.1.post_migration')
@@ -1393,9 +1392,8 @@ def migrate(env, version):
         """
     )
 
-    registry = RegistryManager.get(cr.dbname)
     openupgrade.m2o_to_x2m(
-        cr, registry['account.bank.statement.line'],
+        cr, env['account.bank.statement.line'],
         'account_bank_statement_line',
         'journal_entry_ids',
         openupgrade.get_legacy_name('journal_entry_id'),

--- a/addons/hr/migrations/9.0.1.1/pre-migration.py
+++ b/addons/hr/migrations/9.0.1.1/pre-migration.py
@@ -22,3 +22,7 @@ def migrate(env, version):
         ('module', '=', 'base'),
         ('name', '=', 'group_hr_attendance'),
     ]).write({'noupdate': 0})
+    # Disappeared constraint
+    openupgrade.delete_sql_constraint_safely(
+        env, "hr", "hr_job", "hired_employee_check"
+    )


### PR DESCRIPTION
Constraint removed in https://github.com/odoo/odoo/commit/b5b2718e76cbd0dd79870eafa4a2e2334bd5270e (odoo 9.0).

The field `no_of_hired_employee` always existed in `hr` module. But Odoo 15.0 added a compute for this field in https://github.com/odoo/odoo/commit/b4ba7f12ae367ef3ba99523ba8fcfb6d1d7321a1. So, for databases coming from 9.0 (and still have that constraint) it breaks during the compute.