### PR TITLE
[15.0][OU-ADD] purchase_requisition_stock: purchase_requisition_grouped_by_procurement compatibility

### DIFF
--- a/openupgrade_scripts/scripts/purchase_requisition_stock/15.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/purchase_requisition_stock/15.0.1.2/pre-migration.py
@@ -1,0 +1,23 @@
+# Copyright 2024 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """The module purchase_requisition_grouped_by_procurement previously added
+    group_id column in previous version. Now procurement_group_id field exists."""
+    if openupgrade.is_module_installed(
+        env.cr, "purchase_requisition_grouped_by_procurement"
+    ):
+        openupgrade.rename_fields(
+            env,
+            [
+                (
+                    "purchase.requisition",
+                    "purchase_requisition",
+                    "group_id",
+                    "procurement_group_id",
+                ),
+            ],
+        )


### PR DESCRIPTION
Rename `group_id` column from `purchase.requisition` to procurement_group_id.
Related to https://github.com/OCA/purchase-workflow/pull/2196

@Tecnativa TT41760