### PR TITLE
[16.0][OU-FIX] mail: missing ir_rule to be updated

### DIFF
--- a/openupgrade_scripts/scripts/mail/16.0.1.10/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/noupdate_changes.xml
@@ -13,6 +13,19 @@
                             ('group_public_id', 'in', [g.id for g in user.groups_id])]
             </field>
   </record>
+  <record id="ir_rule_mail_channel_member_group_user" model="ir.rule">
+    <field name="domain_force">[
+                '|',
+                    '&amp;',
+                        ('channel_id.channel_type', '!=', 'channel'),
+                        ('channel_id.is_member', '=', True),
+                    '&amp;',
+                        ('channel_id.channel_type', '=', 'channel'),
+                        '|',
+                            ('channel_id.group_public_id', '=', False),
+                            ('channel_id.group_public_id', 'in', [g.id for g in user.groups_id])]
+            </field>
+  </record>
   <record id="mt_comment" model="mail.message.subtype">
     <field name="track_recipients" eval="True"/>
   </record>


### PR DESCRIPTION
Rule ir_rule_mail_channel_partner_group_user from mail, needs to be force updated (since it is noupdate = True, it will not get updated otherwise).

Without this update, you get an error when trying to open chatter (from top bar when on a different menu than Discuss) when it tries to resolve access rights to mail_channel_member object since public field does not exist anymore on mail_channel model.