### PR TITLE
[16.0][OU-FIX] fix translation of inherited help field

### DIFF
--- a/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
@@ -55,12 +55,12 @@ def login_or_registration_required_at_checkout(cr):
 def update_translatable_fields(cr):
     # exclude fields from translation update
     exclusions = {
-        # ir.actions.* inherits the name column from ir.actions.actions
+        # ir.actions.* inherits the name and help columns from ir.actions.actions
         "ir.actions.act_window": ["name", "help"],
-        "ir.actions.act_url": ["name"],
-        "ir.actions.server": ["name"],
+        "ir.actions.act_url": ["name", "help"],
+        "ir.actions.server": ["name", "help"],
         "ir.actions.client": ["name", "help"],
-        "ir.actions.report": ["name"],
+        "ir.actions.report": ["name", "help"],
     }
     cr.execute(
         "SELECT f.name, m.model FROM ir_model_fields f "


### PR DESCRIPTION
exclude `help` field for all models that inherit from ir.actions.

this is the same problem as fixed in #3866 and #4254, but generalized to all models.