### PR TITLE
[15.0][OU] stock_inventory_exclude_sublocation: merged into stock

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -66,6 +66,7 @@ merged_modules = {
     # OCA/stock-logistics-reporting
     "stock_inventory_valuation_pivot": "stock_account",
     # OCA/stock-logistics-warehouse
+    "stock_inventory_exclude_sublocation": "stock",
     "stock_orderpoint_manual_procurement": "stock",
     # OCA/stock-logistics-workflow
     "stock_deferred_assign": "stock",


### PR DESCRIPTION
Cc @Tecnativa TT36994

With the new approach to inventory adjustment in Odoo, in order to include or not include sub-locations, it is enough to filter the quants of the locations you want in the quants tree view and perform the quantities ajustment.

![Peek 2023-03-31 18-04](https://user-images.githubusercontent.com/38267832/229172399-dd051ce1-2132-40ea-8842-ffb8e3efc5a7.gif)
