### PR TITLE
[FIX] product: Inherit_view migration from V12.0 with groups_id field

### DIFF
--- a/openupgrade_scripts/scripts/product/16.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/product/16.0.1.2/pre-migration.py
@@ -11,3 +11,9 @@ _field_renames = [
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_fields(env, _field_renames)
+    # restricting inherited views to groups isn't allowed any more
+    env.cr.execute(
+        "DELETE FROM ir_ui_view_group_rel r "
+        "USING ir_ui_view v "
+        "WHERE r.view_id=v.id AND v.inherit_id IS NOT NULL AND v.mode != 'primary'"
+    )


### PR DESCRIPTION
In this view definition [res.partner.product.property.form.inherit](https://github.com/odoo/odoo/blob/12.0/addons/product/views/res_partner_views.xml#L7) of V12.0, there is a value for groups_id; this will cause the upgrade from version 15.0 to 16.0 to fail.

```
2024-02-28 02:09:53,530 14 INFO odoo_migration odoo.modules.loading: loading product/views/res_partner_views.xml 
2024-02-28 02:09:53,549 14 WARNING odoo_migration odoo.modules.loading: Transient module states were reset 
2024-02-28 02:09:53,552 14 ERROR odoo_migration odoo.modules.registry: Failed to load registry 
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/modules/registry.py", line 90, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 484, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 231, in load_module_graph
    load_data(cr, idref, mode, kind='data', package=package)
  File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/usr/lib/python3/dist-packages/odoo/tools/convert.py", line 763, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/usr/lib/python3/dist-packages/odoo/tools/convert.py", line 829, in convert_xml_import
    obj.parse(doc.getroot())
  File "/usr/lib/python3/dist-packages/odoo/tools/convert.py", line 749, in parse
    self._tag_root(de)
  File "/usr/lib/python3/dist-packages/odoo/tools/convert.py", line 709, in _tag_root
    raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
odoo.tools.convert.ParseError: while parsing /usr/lib/python3/dist-packages/odoo/addons/product/views/res_partner_views.xml:3
承接的Qweb视图不能在记录中定义“组”。在视图定义中使用“组”属性

View error context:
'-no context-'

```