### PR TITLE
[16.0][OU-IMP] account: False in account.journal~payment_sequence

### DIFF
--- a/openupgrade_scripts/scripts/account/16.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/16.0.1.2/pre-migration.py
@@ -355,6 +355,26 @@ def _fast_fill_account_payment_amount_company_currency_signed(env):
     )
 
 
+def _account_journal_payment_sequence(env):
+    """Add manually this field with False value to avoid different behavior from v15,
+    where there's only one number sequence for whole journal.
+    """
+    openupgrade.add_fields(
+        env,
+        [
+            (
+                "payment_sequence",
+                "account.journal",
+                "account_journal",
+                "boolean",
+                False,
+                "account",
+                False,
+            )
+        ],
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_xmlids(env.cr, _xmlids_renames)
@@ -383,3 +403,4 @@ def migrate(env, version):
         "account_reconcile_model_line_id",
     )
     _fast_fill_account_payment_amount_company_currency_signed(env)
+    _account_journal_payment_sequence(env)

--- a/openupgrade_scripts/scripts/account/16.0.1.2/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/16.0.1.2/upgrade_analysis_work.txt
@@ -164,9 +164,11 @@ account      / account.chart.template   / use_storno_accounting (boolean): NEW h
 
 account      / account.journal          / default_account_type (many2one): relation is now 'False' ('account.account.type') [nothing to do]
 account      / account.journal          / default_account_type (many2one): type is now 'char' ('many2one')
-account      / account.journal          / payment_sequence (boolean)    : NEW hasdefault: compute
 account      / account.journal          / type_control_ids (many2many)  : DEL relation: account.account.type
 # NOTHING TO DO
+
+account      / account.journal          / payment_sequence (boolean)    : NEW hasdefault: compute
+# DONE: pre-migration: initialize to False to preserve v15 behavior and avoid errors when giving numbers
 
 account      / account.move             / attachment_ids (one2many)     : NEW relation: ir.attachment
 # NOTHING TO DO


### PR DESCRIPTION
Add manually this field with False value to avoid different behavior from v15, where there's only one number sequence for whole journal.

@Tecnativa TT48756