### PR TITLE
[REM] remove rename of pos_journal_image into pos_payment_method_image, now handled in V13

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -24,7 +24,6 @@ renamed_modules = {
     # OCA/knowledge
     "knowledge": "document_knowledge",
     # OCA/pos
-    "pos_journal_image": "pos_payment_method_image",
     # OCA/sale-promotion
     "coupon_incompatibility": "loyalty_incompatibility",
     "coupon_limit": "loyalty_limit",


### PR DESCRIPTION
Rational : 
- pos_journal_image exists in V12
- pos_payment_method_image has been developped in V16.

In the meantime, The module pos_payment_method_image now exist in V13 : https://github.com/OCA/pos/pull/668/files

So remove the rename here and create a new PR against V13 (https://github.com/OCA/OpenUpgrade/pull/4330)