### PR TITLE
[14.0][OU-ADD] pos_ticket_logo: Merged into point_of_sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -91,6 +91,8 @@ merged_modules = {
     # OCA/partner-contact
     "base_vat_sanitized": "base_vat",
     "partner_bank_active": "base",
+    # OCA/pos
+    "pos_ticket_logo": "point_of_sale",
     # OCA/project
     "project_description": "project",
     "project_stage_closed": "project",


### PR DESCRIPTION
This module was a mere fix to an historical PoS issue and we got it finally into upstream: https://github.com/odoo/odoo/pull/115102

cc @Tecnativa TT38068