### PR TITLE
[14.0][OU-ADD] apriori: l10n_nl_tax_invoice_basis merged into l10n_nl_tax_statement

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -89,6 +89,8 @@ merged_modules = {
     # OCA/e-commerce
     "website_sale_product_style_badge": "website_sale",
     "website_snippet_carousel_product": "website_sale",
+    # OCA/l10n-netherlands
+    "l10n_nl_tax_invoice_basis": "l10n_nl_tax_statement",
     # OCA/margin-analysis
     "sale_order_margin_percent": "sale_margin",
     # OCA/partner-contact


### PR DESCRIPTION

Module `l10n_nl_tax_invoice_basis` was merged into `l10n_nl_tax_statement`, as mentioned in the description of this PR https://github.com/OCA/l10n-netherlands/pull/298