### PR TITLE
[16.0][OU-ADD] sale_coupon_selection_wizard: Merged into sale_loyalty_order_suggestion

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -83,6 +83,7 @@ merged_modules = {
     "product_form_purchase_link": "purchase",
     # OCA/sale-promotion
     "coupon_commercial_partner_applicability": "loyalty_partner_applicability",
+    "sale_coupon_selection_wizard": "sale_loyalty_order_suggestion",
     # OCA/sale-workflow
     "sale_product_set_layout": "sale_product_set",
     # OCA/stock-logistics-workflow


### PR DESCRIPTION
The wizard module used to allow you to select a promotion and configure it to be applicable to the sales order. This wizard was opened by a gift icon that added the suggestion module to the sales order line whose product was part of the rules of a promotion. The wizard module is no longer needed because odoo has incorporated a wizard to select promotions. The part of the functionality to configure the promotion to be applicable that the module sale_coupon_selection_wizard used to provide has been incorporated into the module sale_loyalty_order_suggestion adapting it to the odoo wizard.

cc @Tecnativa TT44352

@chienandalu please review