### PR TITLE
[15.0][IMP] mail: migrate mail templates from mako to qweb

### DIFF
--- a/openupgrade_scripts/scripts/mail/15.0.1.5/post-migration.py
+++ b/openupgrade_scripts/scripts/mail/15.0.1.5/post-migration.py
@@ -1,4 +1,10 @@
+import html
+import re
+
+from bs4 import BeautifulSoup
 from openupgradelib import openupgrade
+
+_PY_VAR_PATTERN = "[a-zA-Z_][a-zA-Z0-9_]*"
 
 
 def _map_activity_type_chaining_type_field(env):
@@ -64,6 +70,129 @@ def finish_migration_to_mail_group(env):
     )
 
 
+def _migrate_placeholder_char(string):
+    """
+    Replace dynamic placeholders in char/text fields:
+    Example: "Dear ${object.name}," -> "Dear {{object.name}},"
+    """
+    if not string:
+        return string
+    pattern = r"\$\{([^}]*)\}"
+    repl = r"{{\1}}"
+    return re.sub(pattern, repl, string)
+
+
+def _migrate_placeholder_html(string):
+    """
+    Replace dynamic placeholders in HTML fields:
+    Example: 'Your name is ${object.name}' -> 'Your name is <t t-out="object.name"></t>'
+    """
+    pattern = r"\$\{([^}]*)\}"
+
+    def repl(match):
+        (expression,) = match.groups()
+        expression = html.escape(expression)
+        return f'<t t-out="{expression}"></t>'
+
+    return re.sub(pattern, repl, string)
+
+
+def _migrate_end(string):
+    pattern = r"^%\s+end(if|for)\s*$"
+    repl = r"</t>"
+    return re.sub(pattern, repl, string, flags=re.MULTILINE)
+
+
+def _migrate_else(string):
+    pattern = r"^%\s+else\s*:?\s*$"
+    repl = r'<t t-else="">'
+    return re.sub(pattern, repl, string, flags=re.MULTILINE)
+
+
+def _migrate_if(string):
+    pattern = r"^%\s+if\s+(.+?)\s*:?\s*$"
+
+    def repl(match):
+        (if_expression,) = match.groups()
+        if_expression = html.escape(if_expression)
+        return f'<t t-if="{if_expression}">'
+
+    return re.sub(pattern, repl, string, flags=re.MULTILINE)
+
+
+def _migrate_for(string):
+    pattern = rf"^%\s+for\s+({_PY_VAR_PATTERN})\s+in\s+(.+?)\s*:?\s*$"
+
+    def repl(match):
+        var_name, loop_expression = match.groups()
+        loop_expression = html.escape(loop_expression)
+        return f'<t t-foreach="{loop_expression}" t-as="{var_name}">'
+
+    return re.sub(pattern, repl, string, flags=re.MULTILINE)
+
+
+def _migrate_set(string):
+    pattern = rf"^%\s+set\s+({_PY_VAR_PATTERN})\s*=\s*(.+?)\s*$"
+
+    def repl(match):
+        var_name, var_value = match.groups()
+        var_value = html.escape(var_value)
+        return f'<t t-set="{var_name}" t-value="{var_value}"/>'
+
+    return re.sub(pattern, repl, string, flags=re.MULTILINE)
+
+
+def _migrate_html_attributes(string):
+    soup = BeautifulSoup(string, multi_valued_attributes=None, features="html.parser")
+    # replace placeholders in attributes
+    for element in soup.find_all():
+        new_attrs = {}
+        for attr_name, attr_value in element.attrs.items():
+            new_attr_value = _migrate_placeholder_char(attr_value)
+            if new_attr_value != attr_value:
+                new_attrs[f"t-attf-{attr_name}"] = new_attr_value
+            else:
+                new_attrs[attr_name] = attr_value
+        element.attrs = new_attrs
+    return str(soup)
+
+
+def mako_html_to_qweb(string):
+    if not string:
+        return string
+    return _migrate_set(
+        _migrate_end(
+            _migrate_else(
+                _migrate_for(
+                    _migrate_if(
+                        _migrate_placeholder_html(
+                            _migrate_html_attributes(string),
+                        )
+                    )
+                )
+            )
+        )
+    )
+
+
+def _migrate_mail_templates(env):
+    """
+    Migrate all mail templates from jinja2 to qweb
+    """
+    templates = env["mail.template"].with_context(active_test=False).search([])
+    for template in templates:
+        template.email_from = _migrate_placeholder_char(template.email_from)
+        template.email_to = _migrate_placeholder_char(template.email_to)
+        template.reply_to = _migrate_placeholder_char(template.reply_to)
+        for lang in env["res.lang"].search([]).mapped("code"):
+            template.with_context(lang=lang).subject = _migrate_placeholder_char(
+                template.with_context(lang=lang).subject
+            )
+            template.with_context(lang=lang).body_html = mako_html_to_qweb(
+                template.with_context(lang=lang).body_html
+            )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env.cr, "mail", "15.0.1.5/noupdate_changes.xml")
@@ -78,3 +207,4 @@ def migrate(env, version):
         ],
     )
     finish_migration_to_mail_group(env)
+    _migrate_mail_templates(env)


### PR DESCRIPTION
Mail templates are qweb templates since v15. Migrate mail templates regarding :
* Dynamic placeholders in char/text fields (`email_from`, `email_to`, `reply_to` and `subject`)
* Dynamic placeholders in html field `body_html`
* If / else conditions in `body_html`
* For loops in `body_html`
* Setting variables in `body_html`

NB: migrate all translations for translatable fields (`subject` and `body_html`)

Many thanks to @sbidoul for his help writing this migration script