### PR TITLE
[16.0][ADD] Apriori: 'stock_picking_backorder_strategy' merged into 'stock'.

### DIFF
--- a/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
@@ -22,7 +22,28 @@ def _handle_multi_location_visibility(env):
                 view.active = False
 
 
+def _handle_stock_picking_backorder_strategy(env):
+    # Handle the merge of OCA/stock-logistics-workflow/stock_picking_backorder_strategy
+    # feature in odoo/stock V16 module.
+    if openupgrade.column_exists(
+        env.cr, "stock_picking_type", openupgrade.get_legacy_name("backorder_strategy")
+    ):
+        openupgrade.map_values(
+            env.cr,
+            openupgrade.get_legacy_name("backorder_strategy"),
+            "create_backorder",
+            [
+                ("manual", "ask"),
+                ("create", "always"),
+                ("no_create", "never"),
+                ("cancel", "never"),
+            ],
+            table="stock_picking_type",
+        )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     _handle_multi_location_visibility(env)
+    _handle_stock_picking_backorder_strategy(env)
     openupgrade.load_data(env.cr, "stock", "16.0.1.1/noupdate_changes.xml")

--- a/openupgrade_scripts/scripts/stock/16.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/stock/16.0.1.1/pre-migration.py
@@ -112,6 +112,21 @@ def _update_stock_quant_package_pack_date(env):
     )
 
 
+def _handle_stock_picking_backorder_strategy(env):
+    # Handle the merge of OCA/stock-logistics-workflow/stock_picking_backorder_strategy
+    # feature in odoo/stock V16 module.
+    if openupgrade.column_exists(env.cr, "stock_picking_type", "backorder_strategy"):
+        # Rename column
+        openupgrade.rename_columns(
+            env.cr,
+            {
+                "stock_picking_type": [
+                    ("backorder_strategy", None),
+                ],
+            },
+        )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_tables(env.cr, _tables_renames)
@@ -122,3 +137,4 @@ def migrate(env, version):
     _update_stock_quant_package_pack_date(env)
     _update_sol_product_category_name(env)
     _compute_stock_location_replenish_location(env)
+    _handle_stock_picking_backorder_strategy(env)

--- a/openupgrade_scripts/scripts/stock/16.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/stock/16.0.1.1/upgrade_analysis_work.txt
@@ -119,7 +119,8 @@ stock        / stock.picking            / move_lines (one2many)         : DEL re
 
 stock        / stock.picking.type       / auto_show_reception_report (boolean): NEW
 stock        / stock.picking.type       / create_backorder (selection)  : NEW required, selection_keys: ['always', 'ask', 'never'], hasdefault: default
-# NOTHING TO DO
+# - If stock_picking_backorder_strategy was installed, data are populated with the field backorder_strategy
+# - Otherwise, NOTHING TO DO
 
 stock        / stock.production.lot     / activity_ids (one2many)       : DEL relation: mail.activity
 stock        / stock.production.lot     / company_id (many2one)         : DEL relation: res.company, required


### PR DESCRIPTION
[MIG] stock:
- Rename stock_picking_type field 'backorder_strategy' -> 'create_backorder';
- Map values : {'manual': 'ask', 'no_create': 'never', 'cancel': never', 'create': 'always'}

supersed : https://github.com/OCA/OpenUpgrade/pull/3818