### PR TITLE
[15.0][OU-ADD] hr_timesheet_begin_end: Rename hr_timesheet_activity_begin_end to hr_timesheet_begin_end

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -30,6 +30,8 @@ renamed_modules = {
     "sale_coupon_portal_commercial_partner_applicability": "coupon_portal_commercial_partner_applicability",  # noqa: B950
     # OCA/stock-logistics-worehouse
     "stock_inventory_cost_info": "stock_quant_cost_info",
+    # OCA/timesheet:
+    "hr_timesheet_activity_begin_end": "hr_timesheet_begin_end",
     # OCA/...
 }
 


### PR DESCRIPTION
Rename hr_timesheet_activity_begin_end to hr_timesheet_begin_end. This was forgotten when this PR: https://github.com/OCA/timesheet/pull/517 was merged.

MT-1700 @moduon