### PR TITLE
[16.0][OU-FIX] sale_loyalty: Let ORM creates the coupon points table

### DIFF
--- a/openupgrade_scripts/scripts/sale_loyalty/16.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/sale_loyalty/16.0.1.0/post-migration.py
@@ -72,6 +72,27 @@ def merge_sale_gift_card_to_sale_loyalty_card(env):
     )
 
 
+def _generate_sale_order_coupon_points(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        INSERT INTO sale_order_coupon_points (
+            coupon_id, order_id, points, create_uid, write_uid, create_date, write_date
+        )
+        SELECT
+            id AS coupon_id,
+            order_id,
+            points,
+            create_uid,
+            write_uid,
+            create_date,
+            write_date
+        FROM loyalty_card
+        WHERE order_id IS NOT NULL;
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env.cr, "sale_loyalty", "16.0.1.0/noupdate_changes.xml")
@@ -82,3 +103,4 @@ def migrate(env, version):
     convert_applied_coupons_from_sale_order_to_many2many(env)
     fill_code_enabled_rule_ids_from_sale_order(env)
     merge_sale_gift_card_to_sale_loyalty_card(env)
+    _generate_sale_order_coupon_points(env)

--- a/openupgrade_scripts/scripts/sale_loyalty/16.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/sale_loyalty/16.0.1.0/pre-migration.py
@@ -38,41 +38,6 @@ def _generate_random_reward_code():
     return str(random.getrandbits(32))
 
 
-def generate_sale_order_coupon_points(env):
-    openupgrade.logged_query(
-        env.cr,
-        """
-        CREATE TABLE IF NOT EXISTS sale_order_coupon_points (
-            coupon_id INT,
-            order_id INT,
-            points FLOAT,
-            create_uid INT,
-            write_uid INT,
-            create_date DATE,
-            write_date DATE
-        )
-        """,
-    )
-    openupgrade.logged_query(
-        env.cr,
-        """
-        INSERT INTO sale_order_coupon_points (
-            coupon_id, order_id, points, create_uid, write_uid, create_date, write_date
-        )
-        SELECT
-            id AS coupon_id,
-            order_id,
-            points,
-            create_uid,
-            write_uid,
-            create_date,
-            write_date
-        FROM loyalty_card
-        WHERE order_id IS NOT NULL;
-        """,
-    )
-
-
 def update_loyalty_program_data(env):
     # Set sale_ok default values
     if not openupgrade.column_exists(env.cr, "loyalty_program", "sale_ok"):
@@ -211,7 +176,6 @@ def update_template_keys(env):
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_xmlids(env.cr, _xmlids_renames)
-    generate_sale_order_coupon_points(env)
     update_loyalty_program_data(env)
     update_sale_order_line_data(env)
     delete_sql_constraints(env)


### PR DESCRIPTION
We need the id column, plus there's a lot of stuff done by ORM that is not done if the table is created manually in pre.

Let's do it in post, as there's no need to anticipate it.

@Tecnativa 