### PR TITLE
[OU-FIX] apriori: l10n_it_dichiarazione_intento renamed to

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -69,6 +69,7 @@ renamed_modules = {
     "l10n_it_account_balance_report": "l10n_it_financial_statements_report",
     "l10n_it_causali_pagamento": "l10n_it_payment_reason",
     "l10n_it_codici_carica": "l10n_it_appointment_code",
+    "l10n_it_dichiarazione_intento": "l10n_it_declaration_of_intent",
     "l10n_it_withholding_tax_causali": "l10n_it_withholding_tax_reason",
     # OCA/l10n-france
     "account_bank_statement_import_fr_cfonb": "account_statement_import_fr_cfonb",


### PR DESCRIPTION
l10n_it_declaration_of_intent in 14.0

This fix is needed to properly run these migration scripts:
https://github.com/OCA/l10n-italy/tree/14.0/l10n_it_declaration_of_intent/migrations/13.0.1.0.0