### PR TITLE
[14.0][FIX] hr_expense: update noupdate data in case data exists

### DIFF
--- a/openupgrade_scripts/scripts/hr_expense/14.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/14.0.2.0/post-migration.py
@@ -1,0 +1,14 @@
+# Copyright 2023 ForgeFlow <https://www.forgeflow.com/>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    product = env.ref("product_product_fixed_cost", raise_if_not_found=False)
+    if product:
+        try:
+            product.default_code = False
+        except Exception:
+            # this means default_code is requited
+            product.default_code += "/1"


### PR DESCRIPTION
History:

1.- In v12 a product existed with `default_code = EXP_GEN`: https://github.com/odoo/odoo/blob/12.0/addons/hr_expense/data/hr_expense_data.xml#L5

2.- In v13, this product was moved to demo data: https://github.com/odoo/odoo/blob/13.0/addons/hr_expense/data/hr_expense_demo.xml#L82

3.- Thus, it was deleted in v13: https://github.com/OCA/OpenUpgrade/blob/13.0/addons/hr_expense/migrations/13.0.2.0/post-migration.py#L57

4.- In v14, the same product is again as data, but without that default_code: https://github.com/odoo/odoo/blob/14.0/addons/hr_expense/data/hr_expense_data.xml

5.- In v15, a new product is added with uses that default_code: https://github.com/odoo/odoo/blob/15.0/addons/hr_expense/data/hr_expense_data.xml#L15

Error:

Suppose the initial product is not deleted in OU13, and you have installed product_code_unique module. When migrating to v15, an error is shown:
```rst
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "product_product_default_code_uniq"
DETAIL: Key (default_code)=(EXP_GEN) already exists.
```

Alternative solution:

Remove `config["test_enable"]` from https://github.com/OCA/product-attribute/blob/15.0/product_code_unique/models/product.py#L30.
