### PR TITLE
[OU-IMP] apriori : pos_margin_account_invoice_margin merged into point_of_sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -88,6 +88,7 @@ merged_modules = {
     # OCA/e-commerce
     "website_sale_require_login": "website_sale",
     # OCA/pos
+    "pos_margin_account_invoice_margin": "point_of_sale",
     "pos_order_line_no_unlink": "point_of_sale",
     "pos_product_sort": "point_of_sale",
     # OCA/project


### PR DESCRIPTION
pos_margin_account_invoice_margin is not necessary anymore. OCA/account_invoice_margin works out of the box with Odoo/point_of_sale.

See : https://github.com/OCA/pos/pull/1128