### PR TITLE
[15.0][OU-ADD] pos_order_return: Merged in point_of_sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -68,6 +68,8 @@ merged_modules = {
     "website_sale_stock_available_display": "website_sale_stock",
     # OCA/hr-attendance
     "hr_attendance_user_list": "hr_attendance",
+    # OCA/pos
+    "pos_order_return": "point_of_sale",
     # OCA/product-attribute
     "stock_account_product_cost_security": "product_cost_security",
     # OCA/stock-logistics-reporting

--- a/openupgrade_scripts/scripts/point_of_sale/15.0.1.0.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/point_of_sale/15.0.1.0.1/pre-migration.py
@@ -3,8 +3,34 @@
 from openupgradelib import openupgrade
 
 
+def merge_pos_order_return_module(env):
+    """
+    The pos_order_return module is now merged into point_of_sale. We can hook into
+    the new core functionality just renaming the proper fields.
+    """
+    if openupgrade.column_exists(env.cr, "pos_order", "returned_order_id"):
+        openupgrade.rename_fields(
+            env,
+            [
+                (
+                    "pos.order.line",
+                    "pos_order_line",
+                    "returned_line_id",
+                    "refunded_orderline_id",
+                ),
+                (
+                    "pos.order.line",
+                    "pos_order_line",
+                    "refund_line_ids",
+                    "refund_orderline_ids",
+                ),
+            ],
+        )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    merge_pos_order_return_module(env)
     openupgrade.rename_fields(
         env,
         [


### PR DESCRIPTION
TT45179 @Tecnativa

The OCA module pos_order_return allows the user to partially return a sale_order in the frontend, and also links this refunds with their original orders. From Odoo v15 we can do this in core from the frontend and those links are paired to the ones we were providing. One thing that adds this module that isn't in core is a boolean indicating if you want to allow negative quantities on the POS for products. This feature can be discussed if it is worth it to be conserved in a custom module or not as it was a little out of context anyway.

@chienandalu please review!