### PR TITLE
[15.0][OU-FIX] sale_timesheet : Removed nonbillable_xx types

### DIFF
--- a/openupgrade_scripts/scripts/sale_timesheet/15.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/sale_timesheet/15.0.1.0/pre-migration.py
@@ -74,6 +74,14 @@ def _re_fill_account_analytic_line_timesheet_invoice_type(env):
         FROM aal_tmp WHERE aal_tmp.aal_id = aal.id
         """,
     )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_analytic_line
+        SET timesheet_invoice_type = 'non_billable'
+        WHERE timesheet_invoice_type IN ('non_billable_timesheet', 'non_billable_project')
+        """,
+    )
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
After migration I still have a lot of account_analytic_lines with timesheet_invoice_type = 'non_billable_project'
This PR proposes a fix to avoid this.

As per https://github.com/OCA/OpenUpgrade/blob/a5e43bfeb5e96f44105d0e59d9507ee5bc6529b9/openupgrade_scripts/scripts/sale_timesheet/15.0.1.0/upgrade_analysis.txt#L6 the following selection entries are removed from timesheet_invoice_type field in account_analytic_line table :

- non_billable_project
- non_billable_timesheet
(also other selection entries are added which are correctly handled)

The pre-migration script here : https://github.com/OCA/OpenUpgrade/blob/a5e43bfeb5e96f44105d0e59d9507ee5bc6529b9/openupgrade_scripts/scripts/sale_timesheet/15.0.1.0/pre-migration.py#L16
Does handle the new selection entries ( 'other_costs', 'other_revenues', 'service_revenues', 'timesheet_revenues') but not the ones to be removed.

The following lines set the 2 removed selection entries on  timesheet_invoice_type field : 
https://github.com/odoo/odoo/blob/21279a8624c3867a6c6d678ceba0ebab6befbe8e/addons/sale_timesheet/models/account.py#L29-L37

- "non_billable_timesheet" is set on timesheet with field 'non_allow_billable" = True
- "non_billable_project" is set on timesheet with project_id and no task_id (which matches the timesheet from our database which were made on projects without tasks).

The script from pre-migration runs 2 SQL queries setting the "timesheet_invoice_type" : 

1. is run against all account_analytic_lines without project (= non timesheet account_analytic_lines) as per https://github.com/OCA/OpenUpgrade/blob/a5e43bfeb5e96f44105d0e59d9507ee5bc6529b9/openupgrade_scripts/scripts/sale_timesheet/15.0.1.0/pre-migration.py#L31
2. is run against all account_analytic_line with project but without timesheet_invoice_type as per https://github.com/OCA/OpenUpgrade/blob/a5e43bfeb5e96f44105d0e59d9507ee5bc6529b9/openupgrade_scripts/scripts/sale_timesheet/15.0.1.0/pre-migration.py#L70

and therefore none of the above would update the account_analytic_line with project (= timesheets) and timesheet_invoice_type already set.

Therefore I propose to add a 3rd query at the end that would update any line with removed timesheet_invoice_type ("non_billable_timesheet" or "non_billable_project") to "non_billable" so that it makes sure that old selection entries are not used anymore.