### PR TITLE
[15.0][OU-ADD] pos_order_mgmt: Merged in point_of_sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -69,6 +69,7 @@ merged_modules = {
     # OCA/hr-attendance
     "hr_attendance_user_list": "hr_attendance",
     # OCA/pos
+    "pos_order_mgmt": "point_of_sale",
     "pos_order_return": "point_of_sale",
     # OCA/product-attribute
     "stock_account_product_cost_security": "product_cost_security",


### PR DESCRIPTION
@Tecnativa TT45178

This module offers the option to see past orders in the fronted, so it is possible to operate with them for re-printing them or performing a return . This is already accomplished in odoo 15 core, with extra functionallities. To acces them you must select you're desired order in the "Orders" tab of the frontend, and on the panel there will be the buttons that allows you to perform this actions. 
There is one function that is not present in core, which is the option of "duplicate/copy" an order. By using this function, when it's button is pressed the exact products and quantities of the order are setted in order to be used for another order. This could justify the creation of a specific module for preserving this feature.


@chienandalu please review!