### PR TITLE
[14.0][OU-IMP] hr_timesheet: Remove permission group_timesheet_manager from user base.default_user

### DIFF
--- a/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/hr_timesheet/14.0.1.0/noupdate_changes.xml
@@ -1,8 +1,12 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
+  <!--
+  This permission is specifically disabled because although odoo adds it, it is too high
+  and inherits others that are not used / necessary for a "basic" user.
   <record id="base.default_user" model="res.users">
     <field name="groups_id" eval="[(4,ref('group_timesheet_manager'))]"/>
   </record>
+  !-->
   <record id="base.module_category_services_timesheets" model="ir.module.category">
     <field name="description">Helps you manage the timesheets.</field>
     <field name="sequence">13</field>


### PR DESCRIPTION
Remove permission `group_timesheet_manager` from user `base.default_user`

Although odoo adds it at https://github.com/odoo/odoo/blob/14.0/addons/hr_timesheet/security/hr_timesheet_security.xml#L30 I think this permission should not be added for several reasons:
- Until now the user did not have this permission and it is strictly not necessary for a "basic" user.
- Having this permission inherits `hr.group_hr_user`, which in turn inherits `base.group_private_addresses` (which is quite controversial).

Please @pedrobaeza can you review it?

@Tecnativa TT44013