### PR TITLE
[16.0][OU-FIX] point_of_sale: improve pre-migration execution, replacing n SQL requests n=len(pos_orders) by 1 SQL request

### DIFF
--- a/openupgrade_scripts/scripts/point_of_sale/16.0.1.0.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/point_of_sale/16.0.1.0.1/pre-migration.py
@@ -1,6 +1,5 @@
 # SPDX-FileCopyrightText: 2024 Tecnativa - Pedro M. Baeza
 # SPDX-License-Identifier: AGPL-3.0-or-later
-import uuid
 
 from openupgradelib import openupgrade
 
@@ -10,12 +9,9 @@ def _assign_pos_order_token(env):
         env,
         [("access_token", "pos.order", "pos_order", "char", False, "point_of_sale")],
     )
-    env.cr.execute("SELECT id FROM pos_order")
-    for row in env.cr.fetchall():
-        env.cr.execute(
-            "UPDATE pos_order SET access_token = %s WHERE id = %s",
-            (str(uuid.uuid4()), row[0]),
-        )
+    openupgrade.logged_query(
+        env.cr, "UPDATE pos_order SET access_token = gen_random_uuid();"
+    )
 
 
 @openupgrade.migrate()


### PR DESCRIPTION

Fix : https://github.com/OCA/OpenUpgrade/pull/4417 and https://github.com/OCA/OpenUpgrade/commit/dea8b8a70af3e9b3cc29a5b472d2699b0ba8f212

Current implementation generate an SQL request per ``pos_order`` that can be slow for huge database.
Replacing per one single request, using postgresql uuid function 
https://www.postgresql.org/docs/current/functions-uuid.html

Note : No benchmark on huge database done.

Thanks for your review.