### PR TITLE
[13.0][FIX] account: don't set exclude_from_invoice_tab for type entry

### DIFF
--- a/addons/account/migrations/13.0.1.1/post-migration.py
+++ b/addons/account/migrations/13.0.1.1/post-migration.py
@@ -296,7 +296,11 @@ def migration_invoice_moves(env):
         env.cr, """
         UPDATE account_move_line
         SET exclude_from_invoice_tab = TRUE
-        WHERE old_invoice_line_id IS NULL""",
+        FROM account_move
+        WHERE old_invoice_line_id IS NULL
+        AND account_move_line.move_id=account_move.id
+        AND account_move.type <> 'entry'
+        """,
     )
     # 4th. Adding all the missing lines
     openupgrade.logged_query(


### PR DESCRIPTION
when we create an entry in v13, this flag isn't set on move lines for type entry, so the migration shouldn't set it either. Otherwise, we get weird side effects when recomputing ie the balance of such entries