### PR TITLE
[16.0][FIX] openupgrade_framework : end-migration scripts are forced …

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,12 @@ jobs:
           for snippet in openupgrade/openupgrade_scripts/scripts/*/*/tests/data*.py; do
             odoo-old/odoo-bin shell -d $DB < $snippet
           done
+      - name: Test end-migration script for newly installed module (i.e. "spreadsheet" for v16)
+        run: |
+          END_SCRIPT_TEST=openupgrade/openupgrade_scripts/scripts/base/16.0.1.3/tests/end-migration_test.py
+          NEW_MODULE_SCRIPT_DIR=openupgrade/openupgrade_scripts/scripts/spreadsheet/16.0.1.0/
+          mkdir -p $NEW_MODULE_SCRIPT_DIR
+          cp $END_SCRIPT_TEST $NEW_MODULE_SCRIPT_DIR
       - name: OpenUpgrade test
         run: |
           # select modules and perform the upgrade

--- a/openupgrade_framework/odoo_patch/odoo/modules/migration.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/migration.py
@@ -15,9 +15,14 @@ def migrate_module(self, pkg, stage):
     to_install = pkg.state == "to install"
     if to_install:
         pkg.state = "to upgrade"
+    load_state_to_install = getattr(pkg, "load_state", False)
+    if load_state_to_install == "to install":
+        pkg.load_state = "to upgrade"
     MigrationManager.migrate_module._original_method(self, pkg, stage)
     if to_install:
         pkg.state = "to install"
+    if load_state_to_install == "to install":
+        pkg.load_state = "to install"
 
 
 migrate_module._original_method = MigrationManager.migrate_module

--- a/openupgrade_scripts/scripts/base/16.0.1.3/tests/__init__.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_base_migration
+from . import test_newly_installed_end_migration

--- a/openupgrade_scripts/scripts/base/16.0.1.3/tests/end-migration_test.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/tests/end-migration_test.py
@@ -1,0 +1,14 @@
+# Copyright 2023 Odoo Community Association (OCA)
+# Copyright 2023 Guillaume Masson <guillaume.masson@meta-it.fr>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate(no_version=True)
+def migrate(env, version):
+    params = env["ir.config_parameter"].sudo()
+    params.set_param("openupgrade.test_end_migration", "Executed")

--- a/openupgrade_scripts/scripts/base/16.0.1.3/tests/test_newly_installed_end_migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/tests/test_newly_installed_end_migration.py
@@ -1,0 +1,10 @@
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestNewlyInstalledEndMigration(TransactionCase):
+    def test_newly_installed_end_migration(self):
+        """Make sure the code of the end-migration script has been executed"""
+        params = self.env["ir.config_parameter"].sudo()
+        res = params.get_param("openupgrade.test_end_migration", default="Not executed")
+        self.assertEqual(res, "Executed")


### PR DESCRIPTION
…to run at install too

  Fixes OCA/OpenUpgrade#4106