### PR TITLE
[16.0][OU-IMP] project: merge project_task_milestone

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -88,6 +88,8 @@ merged_modules = {
     # OCA/pos
     "pos_order_line_no_unlink": "point_of_sale",
     "pos_product_sort": "point_of_sale",
+    # OCA/project
+    "project_task_milestone": "project",
     # OCA/purchase-workflow
     "product_form_purchase_link": "purchase",
     # OCA/sale-promotion


### PR DESCRIPTION
There is nothing to do more, because milestone_id columns already exists on project_task table.

This PR is related to this issue: https://github.com/OCA/project/issues/1267