### PR TITLE
[15.0][Fix] mail: _migrate_placeholder_html should remove '| safe'

### DIFF
--- a/openupgrade_scripts/scripts/mail/15.0.1.5/post-migration.py
+++ b/openupgrade_scripts/scripts/mail/15.0.1.5/post-migration.py
@@ -83,7 +83,7 @@ def finish_migration_to_mail_group(env):
 def _migrate_placeholder_char(string):
     """
     Replace dynamic placeholders in char/text fields:
-    Example: "Dear ${object.name}," -> "Dear {{object.name}},"
+    Example: "Dear ${object.name | safe}," -> "Dear {{object.name}},"
     """
     if not string:
         return string
@@ -103,8 +103,9 @@ def repl_placeholder(match):
 def _migrate_placeholder_html(string):
     """
     Replace dynamic placeholders in HTML fields:
-    Example: 'Your name is ${object.name}' -> 'Your name is <t t-out="object.name"></t>'
+    Example: 'Your name is ${object.name | safe}' -> 'Your name is <t t-out="object.name"></t>'
     """
+    string = re.sub(r"\s?\|\s?safe\s?", "", string)
     pattern = r"\$\{([^}]*)\}"
     string = re.sub(pattern, repl_placeholder, string)
     return string


### PR DESCRIPTION
This will fix the issue when Odoo renders this wrong syntax

Content in email template body v14:

`${object.company_id.email | safe}`

Content in email template body v15 (after migrate data):

`<t t-out="object.company_id.email | safe">`

Error:

```
odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
TypeError: unsupported operand type(s) for |: 'str' and 'NoneType'
```
