### PR TITLE
[16.0][MIG] account_statement_import_txt_xlsx: Rename to account_statement_import_sheet_file

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -18,6 +18,7 @@ renamed_modules = {
     "sale_coupon_taxcloud_delivery": "sale_loyalty_taxcloud_delivery",
     # OCA/bank-statement-import
     "account_statement_import": "account_statement_import_file",
+    "account_statement_import_txt_xlsx": "account_statement_import_sheet_file",
     # OCA/knowledge
     "knowledge": "document_knowledge",
     # OCA/sale-promotion


### PR DESCRIPTION
Rename addon, from `account_statement_import_txt_xlsx` to `account_statement_import_sheet_file`.

Related to https://github.com/OCA/bank-statement-import/pull/628

@Tecnativa TT45222