### PR TITLE
[IMP] website: BS4->BS5 performance refinement

### DIFF
--- a/openupgrade_scripts/scripts/website/16.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/website/16.0.1.0/end-migration.py
@@ -33,8 +33,11 @@ def convert_custom_qweb_templates_bootstrap_4to5(env):
 def convert_field_html_string_bootstrap_4to5(env):
     """Convert html field which might contain old bootstrap syntax"""
     # These models won't use bootstrap in their html fields
-    exclusions = [
+    model_exclusions = [
+        "mail.activity",
         "mail.message",
+        "mail.wizard.invite",
+        "web_editor.converter.test",
         "mail.mail",
         "mail.template",
         "res.users",
@@ -43,22 +46,32 @@ def convert_field_html_string_bootstrap_4to5(env):
         "account.invoice.send",
         "mail.alias",
     ]
+    # We could want to refine a certain field logic to discard a good bunch of records
+    field_special_domain = {
+        "account.move": {
+            "narration": [
+                ("move_type", "in", ["out_invoice", "out_refund", "out_receipt"])
+            ]
+        },
+    }
     fields = env["ir.model.fields"].search(
-        [("ttype", "=", "html"), ("store", "=", True)]
+        [
+            ("ttype", "=", "html"),
+            ("store", "=", True),
+            ("model", "not in", model_exclusions),
+        ]
     )
     for field in fields:
         model = field.model_id.model
-        if model in exclusions:
-            continue
-        logger.info(f"Converting from BS4 to BS5 field {field} in model {model}")
+        # The method convert_field_bootstrap_4to5 takes care of empty fields considering
+        domain = field_special_domain.get(model, {}).get(field.name, [])
+        logger.info(f"Converting from BS4 to BS5 field {field.name} in model {model}")
         if env.get(model, False) is not False and env[model]._auto:
             if openupgrade.table_exists(env.cr, env[model]._table):
                 if field.name in env[model]._fields and openupgrade.column_exists(
                     env.cr, env[model]._table, field.name
                 ):
-                    convert_field_bootstrap_4to5(
-                        env, model, field.name, domain=[(field.name, "!=", False)]
-                    )
+                    convert_field_bootstrap_4to5(env, model, field.name, domain=domain)
 
 
 def rename_t_group_website_restricted_editor(env):


### PR DESCRIPTION
Depends on:

- [x] https://github.com/OCA/openupgradelib/pull/371

Now that openupgradelib checks implicitly if a record value has a class attribute, we can refine the conversion further applying some extra logical filtering. Mainly when we're dealing with large tables.

We want also to log conversion performance to detect where the bottlenecks might be.

As a performance indicator, in a database with a very large `account_move` table this step passed **from ~14 hours to less than a minute** :upside_down_face: 

cc @Tecnativa TT46020