### PR TITLE
[16.0][OU-ADD] apriori: web_ir_actions_act_view_reload merged into web

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -75,6 +75,7 @@ merged_modules = {
     "stock_picking_backorder_strategy": "stock",
     # OCA/web
     "web_drop_target": "web",
+    "web_ir_actions_act_view_reload": "web",
 }
 
 # only used here for upgrade_analysis


### PR DESCRIPTION
Odoo 16.0 introduces an `ir.action.client` tag name `soft_reload` to restore the current controller without a full browser reload.

For the modules depending on this OCA, module, this would be the new action return mode:

```python
return {'type': 'ir.actions.client', 'tag': 'soft_reload'}
```

cc @Tecnativa TT45650

please review @CarlosRoca13 @victoralmau 