### PR TITLE
[16.0][OU-FIX] base: in order to load translation, we should check if the value is empty

### DIFF
--- a/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
@@ -95,7 +95,10 @@ def update_translatable_fields(cr):
                     bool_or(imd.noupdate) AS noupdate
                 FROM ir_translation it
                 LEFT JOIN ir_model_data imd ON imd.model = %(model)s AND imd.res_id = it.res_id
-                WHERE it.type = 'model' AND it.name = %(name)s AND it.state = 'translated'
+                WHERE it.type = 'model'
+                    AND it.name = %(name)s
+                    AND it.state = 'translated'
+                    AND COALESCE(it.value, '') != ''
                 GROUP BY it.res_id
             )
             UPDATE {table} m


### PR DESCRIPTION
This is a weird case, but if the translation state is "translated" and the value is empty, on 15, we would not use that value

https://github.com/odoo/odoo/blob/15.0/odoo/fields.py#L1602-L1603

with the current change, we are setting the value as an empty string in the database and it might give some issues.