### PR TITLE
[FIX][12.0 -> 13.0]Duplicate move when invoice is draft

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -201,7 +201,7 @@ def migration_invoice_moves(env):
         vendor_display_name, cash_rounding_id, id, create_uid, create_date,
         write_uid, write_date
         FROM account_invoice ai
-        WHERE ai.state in ('draft', 'cancel')""",
+        WHERE ai.state in ('draft', 'cancel') AND ai.move_id IS NULL""",
     )
     openupgrade.merge_models(env.cr, 'account.invoice', 'account.move', 'old_invoice_id')
     # Not Draft or Cancel Invoice Lines

--- a/addons/account/migrations/13.0.1.1/pre-migration.py
+++ b/addons/account/migrations/13.0.1.1/pre-migration.py
@@ -269,7 +269,7 @@ def add_helper_invoice_move_rel(env):
     openupgrade.logged_query(
         env.cr, """
         UPDATE account_invoice ai
-        SET move_id = am.old_invoice_id
+        SET move_id = am.id
         FROM account_move am
         WHERE am.old_invoice_id = ai.id AND ai.move_id IS NULL
         """,


### PR DESCRIPTION
In some cases, when the invoice is in draft status and has an associated move line, the previous code associated the invoice with the invoice ID. This fix associates the invoice with the associated move line's move_id.
to reproduce:
- create invoice in draft
- create a move in draft
- create a move line for this move
- reference that line to draft invoice