### PR TITLE
[FIX] base: Avoid archive EUR and USD currency

### DIFF
--- a/openupgrade_scripts/scripts/base/15.0.1.3/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/base/15.0.1.3/noupdate_changes.xml
@@ -134,7 +134,6 @@
     <field name="full_name">Ethiopian birr</field>
   </record>
   <record id="EUR" model="res.currency">
-    <field name="active" eval="False"/>
     <field name="full_name">Euro</field>
   </record>
   <record id="FJD" model="res.currency">
@@ -453,7 +452,6 @@
     <field name="full_name">Ugandan shilling</field>
   </record>
   <record id="USD" model="res.currency">
-    <field name="active" eval="False"/>
     <field name="full_name">United States dollar</field>
   </record>
   <record id="UYU" model="res.currency">


### PR DESCRIPTION
I think that currencies shouldn't been archived, also when upgrading with EUR or USD as the company currency the script [account/15.0.1.2/post-migration.py](https://github.com/OCA/OpenUpgrade/blob/15.0/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py#L45) fails because those currencies are archived at start and the script does:
- Search for payments
- Filters the payments with currency active=False
- Active those currencies
- Does his work
- Archive again the currencies

 Summary of the error:
``` python
.../openupgrade/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py", line 45, in fill_paired_payment 
payments_inactive_currency.move_id.currency_id.active = False     
...
... odoo/odoo/addons/base/models/res_currency.py", line 110, in _check_company_currency_stays_active 
raise UserError(_("This currency is set on a company and therefore cannot be deactivated.")) 
```

Steps to reproduce:
- Grab a 14.0 DB with company currency = EUR and account module installed.
- Run openupgrade process to 15.0


cc @MiquelRForgeFlow @legalsylvain 