### PR TITLE
[ADD] documentation for OpenUpgrade manager. how to create reference database.

### DIFF
--- a/docsource/100_maintain_repository.rst
+++ b/docsource/100_maintain_repository.rst
@@ -11,6 +11,25 @@ Set up the branch for a new Odoo release
 
 Finally, ``git push`` the branch on your fork, and make a pull request against OCA/$NEW branch.
 
+Create a Reference Database
+---------------------------
+
+To run a test migration, the Github `Test` workflow downloads a preinstalled database of the previous version
+from https://github.com/OCA/OpenUpgrade/releases/tag/databases.
+This database has all Odoo core modules installed with demo data.
+
+* Checkout a clean Odoo up-to-date base code
+* Make sure your addons_path only contains odoo repo, (if it contains OCA / custom repo) the modules will be installed.
+* Odoo version 11.0 may require this patch: https://github.com/odoo/odoo/pull/28620
+* Generate the database
+
+.. literalinclude:: maintainer_scripts/create_reference_database.sh
+  :language: shell
+
+* Upload the database ``.psql`` file present in the ``/tmp/`` folder [here](https://github.com/OCA/OpenUpgrade/releases/tag/databases).
+
+To check if all is ok, you should migrate the ``openupgrade_scripts`` module (first) and then the ``openupgrade_framework`` module, and check if the CI is OK.
+
 Manual changes
 --------------
 
@@ -23,8 +42,6 @@ Manual changes
 * Add a coverage file (e.g. docsource/modules170-180.rst)
 
 * In the ``OpenUpgrade``/``documentation`` branch, add a new line in ``build_openupgrade_docs``.
-
-* Push a test database for the old release to Github (see https://github.com/OCA/OpenUpgrade/wiki/How-to-create-a-reference-database)
 
 * Execute the technical migration of ``openupgrade_framework``.
 

--- a/docsource/maintainer_scripts/create_reference_database.sh
+++ b/docsource/maintainer_scripts/create_reference_database.sh
@@ -1,0 +1,42 @@
+# Note: In that script, we generate a 17.0 database,
+# that will be used by the OpenUpgrade CI of the 18.0 branch.
+
+# Configuration
+export VERSION=17.0
+
+# Install account module first to ensure that the chart of accounts of l10n_generic_coa
+# is installed instead of the chart of accounts of the first localization module that is encountered.
+odoo-bin -d $VERSION -i account --stop-after-init --without-demo=
+
+# Mark all interesting modules as installable
+echo "update ir_module_module set state = 'uninstallable' where name like 'test%' or name like 'hw_%';" | psql $VERSION
+echo "update ir_module_module set state = 'to install', demo=true where state = 'uninstalled';" | psql $VERSION
+
+# Install all modules
+odoo-bin -d $VERSION -i dummy --stop-after-init --without-demo=
+
+# Note: Installation could fail because install modules sometime requires extra python libraries
+# that are not present in the requirements.txt file. For exemple, install ``l10n_eg_edi_eta``
+# requires the installation of the python library ``asn1crypto``.
+# In that case, you have to
+# - install manually the python library in your environment
+# - run again the "set state='to install'" command
+# - run again the "-i dummy" command
+
+# put the attachment in database
+cat <<EOF | odoo-bin shell -d $VERSION
+env['ir.config_parameter'].set_param('ir_attachment.location', 'db')
+env['ir.attachment'].force_storage()
+env.cr.commit()
+EOF
+
+# Install an additional language (optional, e.g. 15.0)
+cat <<EOF | odoo-bin shell -d $VERSION
+lang = env.ref('base.lang_fr')
+lang._activate_lang(lang.code)
+env['ir.module.module'].search([('state', '=', 'installed')])._update_translations(lang.code, True)
+env.cr.commit()
+EOF
+
+# Export database
+sudo su postgres -c "pg_dump -d $VERSION --format=c --file=/tmp/$VERSION.psql"


### PR DESCRIPTION
replace old wiki. see https://github.com/grap/openupgrade_wiki_backup/blob/master/How-to-create-a-reference-database.md

What I did.
- copy paste old wiki page into OpenUpgrade documentation
- split into a ``rst`` part and a ``sh`` part
- add an extra comment to mention that we have to make some retries, if some odoo modules requires extra python lib. see for exemple : asn1crypto remarks.
- I changed shell command, using cat & pipe. it avoid to have to copy paste orm commands.

**blocking point** 
I have a blocking problem regarding force_storage. here is the log of the error, generated by l10n_de module in V17.

```
  File "/home/sylvain/grap_dev/grap-odoo-env-17.0/src/odoo/odoo/addons/base/models/ir_attachment.py", line 81, in force_storage
    ]))._migrate()
  File "/home/sylvain/grap_dev/grap-odoo-env-17.0/src/odoo/odoo/addons/base/models/ir_attachment.py", line 89, in _migrate
    attach.write({'raw': attach.raw, 'mimetype': attach.mimetype})
  File "/home/sylvain/grap_dev/grap-odoo-env-17.0/src/odoo/addons/l10n_de/models/ir_attachment.py", line 31, in write
    self._except_audit_trail()
  File "/home/sylvain/grap_dev/grap-odoo-env-17.0/src/odoo/addons/l10n_de/models/ir_attachment.py", line 27, in _except_audit_trail
    raise UserError(_("You cannot remove parts of the audit trail."))
odoo.exceptions.UserError: You cannot remove parts of the audit trail.

```
-> What is the best way to move forward ? I'd like to avoid to have to write / maintain odoo patches in the database creation process.
-> is this step mandatory ?


@OCA/openupgrade-maintainers : thanks for your help here ! 