### PR TITLE
[OU-IMP] apriori. OCA/pos_invoicing module is now native in 'point_of_sale'

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -71,6 +71,7 @@ merged_modules = {
     # OCA/hr-attendance
     "hr_attendance_user_list": "hr_attendance",
     # OCA/pos
+    "pos_invoicing": "point_of_sale",
     "pos_order_mgmt": "point_of_sale",
     "pos_order_return": "point_of_sale",
     # OCA/product-attribute


### PR DESCRIPTION
due to the call of _apply_invoice_payments during order / invoice creation.

https://github.com/odoo/odoo/blob/15.0/addons/point_of_sale/models/pos_order.py#L648