### PR TITLE
[13.0][OU-FIX] stock: mail.template terms

### DIFF
--- a/addons/stock/migrations/13.0.1.1/post-migration.py
+++ b/addons/stock/migrations/13.0.1.1/post-migration.py
@@ -421,6 +421,15 @@ def migrate(env, version):
     if openupgrade.table_exists(env.cr, 'delivery_carrier'):
         openupgrade.load_data(
             env.cr, "stock", "migrations/13.0.1.1/noupdate_changes2.xml")
+        # This mail.template came from the module delivery to stock, so the translated
+        # terms will have the old module set. We need to change it so we can delete
+        # the translations properly
+        template = env.ref("stock.mail_template_data_delivery_confirmation")
+        env["ir.translation"].search(
+            [
+                ("name", "ilike", "mail.template,"), ("res_id", "=", template.id)
+            ]
+        ).module = "stock"
         openupgrade.delete_record_translations(
             env.cr, 'stock', [
                 'mail_template_data_delivery_confirmation',


### PR DESCRIPTION
The mail.template `mail_template_data_delivery_confirmation` was formerly in the module `delivery`. Along with the regular template refreshing we need to set the translation terms module to the `stock` module so we can fetch them all and delete them properly.

cc @Tecnativa TT43496

ping @pedrobaeza 