### PR TITLE
[MIG] l10n_it_ricevute_bancarie: Rename to l10n_it_riba

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -26,6 +26,8 @@ renamed_modules = {
     "website_sale_coupon_page": "website_sale_loyalty_page",
     # OCA/server-ux
     "mass_editing": "server_action_mass_edit",
+    # OCA/l10n-italy
+    "l10n_it_ricevute_bancarie": "l10n_it_riba",
     # OCA/...
 }
 


### PR DESCRIPTION
It happens in the PR https://github.com/OCA/l10n-italy/pull/3615