### PR TITLE
[14.0][OU-IMP] mass_mailing: compute medium_id

### DIFF
--- a/openupgrade_scripts/scripts/mass_mailing/14.0.2.2/post-migration.py
+++ b/openupgrade_scripts/scripts/mass_mailing/14.0.2.2/post-migration.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def set_mailing_medium(env):
+    """The field column exists before migration so the new compute behavior won't be
+    triggered. We need to load the values as it's required in the view"""
+    medium_email = env.ref("utm.utm_medium_email").id
+    openupgrade.logged_query(
+        env.cr,
+        f"""
+        UPDATE mailing_mailing
+        SET medium_id = {medium_email}
+        WHERE mailing_type = 'mail'
+        AND medium_id IS NULL
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    set_mailing_medium(env)

--- a/openupgrade_scripts/scripts/mass_mailing/14.0.2.2/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/mass_mailing/14.0.2.2/upgrade_analysis_work.txt
@@ -21,7 +21,11 @@ mass_mailing / mailing.mailing          / preview (char)                : NEW
 
 mass_mailing / mailing.mailing          / mailing_domain (char)         : now a function
 mass_mailing / mailing.mailing          / mailing_model_id (many2one)   : now required, req_default: function
+# NOTHING TO DO: computed in load
+
 mass_mailing / mailing.mailing          / medium_id (many2one)          : now a function
+# DONE: post-migration: the field is required in the mailing view, so we fill it according to its default computed values if empty
+
 mass_mailing / mailing.mailing          / reply_to (char)               : now a function
 mass_mailing / mailing.mailing          / reply_to_mode (selection)     : now a function
 # NOTHING TO DO: computed in load


### PR DESCRIPTION
`mailing_mailing.medium_id` existed in prior versions as a non computed field thus it isn't recomputed in the update. We need to do it as it's now a required field in the mailing view.

cc @Tecnativa TT29993

ping @pedrobaeza 