### PR TITLE
[16.0][OU-FIX] Base: Add `help` in ir.actions.client translation exclusions

### DIFF
--- a/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
@@ -56,7 +56,7 @@ def update_translatable_fields(cr):
         "ir.actions.act_window": ["name", "help"],
         "ir.actions.act_url": ["name"],
         "ir.actions.server": ["name"],
-        "ir.actions.client": ["name"],
+        "ir.actions.client": ["name", "help"],
         "ir.actions.report": ["name"],
     }
     cr.execute(


### PR DESCRIPTION

    In PR https://github.com/OCA/OpenUpgrade/pull/3866, cyrilmanuel <cyriljeanneret@gmail.com>
    fixed the same issue for ir.actions.act_window translation

    The pre-migration script excludes some fields from models, inherited by ir.actions fields.
    The goal is to allow the conversion of all text fields in json or jsonb (mecanic in odoo 16),
    but if the field is inherited by another fields in another model (in my example, name and help
    in the model ir_actions_client are inherited by ir.actions fields), you cannot execute the sql request.
    It will failed because you cannot convert fields inherited.