### PR TITLE
[14.0][OU-IMP] website: refine html migration exlusions

### DIFF
--- a/openupgrade_scripts/scripts/website/14.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/website/14.0.1.0/end-migration.py
@@ -3,7 +3,16 @@ from openupgradelib import openupgrade, openupgrade_140
 
 
 def convert_field_html_string(env):
-    exclusions = ["mail.message"]
+    exclusions = [
+        "mail.message",
+        "mail.mail",
+        "mail.template",
+        "res.users",
+        "mail.channel",
+        "mailing.mailing",
+        "account.invoice.send",
+        "mail.alias",
+    ]
     fields = env["ir.model.fields"].search(
         [("ttype", "=", "html"), ("store", "=", True)]
     )


### PR DESCRIPTION
In these models we don't have fields that use the css classes of Odoo and thus we don't need to transform them and lxml could do a little mess when the structure isn't a tree (we should address this in openupgradelib though)

cc @Tecnativa

ping @pedrobaeza @pilarvargas-tecnativa 