### PR TITLE
[16.0][FIX] base: avoid ignoring right translations

### DIFF
--- a/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
@@ -53,6 +53,18 @@ def login_or_registration_required_at_checkout(cr):
 
 
 def update_translatable_fields(cr):
+    # Fix terms with wrong to_translate state. DBs with long version history could have
+    # terms that didn't have the right state and those would be ignored
+    openupgrade.logged_query(
+        cr,
+        """
+            UPDATE ir_translation set state = 'translated'
+            WHERE type = 'model'
+                AND state = 'to_translate'
+                AND value is NOT NULL
+                AND value IS DISTINCT FROM src
+        """,
+    )
     # exclude fields from translation update
     exclusions = {
         # ir.actions.* inherits the name and help columns from ir.actions.actions


### PR DESCRIPTION
DBs with a long versions history could have right translations with wrong to_translate states. We should try to fix them in advance to avoid missing them.

cc @Tecnativa TT51774

please check @pedrobaeza 