### PR TITLE
[15.0][OU-ADD] mrp_subcontracting_resupply_link: Merged into mrp_subcontracting_purchase

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -70,6 +70,8 @@ merged_modules = {
     "website_sale_stock_available_display": "website_sale_stock",
     # OCA/hr-attendance
     "hr_attendance_user_list": "hr_attendance",
+    # OCA/manufacture
+    "mrp_subcontracting_resupply_link": "mrp_subcontracting_purchase",
     # OCA/pos
     "pos_order_mgmt": "point_of_sale",
     "pos_order_return": "point_of_sale",


### PR DESCRIPTION
Merged into `mrp_subcontracting_purchase`. The new module already has the smart-buttons.

Please @pedrobaeza can you review it?

@Tecnativa TT47845