### PR TITLE
[15.0][OU-ADD] website_crm: Migrate website_crm views

### DIFF
--- a/openupgrade_scripts/scripts/website_crm/15.0.2.1/post-migration.py
+++ b/openupgrade_scripts/scripts/website_crm/15.0.2.1/post-migration.py
@@ -1,0 +1,27 @@
+# Copyright 2023 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def migrate_website_crm_views(env):
+    """Update the arch_db field by replacing the occurrences of "mail.mail" with "crm.lead"
+    in "website.contactus". This is done to adapt the functionality in Odoo v15 where the
+    default action is used to send an email and to ensure that the configuration is not
+    lost for the that the configuration is not lost to create an opportunity that in previous
+    versions was configured by default by a was configured by default by a replacement in
+    the form view."""
+    for website in env["website"].search([]):
+        website_contactus_view = website.with_context(website_id=website.id).viewref(
+            "website.contactus"
+        )
+        website_contactus_arch_db = website_contactus_view.arch_db
+        if 'data-model_name="mail.mail"' in website_contactus_arch_db:
+            new_arch = website_contactus_arch_db.replace(
+                'data-model_name="mail.mail"', 'data-model_name="crm.lead"'
+            )
+            website_contactus_view.with_context(website_id=website.id).arch = new_arch
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    migrate_website_crm_views(env)


### PR DESCRIPTION
Migrates website_crm views to replace references to 'mail.mail' with 'crm.lead'. In versions 13 and 14, the creation of opportunities was configured by replacing the default form view with one that had a specific action to create a lead. In version 15, this configuration is no longer present, and the default behavior is to use the base view for sending emails. To ensure a seamless transition and retain the previous configuration of creating opportunities, this migration script modifies the relevant views associated with the website_crm module. It replaces instances of 'mail.mail' with 'crm.lead', preserving the user's preference for creating opportunities.

cc @Tecnativa  TT35811

Tested locally in a shell in v15

@pedrobaeza @chienandalu please review