### PR TITLE
[16.0][OU-ADD] apriori: Add merge of project_account on project

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -74,6 +74,7 @@ merged_modules = {
     "pad_project": "project",
     "pos_coupon": "pos_loyalty",
     "pos_gift_card": "pos_loyalty",
+    "project_account": "project",
     "sale_gift_card": "sale_loyalty",
     "sale_project_account": "sale_project",
     "website_sale_delivery_giftcard": "website_sale_loyalty_delivery",


### PR DESCRIPTION
project_account was removed on 16 https://github.com/odoo/odoo/commit/0d2c09a9381b98b4828f57ae66bbca2b193a607c
but restored on 17
https://github.com/odoo/odoo/commit/2b3e3a44a9582ddd62ca2cf96d9331e9c310bd3e