### PR TITLE
[17.0][OU-ADD] base_maintenance_config: Merged into maintenance

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -40,6 +40,7 @@ merged_modules = {
     "l10n_es_irnr": "l10n_es",
     "l10n_es_irnr_sii": "l10n_es_aeat_sii_oca",
     # OCA/maintenance
+    "base_maintenance_config": "maintenance",
     "maintenance_plan": "maintenance",
     # OCA/purchase-workflow
     "purchase_discount": "purchase",


### PR DESCRIPTION
Merged into `maintenance`

It is pending to remove the corresponding records from `base_maintenance_config` if installed.

Locked by:
- [x] `maintenance`: https://github.com/OCA/OpenUpgrade/pull/4654

@Tecnativa TT51499