### PR TITLE
[16.0][OU-ADD] account_move_force_removal: Merged into account

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -47,6 +47,7 @@ merged_modules = {
     "website_sale_gift_card": "website_sale_loyalty",
     # OCA/account-financial-tools
     "account_balance_line": "account",
+    "account_move_force_removal": "account",
     # OCA/...
 }
 


### PR DESCRIPTION
The module was basically just bypassing the check made in method _unlink_forbid_parts_of_chain() that was ensuring that the sequence number was the last element of a chain of sequence.

In V16 that method was removed, see odoo/odoo@6112f4f.

@Tecnativa TT42213