### PR TITLE
[17.0][OU-ADD] explicitly disable loading demo data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,7 @@ jobs:
       - name: DB Restore
         run: |
           wget -q -O- $DOWNLOADS/16.0.psql | pg_restore -d $DB --no-owner
+          psql $DB -c "UPDATE ir_module_module SET demo=False"
       - name: Check out Odoo
         uses: actions/checkout@v2
         with:
@@ -144,4 +145,5 @@ jobs:
               --test-tags openupgrade \
               --log-handler odoo.models.unlink:WARNING \
               --stop-after-init \
+              --without-demo=$MODULES_NEW \
               --update=$MODULES_NEW


### PR DESCRIPTION
this squelches some unhelpful error messages, and conceptually we don't want the new version to overwrite the demo data from the old version to be able to check if the demo data was migrated correctly