### PR TITLE
[14.0][OU-ADD] website_blog: update cover properties field

### DIFF
--- a/openupgrade_scripts/scripts/website_blog/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website_blog/14.0.1.0/post-migration.py
@@ -1,6 +1,18 @@
 from openupgradelib import openupgrade
 
+from odoo.tools.json import scriptsafe as json_safe
+
+
+def update_cover_properties_field(env):
+    blog_post = env["blog.post"].search([])
+    for post in blog_post:
+        cover_properties = json_safe.loads(post.cover_properties)
+        cover_properties["background_color_class"] = "o_cc3"
+        cover_properties.pop("background-color", None)
+        post.write({"cover_properties": json_safe.dumps(cover_properties)})
+
 
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env.cr, "website_blog", "14.0.1.0/noupdate_changes.xml")
+    update_cover_properties_field(env)


### PR DESCRIPTION
In v13, blog posts without an image in the header were indicated with the parameters "backgroung-image" : "none" and "background-color" : "value" stored in the blog_post.cover_properties field.  
When migrating to v14 this style setting is indicated by "backgroung-image" : "none" and "backgroung_color_class" : "value" and "background-color" disappears.  
For this reason the old publications do not adopt the corresponding style on the website if they use colour and not an image in their header. This is solved by rewriting the data contained in the field blog_post.cover_properties.

cc @Tecnativa TT39016

@chienandalu @pedrobaeza please review