### PR TITLE
[16.0][FIX] payment: is_published state

### DIFF
--- a/openupgrade_scripts/scripts/payment/16.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/payment/16.0.2.0/post-migration.py
@@ -4,6 +4,12 @@
 from openupgradelib import openupgrade
 
 
+def _set_published_state(env):
+    """Set published state according to the provider state as that will keep the former
+    visibility state"""
+    env["payment.provider"].search([("state", "=", "enabled")]).is_published = True
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env.cr, "payment", "16.0.2.0/noupdate_changes.xml")
@@ -17,3 +23,4 @@ def migrate(env, version):
             "payment.payment_acquirer_test",
         ],
     )
+    _set_published_state(env)

--- a/openupgrade_scripts/scripts/payment/16.0.2.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/payment/16.0.2.0/upgrade_analysis_work.txt
@@ -65,7 +65,11 @@ payment      / payment.provider         / code (selection)              : NEW re
 payment      / payment.provider         / allow_express_checkout (boolean): NEW
 payment      / payment.provider         / available_country_ids (many2many): NEW relation: res.country
 payment      / payment.provider         / express_checkout_form_view_id (many2one): NEW relation: ir.ui.view
+# NOTHING TO DO: new features
+
 payment      / payment.provider         / is_published (boolean)        : NEW
+# DONE: Set it on enabled providers to keep the former behavior.
+
 payment      / payment.provider         / maximum_amount (float)        : NEW
 payment      / payment.provider         / token_inline_form_view_id (many2one): NEW relation: ir.ui.view
 # NOTHING TO DO: new features


### PR DESCRIPTION
This new fields should be set on for payment providers which were in state enabled before the migration. Otherwise they're not visible on the portal or the website.

cc @Tecnativa TT50766

please check @victoralmau @pedrobaeza 