### PR TITLE
[16.0][OU-ADD] apriori: sale_coupon_limit renamed to sale_loyalty_limit

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -22,6 +22,7 @@ renamed_modules = {
     "knowledge": "document_knowledge",
     # OCA/sale-promotion
     "coupon_limit": "loyalty_limit",
+    "sale_coupon_limit": "sale_loyalty_limit",
     "sale_coupon_order_line_link": "sale_loyalty_order_line_link",
     "sale_coupon_partner": "sale_loyalty_partner",
     "website_sale_coupon_page": "website_sale_loyalty_page",


### PR DESCRIPTION
Renamed in https://github.com/OCA/sale-promotion/pull/156

cc @Tecnativa TT44347

ping @pedrobaeza 