### PR TITLE
[16.0][OU-ADD] apriori: Rename sale_coupon_order_line_link to sale_loyalty_order_line_link

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -21,6 +21,7 @@ renamed_modules = {
     # OCA/knowledge
     "knowledge": "document_knowledge",
     # OCA/sale-promotion
+    "sale_coupon_order_line_link": "sale_loyalty_order_line_link",
     "website_sale_coupon_page": "website_sale_loyalty_page",
     # OCA/server-ux
     "mass_editing": "server_action_mass_edit",


### PR DESCRIPTION
Rename sale_coupon_order_line_link to sale_loyalty_order_line_link https://github.com/OCA/sale-promotion/pull/152

cc @Tecnativa TT44349

ping @pedrobaeza 