### PR TITLE
[16.0][OU-ADD] apriori: coupon_criteria_multiproduct renamed to loyalty_criteria_multiproduct

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -28,6 +28,7 @@ renamed_modules = {
     "coupon_limit": "loyalty_limit",
     "coupon_mass_mailing": "loyalty_mass_mailing",
     "coupon_multi_gift": "loyalty_multi_gift",
+    "coupon_criteria_multi_product": "loyalty_criteria_multi_product",
     "sale_coupon_incompatibility": "sale_loyalty_incompatibility",
     "sale_coupon_limit": "sale_loyalty_limit",
     "sale_coupon_order_line_link": "sale_loyalty_order_line_link",


### PR DESCRIPTION
Renamed in https://github.com/OCA/sale-promotion/pull/184

cc @Tecnativa TT44317

@pedrobaeza  please review