### PR TITLE
[16.0][OU-ADD] apriori: coupon_incompatibility renamed to loyalty_incompatibility

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -24,6 +24,7 @@ renamed_modules = {
     # OCA/knowledge
     "knowledge": "document_knowledge",
     # OCA/sale-promotion
+    "coupon_incompatibility": "loyalty_incompatibility",
     "coupon_limit": "loyalty_limit",
     "coupon_mass_mailing": "loyalty_mass_mailing",
     "sale_coupon_limit": "sale_loyalty_limit",


### PR DESCRIPTION
Renamed in https://github.com/OCA/sale-promotion/pull/179

cc @Tecnativa TT44318

@pedrobaeza please review