### PR TITLE
[14.0][OU-FIX] mass_mailing: Avoid duplicated mailing list name

### DIFF
--- a/openupgrade_scripts/scripts/mass_mailing/14.0.2.2/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/mass_mailing/14.0.2.2/upgrade_analysis_work.txt
@@ -43,8 +43,10 @@ NEW ir.ui.view: mass_mailing.s_mail_block_header_view
 NEW ir.ui.view: mass_mailing.social_links
 NEW ir.ui.view: mass_mailing.view
 NEW mailing.contact: mass_mailing.mass_mailing_contact_0 (noupdate)
-NEW mailing.list: mass_mailing.mailing_list_data (noupdate)
 # NOTHING TO DO
+
+NEW mailing.list: mass_mailing.mailing_list_data (noupdate)
+# DONE: pre-migration: Assign this XML-ID if there's a list with "Newsletter" name
 
 NEW ir.ui.view: mass_mailing.mailing_contact_view_form
 NEW ir.ui.view: mass_mailing.mailing_contact_view_graph


### PR DESCRIPTION
If you come from v12 or before, there was a mailing list called 'Newsletter' as data. This list dissapeared in v13, so on OpenUpgrade v13, we removed the associated XML-ID for preserving it. As now in v14 it's being introduced again (although with other XML-ID), the unique name contraint makes the migration to crash, so we need to detect if a mailing list with such name exists, and give it in advance the required XML-ID for avoiding the duplicity.

@Tecnativa TT45308