### PR TITLE
[16.0][IMP] apriori: website_sale_require_login to website_sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -55,6 +55,8 @@ merged_modules = {
     "account_move_force_removal": "account",
     # OCA/account-invoice-reporting
     "account_invoice_report_due_list": "account",
+    # OCA/e-commerce
+    "website_sale_require_login": "website_sale",
     # OCA/purchase-workflow
     "product_form_purchase_link": "purchase",
 }


### PR DESCRIPTION
website_sale_require_login makes it mandatory to register/log in to make a purchase, this option is already provided for in website_sale v16 with the "Mandatory" option in the website settings under "Sign in/up at checkout" which does not allow guest checkout.

cc @Tecnativa TT44386

@pedrobaeza @chienandalu please review :)