### PR TITLE
[16.0][FIX] website: Fix xmlid issue in website upgrade script.

### DIFF
--- a/openupgrade_scripts/scripts/website/16.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/website/16.0.1.0/pre-migration.py
@@ -133,3 +133,11 @@ def migrate(env, version):
     delete_constraint_website_visitor_partner_uniq(env)
     _fill_homepage_url(env)
     _mig_s_progress_steps_contents(env)
+
+    # XMLID website_configurator will be re-used for something else
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM ir_model_data WHERE module = 'website' AND name = 'website_configurator'
+        """,
+    )


### PR DESCRIPTION
Migrating with the website module installed will give the following error:
```
odoo.tools.convert.ParseError: while parsing /home/ubuntu/odoo/auto/addons/website/views/website_views.xml:475
For external id website.website_configurator when trying to create/update a record of model ir.actions.client found record of different model ir.ui.view (697420)

View error context:
'-no context-'
```
The problem, as the error suggests, has to do with the fact that the `website.website_configurator` xmlid in 15.0 was used to point to an `ir.ui.view`, and now is used to point to a `ir.actions.client`. I got the sense that it was attempted to delete the xmlid here: [https://github.com/OCA/OpenUpgrade/blob/5cb76b4ae8b819dcf7dd3385f46cb6620c9fa3d0/openupgrade_scripts/scripts/website/16.0.1.0/pre-migration.py#L17]
But it actually only deletes the view, not the xmlid, while it is the existence of the xmlid that has odoo trip.