### PR TITLE
[13.0][OU-ADD] stock_picking_responsible: merged into stock

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -30,6 +30,8 @@ renamed_modules = {
     'sale_product_classification': 'product_abc_classification_sale',
     # OCA/stock-logistics-warehouse
     'stock_putaway_product_form': 'stock_putaway_product_template',
+    # OCA/stock-logistics-workflow
+    'stock_picking_responsible': 'stock',
     # OCA/l10n-netherlands -> OCA/account-financial-reporting
     'l10n_nl_mis_reports': 'mis_template_financial_report',
 }


### PR DESCRIPTION
responsible_id field in `stock_picking_responsible` is replaced by user_id in `stock`. The script migrates data from

```py
# stock_picking_responsible/models/stock_picking.py
responsible_id = fields.Many2one(
    comodel_name="res.partner",
    string="Responsible",
    default=lambda self: self.env.user.partner_id.id,
)
```

to

```py
# stock/models/stock_picking.py
user_id = fields.Many2one(
    'res.users', 'Responsible', tracking=True,
    domain=lambda self: [('groups_id', 'in', self.env.ref('stock.group_stock_user').id)],
    states={'done': [('readonly', True)], 'cancel': [('readonly', True)]},
    default=lambda self: self.env.user)
```

First PR on OpenUpgrade, comments welcome.