### PR TITLE
[17.0][OU-ADD] l10n_es_irnr/l10n_es_irnr_sii: Merged into l10n_es/l10n_es_aeat_sii_oca

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -34,6 +34,9 @@ merged_modules = {
     "website_sale_delivery": "website_sale",
     "website_sale_loyalty_delivery": "website_sale_loyalty",
     "website_sale_stock_product_configurator": "website_sale_product_configurator",
+    # OCA/l10n-spain
+    "l10n_es_irnr": "l10n_es",
+    "l10n_es_irnr_sii": "l10n_es_aeat_sii_oca",
     # OCA/purchase-workflow
     "purchase_discount": "purchase",
     # OCA/web


### PR DESCRIPTION
Following OCA/l10n-spain#3783, those in 16 that have already installed these modules, when migrating to 17, don't really need them (not even in 16), so let's provide them a smooth transition.

@Tecnativa 