### PR TITLE
[13.0][OU-IMP] l10n_es: Include REAGyP fiscal position mapping

### DIFF
--- a/addons/l10n_es/migrations/13.0.4.0/pre-migration.py
+++ b/addons/l10n_es/migrations/13.0.4.0/pre-migration.py
@@ -63,6 +63,7 @@ def rename_food_taxes_and_fiscal_positions_xmlids(env):
         ("fptt_extra_5a", "fptt_extra_5b"),
         ("fptt_intra_0a", "fptt_intra_0b"),
         ("fptt_intra_5a", "fptt_intra_5b"),
+        ("fptt_reagyp_a_0a_2", "fptt_reagyp_a_4b_4"),
         ("fptt_recargo_0a", "fptt_recargo_0b"),
         ("fptt_recargo_0a_2", "fptt_recargo_0b_2"),
         ("fptt_recargo_5a", "fptt_recargo_5b"),


### PR DESCRIPTION
This one was introduced in 14.0 in Odoo core, but already present in `l10n_es_extra_data` in 12.0, so let's rename it here for having everything in the same place.

@Tecnativa TT46315