### PR TITLE
[12.0][ADD]Missed default account_reconciliation_model

### DIFF
--- a/addons/account/migrations/12.0.1.1/noupdate_changes.xml
+++ b/addons/account/migrations/12.0.1.1/noupdate_changes.xml
@@ -110,4 +110,15 @@
   <record id="digest.digest_digest_default" model="digest.digest">
     <field name="kpi_account_total_revenue">True</field>
   </record>
+  <record id="reconciliation_model_default_rule" model="account.reconcile.model">
+    <field name="name">Invoices Matching Rule</field>
+    <field name="sequence">1</field>
+    <field name="rule_type">invoice_matching</field>
+    <field name="auto_reconcile" eval="False"/>
+    <field name="match_nature">both</field>
+    <field name="match_same_currency" eval="True"/>
+    <field name="match_total_amount" eval="True"/>
+    <field name="match_total_amount_param" eval="100"/>
+    <field name="match_partner" eval="True"/>
+  </record>
 </odoo>

--- a/addons/account/migrations/12.0.1.1/noupdate_changes.xml
+++ b/addons/account/migrations/12.0.1.1/noupdate_changes.xml
@@ -110,6 +110,7 @@
   <record id="digest.digest_digest_default" model="digest.digest">
     <field name="kpi_account_total_revenue">True</field>
   </record>
+  <!--manually added -->
   <record id="reconciliation_model_default_rule" model="account.reconcile.model">
     <field name="name">Invoices Matching Rule</field>
     <field name="sequence">1</field>


### PR DESCRIPTION
This is needed for modules like account_accountant, without it , invoices will never get marked as paid, will stod in in_payment