### PR TITLE
[16.0][OU-FIX] stock: do not try to compute quantity_done for canceled stock moves

### DIFF
--- a/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
@@ -49,6 +49,7 @@ def _complete_stock_move_quantity_done_with_orm(env):
         """
         SELECT move_id
         FROM stock_move_line
+        WHERE state != 'cancel'
         GROUP BY move_id
         HAVING COUNT(DISTINCT product_uom_id) > 1
             AND SUM(qty_done) <> 0


### PR DESCRIPTION
Otherwise UserError will be raised [1]

[1] https://github.com/odoo/odoo/blob/0043634d87fdde1fa427eda90e444fe76767bacb/addons/stock/models/stock_move.py#L675-L676