### PR TITLE
[14.0][OU-ADD] base: web_disable_export_group migration

### DIFF
--- a/openupgrade_scripts/scripts/base/14.0.1.3/group_allow_export_noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/group_allow_export_noupdate_changes.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<odoo>
+  <record id="default_user" model="res.users">
+    <field
+            name="groups_id"
+            eval="[(4, ref('base.group_partner_manager')), (4, ref('base.group_allow_export'))]"
+        />
+  </record>
+</odoo>

--- a/openupgrade_scripts/scripts/base/14.0.1.3/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/noupdate_changes.xml
@@ -22,9 +22,13 @@
   <record id="ca" model="res.country">
     <field name="state_required">1</field>
   </record>
-  <record id="default_user" model="res.users">
-    <field name="groups_id" eval="[(4, ref('base.group_partner_manager')), (4, ref('base.group_allow_export'))]"/>
-  </record>
+  <!-- Update only if web_disable_export_group wasn't installed. See post-migration-->
+  <!-- <record id="default_user" model="res.users">
+    <field
+            name="groups_id"
+            eval="[(4, ref('base.group_partner_manager')), (4, ref('base.group_allow_export'))]"
+        />
+  </record> -->
   <record id="es" model="res.country">
     <field eval="'%(street)s\n%(street2)s\n%(zip)s %(city)s (%(state_name)s)\n%(country_name)s'" name="address_format"/>
   </record>

--- a/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/post-migrate.py
@@ -143,3 +143,10 @@ def migrate(env, version):
     binary_conversion_for_db_attachments(env)
     # Load noupdate changes
     openupgrade.load_data(env.cr, "base", "14.0.1.3/noupdate_changes.xml")
+    # By default Odoo grants new users export access. If we had web_disable_export_group
+    # installed is very likely that this isn't the desired behavior and that we want
+    # to keep the access to that feature restricted by default.
+    if not openupgrade.is_module_installed(env.cr, "web_disable_export_group"):
+        openupgrade.load_data(
+            env.cr, "base", "14.0.1.3/group_allow_export_noupdate_changes.xml"
+        )

--- a/openupgrade_scripts/scripts/base/14.0.1.3/pre-migrate.py
+++ b/openupgrade_scripts/scripts/base/14.0.1.3/pre-migrate.py
@@ -155,3 +155,25 @@ def migrate(cr, version):
         cr, "UPDATE res_partner SET lang = 'tl_PH' WHERE lang = 'fil_PH'"
     )
     deduplicate_ir_properties(cr)
+    # Now Odoo supports disabling data exports, which is the main feature that
+    # the module web_disable_export_group provided. Although the module isn't completly
+    # merged into core as it allows to differentiate which type of export users can use.
+    # This might be unnecessary for some module users that would drop the module while
+    # others might want to keep it. To make the transition transparent for both cases,
+    # we put this migration script here.
+    cr.execute(
+        """
+            SELECT id FROM ir_model_data
+            WHERE module='web_disable_export_group' AND name='group_export_data'
+        """
+    )
+    if cr.fetchone():
+        openupgrade.rename_xmlids(
+            cr,
+            [
+                (
+                    "web_disable_export_group.group_export_data",
+                    "base.group_allow_export",
+                )
+            ],
+        )


### PR DESCRIPTION
Take the users from the web_disable_export_group.group_export_data group to the new base.group_allow_export which covers the same features.

As now Odoo supports disabling data exports, which is the main feature that the module web_disable_export_group provided we want to move the existing users in that module's groups to the new core one.

The module's functionality isn't completly merged into core as it allows to differentiate which type of export users can use.

This might be unnecessary for some module users that would drop the module while others might want to keep it. To make the transition transparent for both cases, we put this migration script here.

cc @Tecnativa TT49468

please check @pedrobaeza 

fyi @etobella 