### PR TITLE
[15.0][OU-FIX] fix hr.expense account.move and lines

### DIFF
--- a/openupgrade_scripts/scripts/hr_expense/15.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/15.0.2.0/post-migration.py
@@ -14,44 +14,26 @@ def _fill_payment_state(env):
     openupgrade.logged_query(
         env.cr,
         """
-        UPDATE account_move_line
-        SET exclude_from_invoice_tab=(coalesce(quantity, 0) = 0)
-        WHERE expense_id IS NOT NULL
+        UPDATE account_move_line AS aml
+        SET exclude_from_invoice_tab = true
+        FROM account_account AS aa
+        INNER JOIN account_account_type AS aat ON
+            aa.user_type_id = aat.id
+        WHERE
+            aml.account_id = aa.id AND
+            aml.expense_id IS NOT NULL AND
+            aat.type = 'payable'
         """,
     )
-    # Recompute payment_state for the moves associated to the expenses, as on
-    # v14 these ones were not computed being of type `entry`, which changes now
-    # on v15 if the method `_payment_state_matters` returns True, which is the
-    # case for the expense moves
-    for move in env["hr.expense.sheet"].search([]).account_move_id:
-        # Extracted and adapted from _compute_amount() in account.move
-        new_pmt_state = "not_paid" if move.move_type != "entry" else False
-        total_to_pay = total_residual = 0.0
-        for line in move.line_ids:
-            if line.account_id.user_type_id.type in ("receivable", "payable"):
-                total_to_pay += line.balance
-                total_residual += line.amount_residual
-        currencies = move._get_lines_onchange_currency().currency_id
-        currency = currencies if len(currencies) == 1 else move.company_id.currency_id
-        if currency.is_zero(move.amount_residual):
-            reconciled_payments = move._get_reconciled_payments()
-            if not reconciled_payments or all(
-                payment.is_matched for payment in reconciled_payments
-            ):
-                new_pmt_state = "paid"
-            else:
-                new_pmt_state = move._get_invoice_in_payment_state()
-        elif currency.compare_amounts(total_to_pay, total_residual) != 0:
-            new_pmt_state = "partial"
-        openupgrade.logged_query(
-            env.cr,
-            """
-            UPDATE account_move
-            SET payment_state = %s
-            WHERE id = %s
-            """,
-            (new_pmt_state, move.id),
-        )
+    # Recompute several fields (always_tax_exigible, amount_residual,
+    # amount_residual_signed, amount_untaxed, amount_untaxed_signed,
+    # payment_state) for the moves associated to the expenses, as on v14 these
+    # ones were not computed being of type `entry`, which changes now on v15
+    # if the method `_payment_state_matters` returns True, which is the case
+    # for the expense moves
+    env["account.move"].with_context(active_test=False, tracking_disable=True).search(
+        [("line_ids.expense_id", "!=", False)]
+    )._compute_amount()
 
 
 @openupgrade.migrate()

--- a/openupgrade_scripts/scripts/hr_expense/15.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/15.0.2.0/post-migration.py
@@ -25,6 +25,11 @@ def _fill_payment_state(env):
             aat.type = 'payable'
         """,
     )
+    # Disable fiscalyear_lock_date check
+    _check_fiscalyear_lock_date = env[
+        "account.move"
+    ].__class__._check_fiscalyear_lock_date
+    env["account.move"].__class__._check_fiscalyear_lock_date = lambda self: None
     # Recompute several fields (always_tax_exigible, amount_residual,
     # amount_residual_signed, amount_untaxed, amount_untaxed_signed,
     # payment_state) for the moves associated to the expenses, as on v14 these
@@ -34,6 +39,10 @@ def _fill_payment_state(env):
     env["account.move"].with_context(active_test=False, tracking_disable=True).search(
         [("line_ids.expense_id", "!=", False)]
     )._compute_amount()
+    # Enable fiscalyear_lock_date check
+    env["account.move"].__class__._check_fiscalyear_lock_date = (
+        _check_fiscalyear_lock_date
+    )
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
fix the value of several fields on `account.move` and `account.move.line` records linked to `hr.expense` records.

this computes `account.move.line.exclude_from_invoice_tab` differently than #4386 did. the goal remains the same: it should be true for destination lines. the code was assuming that destination lines where the ones with a quantity of 0, but this does not work, as odoo 14 [does not set a quantity on those lines](https://github.com/OCA/OCB/blob/14.0/addons/hr_expense/models/hr_expense.py#L500) and [the default value for this field is 1](https://github.com/OCA/OCB/blob/14.0/addons/account/models/account_move.py#L3318). instead, this field is computed by checking that the account is of type `"payable"`.

with `exclude_from_invoice_tab` correctly set, it is now safe to call `account.move._compute_amount()` to correctly recompute several fields (`always_tax_exigible`, `amount_residual`, `amount_residual_signed`, `amount_untaxed`, `amount_untaxed_signed`, `payment_state`) of the `account.move` without changing accounting data. `account.move.write()` checks that reconciled moves are not changed, and with this code, it succeeds.

this code also recomputes these fields for `account.move` records not directly linked to `hr.expense.sheet` records, but linked to an `hr.expense` record through their `account.move.line` records, since this is how `account.move._payment_state_matters()` selects the records.