### PR TITLE
Documentation clean intro

### DIFF
--- a/docsource/community.rst
+++ b/docsource/community.rst
@@ -28,3 +28,13 @@ project covers the modules that you have in use, try and use the software
 to upgrade a copy of your database and give us feedback.
 
 Thank you!
+
+Contribute
+----------
+In order to contribute to the OpenUpgrade project, please
+
+* Post your code contributions as pull requests on
+  https://github.com/OCA/OpenUpgrade
+* Donate to the Odoo Community Association (https://github.com/sponsors/OCA)
+* Hire any active contributor to this project to help you migrate your
+  database, and give back any code improvements developed during the project.

--- a/docsource/index.rst
+++ b/docsource/index.rst
@@ -17,6 +17,7 @@ Contents:
    :maxdepth: 3
 
    intro.rst
+   migrating_database.rst
    community.rst
    status.rst
    analysis.rst

--- a/docsource/intro.rst
+++ b/docsource/intro.rst
@@ -26,13 +26,3 @@ Before Odoo 14.0, the branches in https://github.com/OCA/OpenUpgrade
 contain copies (or forks in Git terminology) of the Odoo main project, but
 with extra commits that include the framework, and the analysis and the
 migration scripts for each module.
-
-Contribute
-----------
-In order to contribute to the OpenUpgrade project, please
-
-* Post your code contributions as pull requests on
-  https://github.com/OCA/OpenUpgrade
-* Donate to the Odoo Community Association (https://github.com/sponsors/OCA)
-* Hire any active contributor to this project to help you migrate your
-  database, and give back any code improvements developed during the project.

--- a/docsource/intro.rst
+++ b/docsource/intro.rst
@@ -36,12 +36,3 @@ In order to contribute to the OpenUpgrade project, please
 * Donate to the Odoo Community Association (https://github.com/sponsors/OCA)
 * Hire any active contributor to this project to help you migrate your
   database, and give back any code improvements developed during the project.
-
-Migrating your database
-=======================
-
-.. toctree::
-   :maxdepth: 2
-
-   migration_details
-   after_migration

--- a/docsource/migrating_database.rst
+++ b/docsource/migrating_database.rst
@@ -1,0 +1,8 @@
+Migrating your database
++++++++++++++++++++++++
+
+.. toctree::
+   :maxdepth: 2
+
+   migration_details
+   after_migration


### PR DESCRIPTION
The objective of this trivial PR is to move out of the intro section, things that have a better place elsewhere.

(PR preliminary to a rewrite of the introduction.)

- Move 'migrating database' section in a dedicated file
-  Move 'contribute' section out of the intro, and put it in the "community / how to be involved" section
