### PR TITLE
[15.0][OU-FIX] mass_mailing: editable legacy mailings

### DIFF
--- a/openupgrade_scripts/scripts/mass_mailing/15.0.2.5/post-migration.py
+++ b/openupgrade_scripts/scripts/mass_mailing/15.0.2.5/post-migration.py
@@ -1,4 +1,45 @@
+from lxml.etree import tostring
+from lxml.html import fromstring
 from openupgradelib import openupgrade
+
+from odoo.osv import expression
+
+
+def _migrate_mailing_body(env, domain=None):
+    """Make previous mailings work with the editor. We just have to rewrap them as
+    the editor expect them to be. A simple f string isn't enough as some mailings
+    could have a parent node that we need to replace and some other might not. This
+    way we ensure both scenarios. If there's no parent node lxml injects one."""
+    domain = domain or []
+    domain = expression.AND(
+        [["|", ("body_html", "!=", False), ("body_html", "!=", "")], domain]
+    )
+    mailings = env["mailing.mailing"].with_context(active_test=False).search(domain)
+    for mailing in mailings:
+        try:
+            html_tree = fromstring(str(mailing.body_html))
+        except Exception:
+            # Avoid content errors
+            continue
+        wrapper = fromstring(
+            """
+<div class="o_layout oe_unremovable oe_unmovable bg-200 o_empty_theme" data-name="Mailing">
+    <div class="container o_mail_wrapper o_mail_regular oe_unremovable">
+        <div class="row">
+            <div
+                class="col o_mail_no_options o_mail_wrapper_td bg-white oe_structure o_editable"
+                contenteditable="true"
+            >
+            </div>
+        </div>
+    </div>
+</div>
+            """
+        )
+        new_parent_node, *_ = wrapper.xpath("//div[@contenteditable='true']")
+        for children in html_tree:
+            new_parent_node.append(children)
+        mailing.body_arch = tostring(wrapper, pretty_print=True, encoding="utf-8")
 
 
 @openupgrade.migrate()
@@ -9,3 +50,4 @@ def migrate(env, version):
         "mass_mailing",
         ["ir_cron_mass_mailing_queue"],
     )
+    _migrate_mailing_body(env)


### PR DESCRIPTION
Lecacy mailing bodies don't work in v15 as the wrapper (or the absence of it) doesn't hook properly with the web editor. With this new script we rewrap them so they're usable in the new versions.

cc @Tecnativa TT42980 TT26694

please review @pedrobaeza 