### PR TITLE
[WIP][DOC] Use Case : add module splitted

### DIFF
--- a/docsource/development.rst
+++ b/docsource/development.rst
@@ -55,6 +55,7 @@ Learn from typical Use cases
 
    use_cases/field_renaming
    use_cases/xml_id_renaming
+   use_cases/module_splitted
 
 
 Learn from existing migration scrips


### PR DESCRIPTION
Hi all. (@pedrobaeza, @MiquelRForgeFlow, @hbrunn)

nothing to review for the time being, but a question : 

In the list of the "TODO Use Cases", there is an item named "A module has been split". ([RFQ Detail](https://drive.google.com/file/d/1sRis_GoZiVUOfdx-IJA8HMMDgXvhYZzV/view)).

I found some examples : 
- ``purchase``, splitted in ``purchase_stock`` (between v11 and v12), to remove dependency to stock module
- ``sale``, splitted in ``sale`` and ``sale_management`` (between v10 and v11) for commercial reason.

However, I don't feel that there is anything special to achieve in this case. In all the examples I found, the "new" modules are auto_install=True, so there is no need to "force" the installation. 
There may be some xml id to rename, but this use case is already described in this page: https://oca.github.io/OpenUpgrade/use_cases/xml_id_renaming.html

What do you think ? Do you see other examples, where there is something specific to do ? 

thanks for your insights !
