### PR TITLE
[15.0][OU-FIX] account: should not merge website_legal_page module

### DIFF
--- a/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
@@ -45,9 +45,6 @@ def _handle_website_legal_page(env):
     the information added in the page created by 'website_legal_page' has to be
     transferred to the invoice_terms_html field of the company.
     """
-    openupgrade.update_module_names(
-        env.cr, [("website_legal_page", "account")], merge_modules=True
-    )
     for company in env["res.company"].with_context(active_test=False).search([]):
         openupgrade.logged_query(
             env.cr,


### PR DESCRIPTION
Issue raised while migrating database with both account and website_legal_page installed.

website_legal_page is merged into account model with post-migration.py script since PR #3728 

The problem is that merging module in post-migration does not reload the list of modules to be updated, so when you run the command with -u all, it then tries to update website_legal_page which does not exist anymore, leading to CacheMiss exception. (example of error in the first comment on this PR to not overload the description here).

After giving it some thoughts, I do not think merging website_legal_page into account is a good solution, because in many cases legal page from that module are not the same as the one we want to link to from account move. (for instance in France, legal page is mandatory on every website with few information to identify owner, but the terms you will need on account move are related to the sale you performed).
Also, website_legal_page adds a link to legal page in website footer which is then lost with this merging (since account is not doing that).

Still it can make sense to initialize new invoice_terms_html with legal page content as long as the new mode is not forced (already fixed/reverted with PR #4110 )

Therefore, I propose here to not merge website_legal_page into account but keeping the initialization of the company invoice_terms_html field.

One would then need to uninstall website_legal_page manually if it is not needed anymore.