### PR TITLE
[16.0][OU-ADD] partner_company_group: Merged in base_partner_company_group

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -87,6 +87,8 @@ merged_modules = {
     "account_invoice_report_due_list": "account",
     # OCA/e-commerce
     "website_sale_require_login": "website_sale",
+    # OCA/partner-contact
+    "partner_company_group": "base_partner_company_group",
     # OCA/pos
     "pos_margin_account_invoice_margin": "point_of_sale",
     "pos_order_line_no_unlink": "point_of_sale",


### PR DESCRIPTION
After https://github.com/OCA/partner-contact/pull/1347, the module is no longer needed and should be merged into the base one for proper migration path.

@Tecnativa TT44334