### PR TITLE
[14.0][OU-ADD] apriori: website_sale_product_style_badge merged into website_sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -87,6 +87,7 @@ merged_modules = {
     # OCA/event
     "website_event_questions_free_text": "website_event_questions",
     # OCA/e-commerce
+    "website_sale_product_style_badge": "website_sale",
     "website_snippet_carousel_product": "website_sale",
     # OCA/margin-analysis
     "sale_order_margin_percent": "sale_margin",


### PR DESCRIPTION
In v14 Odoo introduces ribbons for products, which is the equivalent of the badges added by website_sale_product_style_badge. 

cc @Tecnativa TT37336

@chienandalu @pedrobaeza please review