### PR TITLE
[14.0][OU-FIX] website_sale: respect original key

### DIFF
--- a/openupgrade_scripts/scripts/website_sale/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website_sale/14.0.1.0/post-migration.py
@@ -26,9 +26,9 @@ def extract_custom_product_page_term_conditions(env):
             new_arch = product_custom_text_arch.replace(
                 product_custom_text_content, product_matches[0]
             )
-            product_custom_text_view.copy(
-                {"website_id": view.website_id.id, "arch_db": new_arch}
-            )
+            product_custom_text_view.with_context(
+                website_id=view.website_id.id
+            ).arch_db = new_arch
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
Copying the view does not respect the original key, doing it directly via write with website_id context respects the key in the copy.

cc @Tecnativa TT44424

@chienandalu @pedrobaeza please review :)