### PR TITLE
[13.0][OU-FIX] pos_sale: do not delete point_of_sale.pos_config_main

### DIFF
--- a/addons/pos_sale/migrations/13.0.1.0/openupgrade_analysis_work.txt
+++ b/addons/pos_sale/migrations/13.0.1.0/openupgrade_analysis_work.txt
@@ -21,4 +21,8 @@ DEL crm.team: pos_sale.pos_sales_team [renamed to sales_team module] (noupdate)
 # NOTHING TO DO: renamed xmlids in sales_team
 
 DEL pos.config: point_of_sale.pos_config_main (noupdate)
-# DONE: post-migration: Try to delete record
+# NOTHING TO DO: point_of_sale.pos_config_main still exists in module
+    point_of_sale. Now the module pos_sale does not add a value for
+    crm_team_id in the xml file, it only rely on the default value
+    defined with a function in the model pos.config. The value set in
+    previous version should no be modified.

--- a/addons/pos_sale/migrations/13.0.1.0/post-migration.py
+++ b/addons/pos_sale/migrations/13.0.1.0/post-migration.py
@@ -26,9 +26,4 @@ def _map_crm_team_id(env):
 def migrate(env, version):
     openupgrade.load_data(
         env.cr, "pos_sale", "migrations/13.0.1.0/noupdate_changes.xml")
-    openupgrade.delete_records_safely_by_xml_id(
-        env, [
-            "point_of_sale.pos_config_main",
-        ]
-    )
     _map_crm_team_id(env)


### PR DESCRIPTION
In the analysis, the record point_of_sale.pos_config_main appears to be deleted. It's true that it is not overridden in the 13.0 version. But this record is not deleted, it still exists as it main definition is in the module point_of_sale.

In 12.0 the field crm_team_id is added to point_of_sale.pos_config_main and in 13.0 this field rely only on the _get_default function defined in the pos.config model in pos_sale.

There is no need to delete point_of_sale.pos_config_main, and there is no need to modify the crm_team_id value of this record. As this may have been modified by the users.