### PR TITLE
[15.0][OU-IMP] stock: pre-compute stock.quant inventory_date

### DIFF
--- a/openupgrade_scripts/scripts/stock/15.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/stock/15.0.1.1/pre-migration.py
@@ -16,6 +16,12 @@ def _create_column_for_avoiding_automatic_computing(env):
         ALTER TABLE stock_location ADD COLUMN IF NOT EXISTS next_inventory_date date;
         """,
     )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        ALTER TABLE stock_quant ADD COLUMN IF NOT EXISTS inventory_date date;
+        """,
+    )
 
 
 def _fill_stock_quant_package_name_if_null(env):

--- a/openupgrade_scripts/scripts/stock/15.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/stock/15.0.1.1/upgrade_analysis_work.txt
@@ -146,6 +146,7 @@ stock        / stock.quant              / in_date (datetime)            : now re
 # DONE: pre-migration: set in_date = create_date if in_date is null
 
 stock        / stock.quant              / inventory_date (date)         : NEW isfunction: function, stored
+# DONE: pre-migration: pre-fill to avoid computing of new feature
 stock        / stock.quant              / user_id (many2one)            : NEW relation: res.users
 # NOTHING TO DO: new feature
 


### PR DESCRIPTION
This computed field is part of the new inventory system. As we made we the location next_inventory_date, we'll leave it empty by default.

cc @Tecnativa TT38303

please review @pedrobaeza @sergio-teruel 