### PR TITLE
[14.0][MIG] apriori: hr_period -> hr_payroll_period

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -50,6 +50,8 @@ renamed_modules = {
     "edi_xml": "edi_xml_oca",
     # OCA/hr-holidays
     "hr_leave_hour": "hr_leave_custom_hour_interval",
+    # OCA/hr -> OCA/payroll:
+    "hr_period": "hr_payroll_period",
     # OCA/l10n-spain
     "l10n_es_account_bank_statement_import_n43": "l10n_es_account_statement_import_n43",
     # OCA/server-tools


### PR DESCRIPTION
The migration was done in https://github.com/OCA/payroll/pull/89.

Just FYI: user @nimarosa took `hr_period` module from OCA/hr (v12), migrated it to v14 in OCA/payroll, renamed it, didn't conserve commit history and auto-merged without approvals.