### PR TITLE
[ADD] Missing API references, for specific methods for openupgrade 12.0, 13.0 and 16.0

### DIFF
--- a/docsource/API.rst
+++ b/docsource/API.rst
@@ -50,3 +50,33 @@ release.
 
 .. automodule:: openupgradelib.openupgrade_90
    :members:
+
+Methods for OpenUpgrade 12.0
+----------------------------
+
+The following specific methods for 12.0 are available. These have been
+developed to cover specific needs as per data model changes in that
+release.
+
+.. automodule:: openupgradelib.openupgrade_120
+   :members:
+
+Methods for OpenUpgrade 13.0
+----------------------------
+
+The following specific methods for 13.0 are available. These have been
+developed to cover specific needs as per data model changes in that
+release.
+
+.. automodule:: openupgradelib.openupgrade_130
+   :members:
+
+Methods for OpenUpgrade 16.0
+----------------------------
+
+The following specific methods for 16.0 are available. These have been
+developed to cover specific needs as per data model changes in that
+release.
+
+.. automodule:: openupgradelib.openupgrade_160
+   :members:


### PR DESCRIPTION
Trivial PR. The openupgrade documentation references the specifics functions for a given release. Since 12.0, the documentation has not been updated. 