### PR TITLE
[16.0][ADD] Apriori : 'stock_picking_backorder_strategy' merged into 'stock'.

### DIFF
--- a/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
@@ -1,6 +1,25 @@
 from openupgradelib import openupgrade
 
+def _handle_stock_picking_backorder_strategy(env):
+    # Handle the merge of OCA/stock-logistics-workflow/stock_picking_backorder_strategy
+    # feature in odoo/stock V16 module.
+    if openupgrade.column_exists(
+        env.cr, "stock_picking_type", openupgrade.get_legacy_name("backorder_strategy")
+    ):
+        openupgrade.map_values(
+            env.cr,
+            openupgrade.get_legacy_name("backorder_strategy"),
+            "create_backorder",
+            [
+                ("manual", "ask"),
+                ("create", "always"),
+                ("no_create", "never"),
+                ("cancel", "never"),
+            ],
+            table="stock_picking_type",
+        )
 
 @openupgrade.migrate()
 def migrate(env, version):
+    _handle_stock_picking_backorder_strategy(env)
     openupgrade.load_data(env.cr, "stock", "16.0.1.1/noupdate_changes.xml")

--- a/openupgrade_scripts/scripts/stock/16.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/stock/16.0.1.1/pre-migration.py
@@ -111,6 +111,20 @@ def _update_stock_quant_package_pack_date(env):
         """,
     )
 
+def _handle_stock_picking_backorder_strategy(env):
+    # Handle the merge of OCA/stock-logistics-workflow/stock_picking_backorder_strategy
+    # feature in odoo/stock V16 module.
+    if openupgrade.column_exists(env.cr, "stock_picking_type", "backorder_strategy"):
+        # Rename column
+        openupgrade.rename_columns(
+            env.cr,
+            {
+                "stock_picking_type": [
+                    ("backorder_strategy", None),
+                ],
+            },
+        )
+
 
 @openupgrade.migrate()
 def migrate(env, version):
@@ -122,3 +136,4 @@ def migrate(env, version):
     _update_stock_quant_package_pack_date(env)
     _update_sol_product_category_name(env)
     _compute_stock_location_replenish_location(env)
+    _handle_stock_picking_backorder_strategy(env)


### PR DESCRIPTION
**Note** : When migrating 'stock' module

**Rename** ``stock_picking_type field`` 'backorder_strategy' -> 'create_backorder';

**Map values** : {'manual': 'ask', 'no_create': 'never', 'cancel': never', 'create': 'always'}

Ref : OCA/15.0 module : https://github.com/OCA/stock-logistics-workflow/blob/15.0/stock_picking_backorder_strategy/models/stock_picking_type.py#L10
Ref : odoo/16.0 code : https://github.com/odoo/odoo/blob/16.0/addons/stock/models/stock_picking.py#L91

CC: @pedrobaeza, @MiquelRForgeFlow 

