### PR TITLE
[ADD][16.0] New documentation workflow to update documentation website if the coverage changed

### DIFF
--- a/.github/workflows/documentation-commit.yml
+++ b/.github/workflows/documentation-commit.yml
@@ -1,0 +1,66 @@
+# On each push in 16.0 branch,
+# AND if the coverage file changed,
+# build documentation branch and commit the changes
+# so that the changes are visible on the website
+# https://oca.github.io/OpenUpgrade/
+
+name: Build and commit documentation
+
+on:
+  push:
+    paths: ["docsource/modules150-160.rst"]
+
+jobs:
+  documentation-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out OpenUpgrade Documentation
+        uses: actions/checkout@v2
+        with:
+          ref: "documentation"
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Check out Odoo
+        uses: actions/checkout@v2
+        with:
+          repository: odoo/odoo
+          ref: "16.0"
+          fetch-depth: 1
+          path: odoo
+      - name: Configuration
+        run: |
+          sudo apt update
+          sudo apt install \
+              expect \
+              expect-dev \
+              libevent-dev \
+              libldap2-dev \
+              libsasl2-dev \
+              libxml2-dev \
+              libxslt1-dev \
+              nodejs \
+              python3-lxml \
+              python3-passlib \
+              python3-psycopg2 \
+              python3-serial \
+              python3-simplejson \
+              python3-werkzeug \
+              python3-yaml \
+              unixodbc-dev
+      - name: Requirements Installation
+        run: |
+          pip install -q -r odoo/requirements.txt
+          pip install -r ./requirements.txt
+      - name: OpenUpgrade Docs
+        run: |
+          # try to build the documentation
+          sh ./build_openupgrade_docs
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: "docs"
+          default_author: github_actions
+          message: "[UPD] HTML documentation"


### PR DESCRIPTION
on push on 16.0 AND if docsource/modules150-160.rst changed : 

- checkout documentation branch
- build documentation
- commit changes on documentation branch
-> as a result, documentation website is updated.

I had mentioned a scheduled task in my PoC a few months ago:  https://github.com/OCA/OpenUpgrade/issues/3702#issuecomment-1405805444 but the "paths" options looks better. (save CI AND builds are done only if the coverage file has changed)

This answers the questions of :
- @StefanRijnhart : https://github.com/OCA/OpenUpgrade/issues/3702#issuecomment-1404671537 
- @pedrobaeza : https://github.com/OCA/OpenUpgrade/pull/3853#issuecomment-1536709095
- ...

Note : Once merged, I'll do the same PR on recent branches (14.0 and 15.0)

CC : @hbrunn, @etobella, @bguillot 