### PR TITLE
[14.0][OU-IMP] maintenance: Modified record-rule for maintenance requests

### DIFF
--- a/openupgrade_scripts/scripts/maintenance/14.0.1.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/maintenance/14.0.1.0/noupdate_changes.xml
@@ -19,4 +19,7 @@
   <record id="mt_cat_req_created" model="mail.message.subtype">
     <field name="parent_id" ref="mt_req_created"/>
   </record>
+  <record id="equipment_request_rule_user" model="ir.rule">
+    <field name="domain_force">['|', '|', ('owner_user_id', '=', user.id), ('message_partner_ids', 'in', [user.partner_id.id]), ('user_id.id', '=', user.id)]</field>
+  </record>
 </odoo>


### PR DESCRIPTION
Since https://github.com/odoo/odoo/commit/df1badee20f5984ad91ebe855baa9, the noupdate record rule has been changed, so we need to reflect it on the migration.

@Tecnativa 