### PR TITLE
[13.0][OU-ADD] apriori: rename pos_journal_image

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -25,6 +25,8 @@ renamed_modules = {
     'quality_control_stock': 'quality_control_stock_oca',
     # OCA/margin-analysis
     'product_pricelist_margin': 'product_pricelist_simulation',
+    # OCA/pos
+    "pos_journal_image": 'pos_payment_method_image',
     # OCA/product-attribute
     'product_pricelist_print_website_sale': 'product_pricelist_direct_print_website_sale',
     'sale_product_classification': 'product_abc_classification_sale',


### PR DESCRIPTION
From the readme of `pos_payment_method_image` in 13.0:

> This module changes the pos_journal_image (12.0) to pos_payment_method_image (13.0) because of the model changing.

> Migration script from 12.0 is not covered yet.