### PR TITLE
[17.0][OU-IMP] event: Finish migration scripts

### DIFF
--- a/openupgrade_scripts/scripts/event/17.0.1.8/post-migration.py
+++ b/openupgrade_scripts/scripts/event/17.0.1.8/post-migration.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2024-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
@@ -11,7 +11,18 @@ _deleted_xml_records = [
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env, "event", "17.0.1.8/noupdate_changes.xml")
+    openupgrade.delete_record_translations(
+        env.cr,
+        "event",
+        [
+            "event_registration_mail_template_badge",
+            "event_reminder",
+            "event_subscription",
+        ],
+    )
     openupgrade.delete_records_safely_by_xml_id(
         env,
         _deleted_xml_records,
     )
+    openupgrade.logged_query(env.cr, "UPDATE event_event_ticket SET sequence = id")
+    openupgrade.logged_query(env.cr, "UPDATE event_type_ticket SET sequence = id")

--- a/openupgrade_scripts/scripts/event/17.0.1.8/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/event/17.0.1.8/upgrade_analysis_work.txt
@@ -4,42 +4,59 @@ event        / event.event              / _order                        : _order
 event        / event.event              / activity_user_id (many2one)   : not related anymore
 event        / event.event              / activity_user_id (many2one)   : now a function
 # NOTHING TO DO
+
 event        / event.event              / auto_confirm (boolean)        : DEL
 # NOTHING TO DO: Attendees are now created confirmed (state=open)
+
 event        / event.event              / badge_format (selection)      : NEW required, selection_keys: ['A4_french_fold', 'A6', 'four_per_sheet'], hasdefault: default
+# NOTHING TO DO: Default value is the same as the previous behavior.
+
 event        / event.event              / badge_image (binary)          : NEW attachment: True
 # NOTHING TO DO
+
 event        / event.event              / lang (selection)              : NEW selection_keys: function
 # NOTHING TO DO: It is not required, it can be empty, we do not set the value of the old records
+
 event        / event.event              / message_main_attachment_id (many2one): DEL relation: ir.attachment
 event        / event.event              / rating_ids (one2many)         : NEW relation: rating.rating
 event        / event.event              / registration_properties_definition (properties_definition): NEW
 # NOTHING TO DO
+
 event        / event.event.ticket       / _order                        : _order is now 'event_id, sequence, name, id' ('id')
 event        / event.event.ticket       / color (char)                  : NEW hasdefault: default
-event        / event.event.ticket       / sequence (integer)            : NEW hasdefault: default
 # NOTHING TO DO
+
+event        / event.event.ticket       / sequence (integer)            : NEW hasdefault: default
+# DONE: post-migration: We define the value as the id to respect the same ordering as before
+
 event        / event.registration       / activity_user_id (many2one)   : not related anymore
 event        / event.registration       / activity_user_id (many2one)   : now a function
 # NOTHING TO DO
+
 event        / event.registration       / barcode (char)                : NEW
 # NOTHING TO DO: There is no correct way to do it in postgres, we let the ORM set the value of the old records
+
 event        / event.registration       / company_name (char)           : NEW hasdefault: compute
-# DONE: Define the value of existing records in pre-migration
+# DONE: pre-migration: Pre-create and fill the column for avoiding the ORM computation
+
 event        / event.registration       / message_main_attachment_id (many2one): DEL relation: ir.attachment
 event        / event.registration       / mobile (char)                 : DEL
 event        / event.registration       / rating_ids (one2many)         : NEW relation: rating.rating
 event        / event.registration       / registration_properties (properties): NEW hasdefault: compute
 # NOTHING TO DO
+
 event        / event.type               / auto_confirm (boolean)        : DEL
 # NOTHING TO DO: Explained in auto_confirm field of event.event
+
 event        / event.type.ticket        / _order                        : _order is now 'sequence, name, id' ('id')
 event        / event.type.ticket        / sequence (integer)            : NEW hasdefault: default
-# NOTHING TO DO
+# DONE: post-migration: We define the value as the id to respect the same ordering as before
+
 ---XML records in module 'event'---
 DEL event.type: event.event_type_data_conference (noupdate)
 DEL event.type: event.event_type_data_ticket (noupdate)
 # DONE: removed in post-migration
+
 NEW ir.actions.client: event.event_barcode_action_main_view
 NEW ir.actions.report: event.action_report_event_event_attendee_list
 NEW ir.actions.report: event.action_report_event_event_badge


### PR DESCRIPTION
Related to https://github.com/OCA/OpenUpgrade/pull/4663

Changes done:
- [x] Remove translations related to mail templates (https://github.com/OCA/OpenUpgrade/pull/4663#discussion_r1900192325)
- [x] Add blank lines between comments for better readability (https://github.com/OCA/OpenUpgrade/pull/4663#discussion_r1900197828)
- [x] Define correct sequence field value (event_event_ticket + event_type_ticket) (https://github.com/OCA/OpenUpgrade/pull/4663#discussion_r1900197612 + https://github.com/OCA/OpenUpgrade/pull/4663#discussion_r1900199055)

Please @pedrobaeza can you review it?

@Tecnativa TT49909