### PR TITLE
[15.0][OU-ADD] sale_coupon_portal: Renamed to coupon_portal

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -20,6 +20,7 @@ renamed_modules = {
     # OCA/sale-promotion
     "sale_coupon_chatter": "coupon_chatter",
     "sale_coupon_mass_mailing": "coupon_mass_mailing",
+    "sale_coupon_portal": "coupon_portal",
     # OCA/stock-logistics-worehouse
     "stock_inventory_cost_info": "stock_quant_cost_info",
     # OCA/...


### PR DESCRIPTION
This PR depends on this [PR](https://github.com/OCA/sale-promotion/pull/131)