### PR TITLE
[16.0][OU-ADD] apriori: sale_coupon_criteria_multi_product renamed to sale_loyalty_criteria_multi_product

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -29,6 +29,7 @@ renamed_modules = {
     "coupon_mass_mailing": "loyalty_mass_mailing",
     "coupon_multi_gift": "loyalty_multi_gift",
     "coupon_criteria_multi_product": "loyalty_criteria_multi_product",
+    "sale_coupon_criteria_multi_product": "sale_loyalty_criteria_multi_product",
     "sale_coupon_incompatibility": "sale_loyalty_incompatibility",
     "sale_coupon_limit": "sale_loyalty_limit",
     "sale_coupon_order_line_link": "sale_loyalty_order_line_link",


### PR DESCRIPTION
Renamed in https://github.com/OCA/sale-promotion/pull/185

cc @Tecnativa TT44344

@pedrobaeza please review