### PR TITLE
[13.0][ADD] rename l10n_nl_mis_reports to mis_template_financial_report

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -30,6 +30,8 @@ renamed_modules = {
     'sale_product_classification': 'product_abc_classification_sale',
     # OCA/stock-logistics-warehouse
     'stock_putaway_product_form': 'stock_putaway_product_template',
+    # OCA/l10n-netherlands -> OCA/account-financial-reporting
+    'l10n_nl_mis_reports': 'mis_template_financial_report',
 }
 
 merged_modules = {


### PR DESCRIPTION
this started in https://github.com/OCA/account-financial-reporting/pull/823
and has been backported to 13 in https://github.com/OCA/account-financial-reporting/pull/877