### PR TITLE
[15.0][FIX] mail: remove `safe` filters from email templates

### DIFF
--- a/openupgrade_scripts/scripts/mail/15.0.1.5/post-migration.py
+++ b/openupgrade_scripts/scripts/mail/15.0.1.5/post-migration.py
@@ -104,7 +104,9 @@ def _migrate_placeholder_html(string):
     """
     Replace dynamic placeholders in HTML fields:
     Example: 'Your name is ${object.name}' -> 'Your name is <t t-out="object.name"></t>'
+    Example:'${object.html_content | safe}' -> '<t t-out="object.html_content"></t>'
     """
+    string = re.sub(r"\|\s*safe\s*(?=\W|$)", "", string)
     pattern = r"\$\{([^}]*)\}"
     string = re.sub(pattern, repl_placeholder, string)
     return string


### PR DESCRIPTION
We need to remove `safe` filters from email templates placeholders as they will crash in rendering as qweb can't deal with them.

cc @Tecnativa TT49382

please check @pedrobaeza 