### PR TITLE
[DOC][FIX] Do not ignore output path. (Fix 'View page source ' broken links)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
-docs/_sources/
 docs/.doctrees
 docsource/modules50-60.rst
 docsource/modules60-61.rst

--- a/docsource/conf.py
+++ b/docsource/conf.py
@@ -135,7 +135,10 @@ html_last_updated_fmt = "%b %d, %Y"
 # html_split_index = False
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
-# html_copy_source = True
+html_copy_source = False
+
+# Hide the Page source link in each documentation page's footer.
+html_show_sourcelink = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
Rational : 

- go to the documentation https://oca.github.io/OpenUpgrade/
- click on "View page source" link (top right button)
- the link of the file in _sources is broken

Note : the original V14 branch doesn't contains that exclusion : see : 
https://github.com/OCA/OpenUpgrade/blame/14.0/.gitignore#L66

but the V15 initialization introduced it : 
https://github.com/OCA/OpenUpgrade/blame/15.0/.gitignore#L69

@pedrobaeza : an idea why this line has been introduced ? 


Side question : I have no idea why docs/_build/ is also ignored, but it doesn't seems to break anything.