### PR TITLE
[15.0][OU-FIX] account: payment_method_line

### DIFF
--- a/openupgrade_scripts/scripts/account/15.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/pre-migration.py
@@ -284,7 +284,8 @@ def _create_account_payment_method_line(env):
         SELECT apm.name, 10, apm.id, aj.id,
             apm.create_uid, apm.write_uid, apm.create_date, apm.write_date
         FROM account_payment_method apm, account_journal aj
-        WHERE apm.code = 'manual' AND aj.type IN ('bank', 'cash')
+        WHERE apm.code IN ('manual', 'sepa_credit_transfer')
+            AND aj.type IN ('bank', 'cash')
         """,
     )
 


### PR DESCRIPTION
Not all payment_method should generate payment_method_line, but SEPA method from module account_banking_sepa_credit_transfer should generate one.

See comments in https://github.com/OCA/OpenUpgrade/pull/4537