### PR TITLE
[15.0][OU-FIX] account: Perform account.payment~payment_method_line_id assignation on end

### DIFF
--- a/openupgrade_scripts/scripts/account/15.0.1.2/end-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/end-migration.py
@@ -33,6 +33,22 @@ def _fast_fill_account_payment_outstanding_account_id(env):
     )
 
 
+def _fast_fill_account_payment_payment_method_line_id(env):
+    """Done on end-migration for waiting until all the payment method lines are created,
+    like for example those for checks (account_check_printing).
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_payment ap
+        SET payment_method_line_id = apml.id
+        FROM account_move am
+        JOIN account_payment_method_line apml ON apml.journal_id = am.journal_id
+        WHERE ap.move_id = am.id AND ap.payment_method_id = apml.payment_method_id
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     _fast_fill_account_payment_outstanding_account_id(env)

--- a/openupgrade_scripts/scripts/account/15.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/pre-migration.py
@@ -296,16 +296,6 @@ def _fast_fill_account_payment_payment_method_line_id(env):
         ALTER TABLE account_payment
         ADD COLUMN IF NOT EXISTS payment_method_line_id INTEGER""",
     )
-    openupgrade.logged_query(
-        env.cr,
-        """
-        UPDATE account_payment ap
-        SET payment_method_line_id = apml.id
-        FROM account_move am
-        JOIN account_payment_method_line apml ON apml.journal_id = am.journal_id
-        WHERE ap.move_id = am.id AND ap.payment_method_id = apml.payment_method_id
-        """,
-    )
 
 
 def _fill_account_tax_country_id(env):


### PR DESCRIPTION
If not, as we insert through the migration process some account.payment.method.line records, like the `check_printing` ones, some of the account.payment won't have the proper line assigned.

@Tecnativa TT47256