### PR TITLE
[17.0][OU-FIX] resource: Reset sequence field in resource.calendar.attendance

### DIFF
--- a/openupgrade_scripts/scripts/resource/17.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/resource/17.0.1.1/pre-migration.py
@@ -1,11 +1,26 @@
 # Copyright 2024 Viindoo Technology Joint Stock Company (Viindoo)
+# Copyright 2024 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
 
 
+def _reset_calendar_attendance_sequence(env):
+    """As the field `sequence` exists previously in 16, and you were able to change it
+    on screen, there's a chance that your DB have some sequence values that alters the
+    previous order when migrating.
+
+    Thus, the safest thing is to reset the sequence value to its default value for
+    preserving always the previous order.
+    """
+    openupgrade.logged_query(
+        env.cr, "UPDATE resource_calendar_attendance SET sequence = 10"
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
+    _reset_calendar_attendance_sequence(env)
     openupgrade.set_xml_ids_noupdate_value(
         env,
         "resource",

--- a/openupgrade_scripts/scripts/resource/17.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/resource/17.0.1.1/upgrade_analysis_work.txt
@@ -4,7 +4,7 @@ resource     / resource.calendar        / hours_per_day (float)         : now a 
 # Nothing To Do, compute non-stored
 
 resource     / resource.calendar.attendance / _order                        : _order is now 'sequence, week_type, dayofweek, hour_from' ('week_type, dayofweek, hour_from')
-# Nothing To Do, default order when search
+# DONE: pre-migration: Reset the sequence field to its default value for preserving the order.
 
 resource     / resource.calendar.attendance / day_period (selection)        : selection_keys is now '['afternoon', 'lunch', 'morning']' ('['afternoon', 'morning']')
 # Nothing To Do, new option: lunch


### PR DESCRIPTION
As the field `sequence` exists previously in 16, and you were able to change it on screen:

![imagen](https://github.com/user-attachments/assets/7201233f-de3e-465c-9bca-df0c866a7270)

there's a chance that your DB have some sequence values that alters the previous order when migrating.

Thus, the safest thing is to reset the sequence value to its default value for preserving always the previous order.

@Tecnativa TT49327