### PR TITLE
[15.0][FIX] hr_expense: set exclude_from_invoice_tab on destination move line

### DIFF
--- a/openupgrade_scripts/scripts/hr_expense/15.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/15.0.2.0/post-migration.py
@@ -10,6 +10,15 @@ def _fill_payment_state(env):
         WHERE account_move_id IS NULL
         """,
     )
+    # set exclude_from_invoice_tab the way v15 does it
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move_line
+        SET exclude_from_invoice_tab=(coalesce(quantity, 0) = 0)
+        WHERE expense_id IS NOT NULL
+        """,
+    )
     # Recompute payment_state for the moves associated to the expenses, as on
     # v14 these ones were not computed being of type `entry`, which changes now
     # on v15 if the method `_payment_state_matters` returns True, which is the


### PR DESCRIPTION
Fixes #4251 - we can derive the flag from the quantity field because [v14](https://github.com/OCA/OCB/blob/14.0/addons/hr_expense/models/hr_expense.py#L500-L510) as well as [v15](https://github.com/OCA/OCB/blob/15.0/addons/hr_expense/models/hr_expense.py#L613-L624) don't set it on the destination line.

Superseding https://github.com/OCA/OpenUpgrade/pull/4253

(this is somewhat connected to https://github.com/OCA/OpenUpgrade/pull/4385 - if all entries have the flag set, we want to *unset* it for the lines that are not the destination account. If entries don't have the flag set, we want to *set* it for lines with the destination account)