### PR TITLE
[14.0][OU-FIX] account: change statement state after st_lines filling

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -814,7 +814,6 @@ def migrate(env, version):
     create_account_reconcile_model_lines(env)
     create_account_reconcile_model_template_lines(env)
     create_account_tax_report_lines(env)
-    post_statements_with_unreconciled_lines(env)
     pass_bank_statement_line_note_to_journal_entry_narration(env)
     pass_payment_to_journal_entry_narration(env)
     fill_company_account_cash_basis_base_account_id(env)
@@ -831,6 +830,7 @@ def migrate(env, version):
     fill_account_payment_reconciliation(env)
     fill_account_payment_with_no_move(env)
     fill_account_bank_statement_line_reconciliation(env)
+    post_statements_with_unreconciled_lines(env)
     _delete_hooks(env)
     openupgrade.delete_record_translations(
         env.cr,


### PR DESCRIPTION
We are changing the state of the statement to "Processing" if not all the statement lines are reconciled, but the field used for such comparison is not yet filled, so we have to delay the query until the execution of the other method (fill_account_bank_statement_line_reconciliation).

TT42592