### PR TITLE
[16.0][OU-FIX] digest: Load upstream latest template

### DIFF
--- a/openupgrade_scripts/scripts/digest/16.0.1.1/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/digest/16.0.1.1/noupdate_changes.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8'?>
 <odoo>
-  <template id="digest_mail_layout">
+  <!-- <template id="digest_mail_layout">
 &lt;!DOCTYPE html&gt;
 <html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/><meta name="format-detection" content="telephone=no"/><meta name="viewport" content="width=device-width; initial-scale=1.0; maximum-scale=1.0; user-scalable=no;"/><meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7; IE=EDGE"/><style type="text/css"><t t-set="company_color" t-value="company.secondary_color or '#875a7b'"/>
             body {
@@ -312,7 +312,7 @@
                 }
             }
          </style></head><body><t t-out="body"/></body></html>
-    </template>
+    </template> -->
   <template id="digest_section_mobile">
     <div class="global_layout" style="overflow: auto;">
       <div style="width: 50%; float: left; text-align: right;">

--- a/openupgrade_scripts/scripts/digest/16.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/digest/16.0.1.1/post-migration.py
@@ -1,4 +1,5 @@
 # Copyright 2023 ACSONE SA/NV
+# Copyright 2024 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from openupgradelib import openupgrade
@@ -18,3 +19,5 @@ _translations_to_delete = [
 def migrate(env, version):
     openupgrade.load_data(env.cr, "digest", "16.0.1.1/noupdate_changes.xml")
     openupgrade.delete_record_translations(env.cr, "digest", _translations_to_delete)
+    # Restore the noupdate=1 after forcing the update of upstream code content
+    openupgrade.set_xml_ids_noupdate_value(env, "digest", ["digest_mail_layout"], True)

--- a/openupgrade_scripts/scripts/digest/16.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/digest/16.0.1.1/pre-migration.py
@@ -1,0 +1,10 @@
+# Copyright 2024 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Switch to noupdate=0 for getting the current v16 arch, for switching in post again
+    openupgrade.set_xml_ids_noupdate_value(env, "digest", ["digest_mail_layout"], False)


### PR DESCRIPTION
As the template is constantly changing upstream:

https://github.com/odoo/odoo/commits/16.0/addons/digest/data/digest_data.xml

keeping a copy here and loading it is not practical and can lead to errors, like the one that triggers this PR, having an inheritance in mass_mailing that crashes due to obsolete content.

Thus, the best strategy is to switch to noupdate=0 before updating contents, and then restore it to noupdate.