### PR TITLE
[16.0][OU-FIX] Base: Add `help` in ir.actions.act_window translation exclusions

### DIFF
--- a/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
@@ -53,7 +53,7 @@ def migrate(cr, version):
     # exclude fields from translation update
     exclusions = {
         # ir.actions.* inherits the name column from ir.actions.actions
-        "ir.actions.act_window": ["name"],
+        "ir.actions.act_window": ["name", "help"],
         "ir.actions.act_url": ["name"],
         "ir.actions.server": ["name"],
         "ir.actions.client": ["name"],


### PR DESCRIPTION
Add fields help in exclusion of ir_act_window 

The pre-migration script exclude some fields from models, inherited by ir.actions fields. the objectif is allow the conversion of all text fields in json or jsonb (mecanic in odoo 16). but if the field is inherited by another fields in another model ( in my exemple name and help  in the model ir_act_window are inherited by ir.actions fields) you cannot execute the sql request. the sql request will failed because you cannot convert fields inherited. 

