### PR TITLE
[16.0][OU-FIX] hr: Error when calling the join() function

### DIFF
--- a/openupgrade_scripts/scripts/hr/16.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/hr/16.0.1.1/post-migration.py
@@ -147,7 +147,7 @@ def create_work_contact(env):
                     "Arbitrarily, the res.partner(%s) (the first one) "
                     "is used for work_contact_id of the hr.employee(%s).",
                     employee.id,
-                    ", ".joins(matching_partner.ids),
+                    ", ".join(str(v) for v in matching_partner.ids),
                     partner.id,
                     employee.id,
                 )


### PR DESCRIPTION
- The error was located in the create_work_contact() method at line 150, where the join function was incorrectly called. The original call '" , ".joins(matching_partner.ids)' resulted in a TypeError because it expected a str instance but found an int.

The error was fixed using the following line of code: ", ".join(str(v) for v in matching_partner.ids)

This fix ensures that the elements of matching_partner.ids are properly converted to strings before being joined by the join function, thereby avoiding the error.