### PR TITLE
[15.0][OU-FIX] payment_transfer: don't squash pending_msg

### DIFF
--- a/openupgrade_scripts/scripts/payment_transfer/15.0.2.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/payment_transfer/15.0.2.0/noupdate_changes.xml
@@ -4,7 +4,7 @@
 <!--    <field name="company_id"/>-->
     <field name="image_128" type="base64" file="payment_transfer/static/src/img/transfer_icon.png"/>
 <!--    <field name="name"/>-->
-    <field name="pending_msg" eval="False"/>
+<!--    <field name="pending_msg" eval="False"/>-->
     <field name="redirect_form_view_id" ref="redirect_form"/>
     <field name="support_authorization">False</field>
     <field name="support_fees_computation">False</field>


### PR DESCRIPTION
If we reload this aquirer default pending_msg we'll have all the company's journal bank accounts listed: https://github.com/OCA/OCB/blob/bf664b5bb58cf10e105ed7394b06c9a62a1af502/addons/payment_transfer/models/payment_acquirer.py#L55

It shouldn't be an issue to keep the old description.

cc @Tecnativa TT44190

FYI @pedrobaeza @MiquelRForgeFlow @legalsylvain 