### PR TITLE
[16.0][OU-FIX] sale_purchase: Changes in Odoo upstream

### DIFF
--- a/openupgrade_scripts/scripts/sale_purchase/16.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/sale_purchase/16.0.1.0/post-migration.py
@@ -76,11 +76,6 @@ def convert_service_to_purchase_to_company_dependent(env):
 @openupgrade.migrate()
 def migrate(env, version):
     convert_service_to_purchase_to_company_dependent(env)
-    constraint = env.ref(
-        "sale_purchase.constraint_product_template_service_to_purchase", False
-    )
-    if constraint:
-        constraint._module_data_uninstall()
     openupgrade.delete_records_safely_by_xml_id(
         env, ["sale_purchase.constraint_product_template_service_to_purchase"]
     )

--- a/openupgrade_scripts/scripts/sale_purchase/16.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/sale_purchase/16.0.1.0/upgrade_analysis_work.txt
@@ -5,7 +5,7 @@ sale_purchase / product.template         / service_to_purchase (boolean) : not s
 
 ---XML records in module 'sale_purchase'---
 DEL ir.model.constraint: sale_purchase.constraint_product_template_service_to_purchase
-# DONE: post-migration, delete constraint
+# NOTHING TO DO: Handled in ORM since https://github.com/odoo/odoo/commit/3fd308981d077bd9b93394d45defaa990d9c7acd
 
 NEW ir.ui.view: sale_purchase.sale_order_cancel_view_form
 # NOTHING TO DO


### PR DESCRIPTION
Since

https://github.com/odoo/odoo/commit/3fd308981d077bd9b93394d45defaa990d9c7acd

the method _module_data_uninstall doesn't exist, and the constraint removal is performed by the ORM itsel, so this has converted in a "nothing to do".

Fixes #4420

@Tecnativa 