### PR TITLE
[14.0][FIX] partner_id is ambiguous

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -436,7 +436,7 @@ def fill_account_payment_data(env):
         env.cr,
         query
         + """
-        AND partner_id IS NOT NULL
+        AND ap.partner_id IS NOT NULL
         AND ip.res_id = 'res.partner,' || ap.partner_id::VARCHAR
         """,
     )


### PR DESCRIPTION
The query crashes because partner_id is ambiguous.