### PR TITLE
[16.0][GH] Remove less installation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,6 @@ jobs:
               unixodbc-dev
       - name: Requirements Installation
         run: |
-          sudo npm install -g less less-plugin-clean-css
           pip install -q -r odoo/requirements.txt
           pip install -r ./openupgrade/requirements.txt
           # this is for v15 l10n_eg_edi_eta which crashes without it


### PR DESCRIPTION
AFAIK, less files are not used since a lot of versions, so let's save some bits and time on each CI build.

@Tecnativa 