### PR TITLE
[14.0][OU-ADD] website_event_crm: Renamed into website_event_crm_invitation

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -32,6 +32,8 @@ renamed_modules = {
     "account_bank_statement_import_txt_xlsx": "account_statement_import_txt_xlsx",
     # OCA/e-commerce
     "website_sale_attribute_filter_category": "website_sale_product_attribute_filter_category",  # noqa: B950
+    # OCA/event
+    "website_event_crm": "website_event_crm_invitation",
     # OCA/edi
     "account_e-invoice_generate": "account_einvoice_generate",
     "edi": "edi_oca",


### PR DESCRIPTION
This OCA module is now clashing with the core module of the same name.

Rename addressed in https://github.com/OCA/event/pull/341

cc @Tecnativa TT45105

