### PR TITLE
[OU-IMP] apriori : OCA/pos_journal_image renamed into OCA/pos_payment_method_image

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -23,6 +23,8 @@ renamed_modules = {
     "crm_project": "crm_lead_to_task",
     # OCA/knowledge
     "knowledge": "document_knowledge",
+    # OCA/pos
+    "pos_journal_image": "pos_payment_method_image",
     # OCA/sale-promotion
     "coupon_incompatibility": "loyalty_incompatibility",
     "coupon_limit": "loyalty_limit",


### PR DESCRIPTION
See : https://github.com/OCA/pos/pull/1021

(Note : The module will be obsolete in V17, as the feature is now native in Odoo / point_of_sale)