### PR TITLE
[MIG] l10n_it_account_balance_eu: Rename to l10n_it_financial_statement_eu

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -40,6 +40,7 @@ renamed_modules = {
     # OCA/server-ux
     "mass_editing": "server_action_mass_edit",
     # OCA/l10n-italy
+    "l10n_it_account_balance_eu": "l10n_it_financial_statement_eu",
     "l10n_it_ricevute_bancarie": "l10n_it_riba",
     # OCA/...
 }


### PR DESCRIPTION
It happens in the PR https://github.com/OCA/l10n-italy/pull/3599