### PR TITLE
[15.0][FIX] payment: Wait for payment methods to be created

### DIFF
--- a/openupgrade_scripts/scripts/payment/15.0.2.0/end-migration.py
+++ b/openupgrade_scripts/scripts/payment/15.0.2.0/end-migration.py
@@ -1,0 +1,32 @@
+from openupgradelib import openupgrade
+
+
+def create_account_payment_method_line(env):
+    """
+    Create account payment method lines from account payment methods
+
+    This is placed in 'end-' instead of 'post-' because we need to wait for
+    other modules to update. For instance payment_adyen creates its
+    'account.payment.method' object in XML and that is execute after this
+    module has been migrated. But running this at 'end-' means that we will
+    have that updated data.
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        INSERT INTO account_payment_method_line (name, sequence,
+            payment_method_id, journal_id, create_uid, write_uid,
+            create_date, write_date)
+        SELECT DISTINCT ON (apm.id, aj.id) apm.name, 10, apm.id, aj.id,
+            apm.create_uid, apm.write_uid, apm.create_date, apm.write_date
+        FROM account_payment_method apm
+        JOIN payment_acquirer pa ON pa.provider = apm.code
+        JOIN account_journal aj ON aj.type = 'bank' AND aj.id = pa.journal_id
+        WHERE apm.code NOT IN ('manual', 'check_printing')
+        """,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    create_account_payment_method_line(env)

--- a/openupgrade_scripts/scripts/payment/15.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/payment/15.0.2.0/post-migration.py
@@ -44,31 +44,12 @@ def fill_payment_transaction_partner_state_id(env):
     )
 
 
-def create_account_payment_method_line(env):
-    # Create account payment method lines from account payment methods
-    openupgrade.logged_query(
-        env.cr,
-        """
-        INSERT INTO account_payment_method_line (name, sequence,
-            payment_method_id, journal_id, create_uid, write_uid,
-            create_date, write_date)
-        SELECT DISTINCT ON (apm.id, aj.id) apm.name, 10, apm.id, aj.id,
-            apm.create_uid, apm.write_uid, apm.create_date, apm.write_date
-        FROM account_payment_method apm
-        JOIN payment_acquirer pa ON pa.provider = apm.code
-        JOIN account_journal aj ON aj.type = 'bank' AND aj.id = pa.journal_id
-        WHERE apm.code NOT IN ('manual', 'check_printing')
-        """,
-    )
-
-
 @openupgrade.migrate()
 def migrate(env, version):
     fill_payment_adquirer_allow_tokenization(env)
     fill_payment_transaction_tokenize(env)
     fill_payment_transaction_partner_state_id(env)
     fill_payment_transaction_last_state_change(env)
-    create_account_payment_method_line(env)
     openupgrade.load_data(env.cr, "payment", "15.0.2.0/noupdate_changes.xml")
     openupgrade.delete_record_translations(
         env.cr,


### PR DESCRIPTION
Since other modules create account.payment.method in this migration we need to wait for them before finding all payment methods and and connecting them to the journal and acquirer.

Discussed in #4257