### PR TITLE
[16.0][OU-FIX] fill new mail.template template_fs field

### DIFF
--- a/openupgrade_scripts/scripts/mail/16.0.1.10/end-migration.py
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/end-migration.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import os.path
+
+from lxml import etree
+from openupgradelib import openupgrade
+
+from odoo.modules import get_manifest
+from odoo.tools.misc import file_open
+
+
+def is_xml_filename(filename):
+    return os.path.splitext(filename)[1].lower() == ".xml"
+
+
+def get_module_xml_files(module_name):
+    return filter(is_xml_filename, get_manifest(module_name).get("data", []))
+
+
+def find_record_data_path(model_name, module_name, xml_id):
+    """
+    Get the path of the XML data file containing the record.
+    """
+    for xml_file in get_module_xml_files(module_name):
+        filepath = "/".join((module_name, xml_file))
+        with file_open(filepath, "rb") as f:
+            root = etree.parse(f)
+            found = root.xpath(
+                '//record[@model="{model_name}"][@id="{xml_id}"]'.format(
+                    model_name=model_name, xml_id=xml_id
+                )
+            )
+            if found:
+                return filepath
+    return None
+
+
+def fill_all_null_mail_template_template_fs(env):
+    """
+    Fill the new template_fs field of all mail.template if it is null.
+
+    The mail.template template_fs field must contain the path of the data file
+    where it is defined (to allow for it to be reset to its default value).
+    Fill empty values by searching for the mail templates (by xml id) in the
+    XML files of the module that defines it.
+    """
+    env.cr.execute(
+        """
+        select mt.id, imd.module, imd.name
+        from mail_template as mt
+        inner join ir_model_data as imd on
+            imd.model = 'mail.template' and
+            imd.res_id = mt.id
+        where mt.template_fs is null
+        """
+    )
+    mail_template_model = env["mail.template"]
+    for mail_template_id, module_name, template_name in env.cr.fetchall():
+        template_fs = find_record_data_path("mail.template", module_name, template_name)
+        if template_fs is not None:
+            mail_template = mail_template_model.browse(mail_template_id)
+            mail_template.template_fs = template_fs
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    fill_all_null_mail_template_template_fs(env)

--- a/openupgrade_scripts/scripts/mail/16.0.1.10/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/upgrade_analysis_work.txt
@@ -86,8 +86,10 @@ mail         / mail.template            / model_object_field (many2one) : DEL re
 mail         / mail.template            / null_value (char)             : DEL
 mail         / mail.template            / sub_model_object_field (many2one): DEL relation: ir.model.fields
 mail         / mail.template            / sub_object (many2one)         : DEL relation: ir.model
-mail         / mail.template            / template_fs (char)            : NEW
 # NOTHING TO DO
+
+mail         / mail.template            / template_fs (char)            : NEW
+# DONE (end-migration): fill the new field
 
 
 mail         / res.partner              / channel_ids (many2many)       : table is now 'mail_channel_member' ('mail_channel_partner')


### PR DESCRIPTION
the `mail.template` `template_fs` field must contain the path of the data file where it is defined (to allow for it to be reset to its default value). fill empty values by searching for the mail templates (by xml id) in the xml files of the module that defines it.