### PR TITLE
[15.0][OU-FIX] don't fail when there's an unknown field in a view

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
@@ -61,9 +61,21 @@ def _raise_view_error(
             )
 
 
+def _check_field_paths(self, node, field_paths, model_name, use):
+    """Ignore UnboundLocalError when we squelched the raise about missing fields"""
+    try:
+        return View._check_field_paths._original_method(
+            self, node, field_paths, model_name, use
+        )
+    except UnboundLocalError:
+        pass
+
+
 _check_xml._original_method = View._check_xml
 View._check_xml = _check_xml
 check._original_method = NameManager.check
 NameManager.check = check
 _raise_view_error._original_method = View._raise_view_error
 View._raise_view_error = _raise_view_error
+_check_field_paths._original_method = View._check_field_paths
+View._check_field_paths = _check_field_paths


### PR DESCRIPTION
given we don't raise in `raise_view_error`, we get an unbound local error after https://github.com/OCA/OCB/blob/15.0/odoo/addons/base/models/ir_ui_view.py#L1838 if a field used in a view doesn't exist. Seems fine to me to just ignore this then. If you agree I'll cherry pick to v16