### PR TITLE
[14.0][OU-FIX] uom: setting reference unit

### DIFF
--- a/openupgrade_scripts/scripts/uom/14.0.1.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/uom/14.0.1.0/noupdate_changes.xml
@@ -17,18 +17,20 @@
   </record>
   <record id="product_uom_kgm" model="uom.uom">
     <field name="rounding" eval="0.01"/>
-    <field name="uom_type">reference</field>
+    <!-- <field name="uom_type">reference</field> -->
   </record>
   <record id="product_uom_lb" model="uom.uom">
     <field name="name">lb</field>
   </record>
   <record id="product_uom_litre" model="uom.uom">
     <field name="name">L</field>
-    <field name="uom_type">reference</field>
+    <!-- <field name="uom_type">reference</field> -->
   </record>
+  <!--
   <record id="product_uom_meter" model="uom.uom">
     <field name="uom_type">reference</field>
   </record>
+  -->
   <record id="product_uom_mile" model="uom.uom">
     <field name="name">mi</field>
   </record>
@@ -40,6 +42,6 @@
   </record>
   <record id="product_uom_unit" model="uom.uom">
     <field name="rounding" eval="0.01"/>
-    <field name="uom_type">reference</field>
+    <!-- <field name="uom_type">reference</field> -->
   </record>
 </odoo>


### PR DESCRIPTION
Some of the noupdate_changes imply to set the uom_type as "reference". Given that there can be only one reference unit per uom_category, forcing some uom.uom to be the reference of their category fails if the reference unit has been changed by the customer.

As an example, I have a customer who changed the volume reference unit to be 0.5 L instead of 1 L. Therefore this openupgrade script fail to apply the 1 L as a reference unit for the volume category.

If the database does not contain any reference unit for a unit category, then, this should be fixed before migrating the data. Changing the reference unit during migration does not seams a good idea to me.