### PR TITLE
[12.0][OU-IMP] base: vacuum of transient models (backport)

### DIFF
--- a/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
+++ b/odoo/addons/base/migrations/12.0.1.3/pre-migration.py
@@ -222,6 +222,7 @@ def migrate(env, version):
         env.cr, apriori.renamed_modules.items())
     openupgrade.update_module_names(
         env.cr, apriori.merged_modules.items(), merge_modules=True)
+    openupgrade.clean_transient_models(env.cr)
     if openupgrade.table_exists(env.cr, 'product_uom'):
         openupgrade.rename_models(env.cr, model_renames_product)
         openupgrade.rename_tables(env.cr, table_renames_product)


### PR DESCRIPTION
Backport of https://github.com/OCA/OpenUpgrade/pull/4374.