### PR TITLE
[16.0][OU-ADD] purchase_picking_state: Merged into purchase_stock

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -101,6 +101,7 @@ merged_modules = {
     # OCA/purchase-workflow
     "product_form_purchase_link": "purchase",
     "purchase_order_line_price_history": "purchase",
+    "purchase_picking_state": "purchase_stock",
     # OCA/sale-promotion
     "coupon_commercial_partner_applicability": "loyalty_partner_applicability",
     "sale_coupon_selection_wizard": "sale_loyalty_order_suggestion",


### PR DESCRIPTION
Related to https://github.com/OCA/purchase-workflow/pull/2081

Merged into purchase_stock (`receipt_status` field)

Please @pedrobaeza can you review it?

@Tecnativa TT47855