### PR TITLE
[16.0][OU-ADD] apriori: sale_coupon_incompatibility renamed to sale_loyalty_incompatibility

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -26,6 +26,7 @@ renamed_modules = {
     # OCA/sale-promotion
     "coupon_limit": "loyalty_limit",
     "coupon_mass_mailing": "loyalty_mass_mailing",
+    "sale_coupon_incompatibility": "sale_loyalty_incompatibility",
     "sale_coupon_limit": "sale_loyalty_limit",
     "sale_coupon_order_line_link": "sale_loyalty_order_line_link",
     "sale_coupon_partner": "sale_loyalty_partner",


### PR DESCRIPTION
Renamed in: https://github.com/OCA/sale-promotion/pull/180

cc @Tecnativa TT44346

@pedrobaeza please review