### PR TITLE
[14.0][OU-FIX] website_sale: move script to website and disable it

### DIFF
--- a/openupgrade_scripts/scripts/website_sale/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website_sale/14.0.1.0/post-migration.py
@@ -7,40 +7,6 @@ import re
 from openupgradelib import openupgrade
 
 
-def extract_footer_copyright_company_name(env):
-    """Replace Copyright content in the footer so as not to lose
-    content from previous versions if the copyright has been customised."""
-    for website in env["website"].search([]):
-        # Search for old copyright and if it does not exist set the default company name
-        web_frontend_layout_view = env["ir.ui.view"].search(
-            [("key", "=", "web.frontend_layout"), ("website_id", "=", website.id)]
-        )
-        if web_frontend_layout_view:
-            frontend_layout_pattern = r"<span(?:.*?)>(.*?)</span>"
-            frontend_layout_matches = re.findall(
-                frontend_layout_pattern,
-                web_frontend_layout_view.arch_db,
-                re.DOTALL,
-            )
-            copyright_content = " ".join(
-                match.strip() for match in frontend_layout_matches
-            )
-        else:
-            copyright_content = f"Copyright © {website.company_id.name}"
-        # Set new copyright
-        website_layout_view = env.ref("website.layout")
-        website_layout_pattern = (
-            r'<span class="o_footer_copyright_name mr-2">(.*?)<\/span>'
-        )
-        website_layout_matches, *_ = re.findall(
-            website_layout_pattern, website_layout_view.arch_db, re.DOTALL
-        )
-        new_arch = website_layout_view.arch_db.replace(
-            website_layout_matches, copyright_content
-        )
-        website_layout_view.with_context(website_id=website.id).arch_db = new_arch
-
-
 def extract_custom_product_page_term_conditions(env):
     """Replace Terms and Conditions content in the new v14 template so as not to lose
     content from previous versions if it has been customised."""
@@ -119,4 +85,3 @@ def migrate(env, version):
         """,
     )
     extract_custom_product_page_term_conditions(env)
-    extract_footer_copyright_company_name(env)


### PR DESCRIPTION
This script should go in website, not website_sale. However, this script is causing errors in migrations to later versions and its call will be commented in case someone considers that its execution is relevant and can decomment it. The reason is that in v14 the main view website.layout was duplicated with the associated web when modifying the name of the company, something that this script reproduces and in the behaviour of later versions this view should not be duplicated. It is better not to automate tasks on main views to avoid errors in migrations to later versions.

cc @Tecnativa TT44794

@pedrobaeza @chienandalu please review :)