### PR TITLE
[14.0][FIX] detect if we have edi_oca from v12 already

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/pre-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/pre-migrate.py
@@ -137,6 +137,14 @@ def migrate(cr, version):
     """
     )
     # Perform module renames and merges
+
+    # edi_oca has been merged into oca/edi 12.0, so move the rename of edi
+    # to merged in case it already exists at this point (we still need the
+    # rename when migrating just a v13 db
+    cr.execute("SELECT 1 FROM ir_module_module WHERE name='edi_oca'")
+    if cr.fetchall():
+        merged_modules["edi"] = renamed_modules.pop("edi")
+
     openupgrade.update_module_names(cr, renamed_modules.items())
     openupgrade.update_module_names(cr, merged_modules.items(), merge_modules=True)
     openupgrade.clean_transient_models(cr)


### PR DESCRIPTION
`edi_oca` has been merged into [v12](https://github.com/OCA/edi/pull/877), but doesn't exist in v13. So when migrating from a v12 database, the rename fails.

On the other hand, when migrating from a v13 database, we want the rename.