### PR TITLE
[16.0][FIX] stock: handle improper variable declaration

### DIFF
--- a/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
@@ -17,7 +17,7 @@ def _handle_multi_location_visibility(env):
             "stock.stock_location_view_tree2_editable",
             "stock.stock_location_view_form_editable",
         ):
-            view = (env.ref(xml_id, raise_if_not_found=False),)
+            view = env.ref(xml_id, raise_if_not_found=False)
             if view:
                 view.active = False
 


### PR DESCRIPTION
In the current implementation `view` will always be truthy, even when no view is found

With this PR the intended behavior is restored