### PR TITLE
[15.0][OU-FIX] website: unlink view when extract footer copyright company name

### DIFF
--- a/openupgrade_scripts/scripts/website/15.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website/15.0.1.0/post-migration.py
@@ -3,6 +3,14 @@ import re
 from openupgradelib import openupgrade
 
 
+def _delete_views_recursively(env, view):
+    views = env["ir.ui.view"].with_context(active_test=False).browse(view.id).exists()
+    views |= views.mapped("inherit_children_ids")
+    while views.mapped("inherit_children_ids") - views:
+        views |= views.mapped("inherit_children_ids")
+    views.unlink()
+
+
 def extract_footer_copyright_company_name(env):
     """Replace Copyright content in the new v15 template so as not to lose
     content from previous versions if it has been customised, or directly put
@@ -36,6 +44,7 @@ def extract_footer_copyright_company_name(env):
             or f"Copyright © {website.company_id.name}",
         )
         main_copyright_view.with_context(website_id=website.id).arch_db = new_arch
+        _delete_views_recursively(view)
 
 
 def update_website_form_call(env):


### PR DESCRIPTION
cc @Tecnativa TT44794

The duplicate view of website.layout with associated website needs to be removed as in v15 this view should not be duplicated and if not removed it causes inheritance problems which are aggravated when there is more than one website.

@pedrobaeza @chienandalu please review