### PR TITLE
[15.0][OU-FIX] sale_coupon: mail template translations

### DIFF
--- a/openupgrade_scripts/scripts/coupon/15.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/coupon/15.0.1.0/pre-migration.py
@@ -5,6 +5,15 @@ from openupgradelib import openupgrade
 
 @openupgrade.migrate()
 def migrate(env, version):
+    # Delete old template translations before the new template is renamed to ensure that
+    # we remove the terms properly
+    openupgrade.delete_record_translations(
+        env.cr,
+        "coupon",
+        [
+            "mail_template_sale_coupon",
+        ],
+    )
     openupgrade.rename_xmlids(
         env.cr,
         [("coupon.mail_template_sale_coupon", "sale_coupon.mail_template_sale_coupon")],

--- a/openupgrade_scripts/scripts/sale_coupon/15.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/sale_coupon/15.0.1.0/post-migration.py
@@ -6,10 +6,3 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env.cr, "sale_coupon", "15.0.1.0/noupdate_changes.xml")
-    openupgrade.delete_record_translations(
-        env.cr,
-        "sale_coupon",
-        [
-            "mail_template_sale_coupon",
-        ],
-    )


### PR DESCRIPTION
We must remove the translations before the new xml_id is loaded so no orphan terms are left behind.

cc @Tecnativa TT44289

ping @pedrobaeza 