### PR TITLE
[15.0][OU-FIX] account: Don't create counterpart payments for internal transfers

### DIFF
--- a/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
@@ -20,7 +20,7 @@ def _fill_account_analytic_line_category(env):
     )
 
 
-def fill_paired_payment(env):
+def _fill_payment_destination_journal(env):
     openupgrade.logged_query(
         env.cr,
         """
@@ -31,18 +31,6 @@ def fill_paired_payment(env):
             AND ap.move_id = am.id AND am.state = 'posted'
             AND aj.type in ('bank', 'cash') AND aj.id != am.journal_id""",
     )
-    payments = env["account.payment"].search(
-        [("state", "=", "posted"), ("destination_journal_id", "!=", False)]
-    )
-    payments_inactive_currency = payments.filtered(
-        lambda p: not p.move_id.currency_id.active
-    )
-    payments_inactive_currency.move_id.currency_id.active = True
-    payments.filtered(
-        lambda pay: pay.is_internal_transfer
-        and not pay.paired_internal_transfer_payment_id
-    )._create_paired_internal_transfer_payment()
-    payments_inactive_currency.move_id.currency_id.active = False
 
 
 def set_res_company_account_setup_taxes_state_done(env):
@@ -91,7 +79,7 @@ def _handle_website_legal_page(env):
 @openupgrade.migrate()
 def migrate(env, version):
     _fill_account_analytic_line_category(env)
-    fill_paired_payment(env)
+    _fill_payment_destination_journal(env)
     set_res_company_account_setup_taxes_state_done(env)
     openupgrade.load_data(env.cr, "account", "15.0.1.2/noupdate_changes.xml")
     openupgrade.delete_record_translations(

--- a/openupgrade_scripts/scripts/account/15.0.1.2/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/upgrade_analysis_work.txt
@@ -83,8 +83,10 @@ account      / account.payment          / outstanding_account_id (many2one): NEW
 # DONE: end-migration: filled for outstanding_account_id
 
 account      / account.payment          / destination_journal_id (many2one): NEW relation: account.journal
+# DONE: post-migration: filled through an SQL
+
 account      / account.payment          / paired_internal_transfer_payment_id (many2one): NEW relation: account.payment
-# DONE: post-migration: filled using _create_paired_internal_transfer_payment method
+# TODO: Try to guess the twin payment on existing moves. For v13-, there should be a move, but not a payment
 
 account      / account.payment          / payment_method_id (many2one)  : not a function anymore
 account      / account.payment          / payment_method_id (many2one)  : now related


### PR DESCRIPTION
Accounting can't be changed for past internal payments. They will create extra journal entries that alter the accounting.

On v14, doing an internal transfer payment only puts one journal entry, and you had to manually create the counterpart internal transfer payment, but it's not mandatory (as you can do it through other way). Some code can be added to guess and link both payments if exist, but the added value is very low, and there are chances of being wrong. So it's not going to be implemented for now.

On <=v13, creating an internal transfer payment generated 2 journal entries, so for these payments, an enveloppe payment linked to the second move can be done, but again the added value is very low, and the noise on the extra created payments doesn't worth, so not being implemented either.

@Tecnativa 