### PR TITLE
[16.0][MIG] web_tree_image_tooltip: Merged to web

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -113,6 +113,7 @@ merged_modules = {
     # OCA/web
     "web_drop_target": "web",
     "web_ir_actions_act_view_reload": "web",
+    "web_tree_image_tooltip": "web",
 }
 
 # only used here for upgrade_analysis


### PR DESCRIPTION
The module web_tree_image_tooltip is not necessary anymore because odoo has added the zoom option which, if set to True, adds the tooltip with the image.

Example of how to use the feature:
`<field name="image_512" options="{'zoom': True}" widget="image" string="Image"/>`

![zoom](https://github.com/user-attachments/assets/63853512-8eab-425f-bea5-b7dcade44901)

cc @Tecnativa TT49818

ping @pedrobaeza @chienandalu 