### PR TITLE
[14.0][OU-FIX] stock: Check picking state, not move

### DIFF
--- a/openupgrade_scripts/scripts/stock/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/stock/14.0.1.1/post-migration.py
@@ -1,4 +1,5 @@
 # Copyright 2021 ForgeFlow S.L.  <https://www.forgeflow.com>
+# Copyright 2023 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
@@ -26,7 +27,7 @@ def recompute_stock_picking_scheduled_date(env):
         SELECT sp.id
         FROM stock_picking sp
         JOIN stock_move sm ON sm.picking_id = sp.id
-        WHERE sm.state NOT IN ('done', 'cancel')"""
+        WHERE sp.state NOT IN ('done', 'cancel')"""
     )
     picking_ids = [pick[0] for pick in env.cr.fetchall()]
     if picking_ids:


### PR DESCRIPTION
The constraint condition is checked on the picking, not the move:

https://github.com/odoo/odoo/blob/29d691327317600ddf2116b7c02709bbeb6cae5b/addons/stock/models/stock_picking.py#L540

so we should build the SQL with that in mind.

If not, you can find an stock.move in draft inside a done picking, which was possible in previous Odoo versions.

@Tecnativa