### PR TITLE
[15.0][ADD] missed default partial account_reconcile_model

### DIFF
--- a/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
@@ -74,6 +74,7 @@ def _handle_website_legal_page(env):
             )
             view_temp.unlink()
 
+
 def add_default_partial_account_reconcile_model(env):
     openupgrade.logged_query(
         env.cr,

--- a/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
@@ -80,15 +80,16 @@ def add_default_partial_account_reconcile_model(env):
         """
         INSERT INTO account_reconcile_model (name, sequence, rule_type,
             auto_reconcile, match_nature, match_same_currency, allow_payment_tolerance,
-            match_partner, matching_order, company_id)
+            match_partner, matching_order, payment_tolerance_type, company_id)
         SELECT  'Invoices/Bills Partial Match if Underpaid', 2, 'invoice_matching',
-            FALSE, 'both', TRUE, FALSE, TRUE, 'old_first', arm.company_id
+            FALSE, 'both', TRUE, FALSE, TRUE, 'old_first', 'percentage', arm.company_id
         FROM (
             SELECT DISTINCT company_id
             FROM account_reconcile_model
             WHERE rule_type = 'invoice_matching'
         ) AS arm
-        """)
+        """,
+    )
 
 @openupgrade.migrate()
 def migrate(env, version):

--- a/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
@@ -74,12 +74,28 @@ def _handle_website_legal_page(env):
             )
             view_temp.unlink()
 
+def add_default_partial_account_reconcile_model(env):
+    openupgrade.logged_query(
+            env.cr,
+            """
+            INSERT INTO account_reconcile_model (name, sequence, rule_type,
+                auto_reconcile, match_nature, match_same_currency, allow_payment_tolerance,
+                match_partner, company_id)
+            SELECT  'Invoices/Bills Partial Match if Underpaid', 2, 'invoice_matching',
+                FALSE, 'both', TRUE, FALSE, TRUE, arm.company_id
+            FROM (
+                SELECT DISTINCT company_id
+                FROM account_reconcile_model
+                WHERE rule_type = 'invoice_matching'
+            ) AS arm
+            """)
 
 @openupgrade.migrate()
 def migrate(env, version):
     _fill_account_analytic_line_category(env)
     _fill_payment_destination_journal(env)
     set_res_company_account_setup_taxes_state_done(env)
+    add_default_partial_account_reconcile_model(env)
     openupgrade.load_data(env.cr, "account", "15.0.1.2/noupdate_changes.xml")
     openupgrade.delete_record_translations(
         env.cr,

--- a/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
@@ -91,6 +91,7 @@ def add_default_partial_account_reconcile_model(env):
         """,
     )
 
+
 @openupgrade.migrate()
 def migrate(env, version):
     _fill_account_analytic_line_category(env)

--- a/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/post-migration.py
@@ -76,19 +76,19 @@ def _handle_website_legal_page(env):
 
 def add_default_partial_account_reconcile_model(env):
     openupgrade.logged_query(
-            env.cr,
-            """
-            INSERT INTO account_reconcile_model (name, sequence, rule_type,
-                auto_reconcile, match_nature, match_same_currency, allow_payment_tolerance,
-                match_partner, company_id)
-            SELECT  'Invoices/Bills Partial Match if Underpaid', 2, 'invoice_matching',
-                FALSE, 'both', TRUE, FALSE, TRUE, arm.company_id
-            FROM (
-                SELECT DISTINCT company_id
-                FROM account_reconcile_model
-                WHERE rule_type = 'invoice_matching'
-            ) AS arm
-            """)
+        env.cr,
+        """
+        INSERT INTO account_reconcile_model (name, sequence, rule_type,
+            auto_reconcile, match_nature, match_same_currency, allow_payment_tolerance,
+            match_partner, matching_order, company_id)
+        SELECT  'Invoices/Bills Partial Match if Underpaid', 2, 'invoice_matching',
+            FALSE, 'both', TRUE, FALSE, TRUE, 'old_first', arm.company_id
+        FROM (
+            SELECT DISTINCT company_id
+            FROM account_reconcile_model
+            WHERE rule_type = 'invoice_matching'
+        ) AS arm
+        """)
 
 @openupgrade.migrate()
 def migrate(env, version):


### PR DESCRIPTION
By default , must be created 2 reconcile method, in odoo 15.0 was introduced the partial one:

https://github.com/odoo/odoo/blob/ca9db797e37e29030d6f727bd0c0947d09aea203/addons/account/models/chart_template.py#L1063