### PR TITLE
[13.0][OU-FIX] account_check_printing: Proper SQL string

### DIFF
--- a/addons/account_check_printing/migrations/13.0.1.0/post-migration.py
+++ b/addons/account_check_printing/migrations/13.0.1.0/post-migration.py
@@ -8,10 +8,12 @@ def map_account_payment_check_number(env):
     openupgrade.logged_query(
         env.cr, """
         UPDATE account_payment
-        SET check_number = '' || %s
+        SET check_number = %s::VARCHAR
         WHERE %s IS NOT NULL
-        """, (openupgrade.get_legacy_name('check_number'),
-              openupgrade.get_legacy_name('check_number'))
+        """ % (
+            openupgrade.get_legacy_name('check_number'),
+            openupgrade.get_legacy_name('check_number')
+        )
     )
 
 


### PR DESCRIPTION
The formatting should be done regularly, or the value that will be used will be literally `openupgrade_legacy_13_0_check_number`.

@Tecnativa TT46186