### PR TITLE
[14.0][OU-FIX] product: don't reset product uom precision

### DIFF
--- a/openupgrade_scripts/scripts/product/14.0.1.2/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/product/14.0.1.2/noupdate_changes.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
   <record id="decimal_product_uom" model="decimal.precision" forcecreate="True">
-    <field name="digits" eval="2"/>
+    <!-- <field name="digits" eval="2"/> -->
   </record>
   <record id="product_comp_rule" model="ir.rule">
 <!--    <field name="global"/>-->


### PR DESCRIPTION
Reseting the decimal precision for the product can lead to unexpected inconsitencies. The new value is just the proposed default for Odoo, but we should respect the value that the instance is currently using at convenience.

please check @carlosdauden @pedrobaeza 