### PR TITLE
[14.0] Rename module delivery_roulier_laposte to delivery_roulier_laposte_fr

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -95,6 +95,8 @@ merged_modules = {
     "theme_graphene_blog": "theme_graphene",
     # odoo/enterprise
     "hr_holidays_gantt_calendar": "hr_holidays_gantt",
+    # OCA/delivery-carrier
+    "delivery_roulier_laposte": "delivery_roulier_laposte_fr",
     # OCA/intrastat-extrastat
     "hs_code_link": "product_harmonized_system_delivery",
     # OCA/event


### PR DESCRIPTION
Rename module delivery_roulier_laposte to delivery_roulier_laposte_fr (module from OCA/delivery-carrier)