### PR TITLE
[9.0] Fix `Many2one.convert_to_write` in presence of None

### DIFF
--- a/openerp/fields.py
+++ b/openerp/fields.py
@@ -1723,7 +1723,7 @@ class Many2one(_Relational):
             return value.id
 
     def convert_to_write(self, value):
-        return value.id
+        return value.id if value else False
 
     def convert_to_export(self, value, env):
         return value.name_get()[0][1] if value else ''


### PR DESCRIPTION
I got a situation where `Many2one.convert_to_write` got called with a `None` value.

The stack trace looked like this:

```
Traceback (most recent call last):
  File "/home/work/venv-08to09/src/odoo/openerp/service/server.py", line 894, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "/home/work/venv-08to09/src/odoo/openerp/modules/registry.py", line 390, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/home/work/venv-08to09/src/odoo/openerp/modules/loading.py", line 446, in load_modules
    force, status, report, loaded_modules, update_module, models_to_check, upg_registry)
  File "/home/work/venv-08to09/src/odoo/openerp/modules/loading.py", line 331, in load_marked_modules
    perform_checks=perform_checks, models_to_check=models_to_check, upg_registry=upg_registry
  File "/home/work/venv-08to09/src/odoo/openerp/modules/loading.py", line 178, in load_module_graph
    init_module_models(cr, package.name, models)
  File "/home/work/venv-08to09/src/odoo/openerp/modules/module.py", line 300, in init_module_models
    result = obj._auto_init(cr, {'module': module_name})
  File "/home/work/venv-08to09/src/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/work/venv-08to09/src/odoo/openerp/models.py", line 2640, in _auto_init
    self._set_default_value_on_column(cr, k, context=context)
  File "/home/work/venv-08to09/src/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/work/venv-08to09/src/odoo/openerp/models.py", line 2450, in _set_default_value_on_column
    default = default(self, cr, SUPERUSER_ID, context)
  File "/home/work/venv-08to09/src/odoo/openerp/api.py", line 250, in wrapper
    return old_api(self, *args, **kwargs)
  File "/home/work/venv-08to09/src/odoo/openerp/api.py", line 354, in old_api
    result = method(recs, *args, **kwargs)
  File "/home/work/venv-08to09/src/odoo/openerp/fields.py", line 83, in <lambda>
    return api.model(lambda model: field.convert_to_write(value(model)))
  File "/home/work/venv-08to09/src/odoo/openerp/fields.py", line 1726, in convert_to_write
    return value.id
AttributeError: 'NoneType' object has no attribute 'id'
```

And the None value came from https://github.com/OCA/OpenUpgrade/blob/30b6c228c83024a8e55da4f210ff3e7d9b66c5d2/addons/account/models/account_invoice.py#L1103-L1109

apparently because OpenUpgrade had no `journal_id` in context.