### PR TITLE
[16.0][FIX] stock: switch groups

### DIFF
--- a/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/stock/16.0.1.1/post-migration.py
@@ -12,7 +12,8 @@ def _handle_multi_location_visibility(env):
     by default with active=True.
     """
     multi_location_group_xml_id = "stock.group_stock_multi_locations"
-    if env.ref("base.group_user") in env.ref(multi_location_group_xml_id).implied_ids:
+    internal_user_id = "base.group_user"
+    if env.ref(multi_location_group_xml_id) in env.ref(internal_user_id).implied_ids:
         for xml_id in (
             "stock.stock_location_view_tree2_editable",
             "stock.stock_location_view_form_editable",


### PR DESCRIPTION
The current implementation is switched: we need to check if the 'Multi Location' group is implied by 'Internal User'.
The field `group_stock_multi_locations` in the settings adds the group to the implied_ids of `base.group_user`

I tested this locally with a migration from 14.0 to 16.0.

We had a problem where users could not create locations. We found that the setting wasn't ported correctly: the flag was set but tthe views were not deactivated

Re-doing the migration with this change fixed the problem.