### PR TITLE
[13.0][IMP] apriori: edi_oca -> edi

### DIFF
--- a/odoo/addons/openupgrade_records/lib/apriori.py
+++ b/odoo/addons/openupgrade_records/lib/apriori.py
@@ -9,6 +9,8 @@ renamed_modules = {
     'payment_ogone': 'payment_ingenico',
     # OCA/delivery-carrier
     'delivery_carrier_label_ups': 'delivery_ups_oca',
+    # OCA/edi
+    'edi_oca': 'edi',
     # OCA/event
     'website_event_filter_selector': 'website_event_filter_city',
     # OCA/hr


### PR DESCRIPTION
Was done in https://github.com/OCA/edi/pull/877.

It was commented in https://github.com/OCA/OpenUpgrade/pull/4384:
![Selection_3378](https://github.com/OCA/OpenUpgrade/assets/25005517/c02a942e-c466-4f31-b720-b5cb70b9384b)
