### PR TITLE
[MIG] sale_order_margin_percent: Migration to 16.0

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -50,6 +50,8 @@ merged_modules = {
     "account_move_force_removal": "account",
     # OCA/account-invoice-reporting
     "account_invoice_report_due_list": "account",
+    # OCA/margin-analysis
+    "sale_order_margin_percent": "sale_margin",
     # OCA/purchase-workflow
     "product_form_purchase_link": "purchase",
 }


### PR DESCRIPTION
We were reviewing the migration of the 'sale_order_margin_percent' module, and we have seen that its functionality is already incorporated in the 'sale_margin' module. There is no need to migrate that module.