### PR TITLE
[15.0][OU-FIX] account: don't set term_type

### DIFF
--- a/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
@@ -69,7 +69,6 @@ def _handle_website_legal_page(env):
             )
             company.write(
                 {
-                    "terms_type": "html",
                     "invoice_terms_html": view_temp._render({}, engine="ir.qweb"),
                 }
             )


### PR DESCRIPTION
The intention of this script is to render the contents of the invoice_terms_html field but if we change the company terms type as well we're going to be forcing a different default from the one expected. For example, we won't see the note in the sale portal view and instead we'll see the company terms.

cc @Tecnativa TT44815

please check @CarlosRoca13 @pedrobaeza 