### PR TITLE
[13.0][IMP] apriori: merge account_reconciliation_widget_partial

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -67,6 +67,7 @@ merged_modules = {
     # OCA/account-reconcile
     'account_set_reconcilable': 'account',
     'bank_statement_foreign_currency': 'account',
+    'account_reconciliation_widget_partial': 'account',
     # OCA/e-commerce
     'website_sale_category_description': 'website_sale',
     # OCA/event


### PR DESCRIPTION
The `account_reconciliation_widget_partial` module is no longer necessary in version 13.0 as its functionality has been implemented in the account module.

