### PR TITLE
[OU-IMP] mail: fix mail.channel sql constraints group_public_id_check

### DIFF
--- a/openupgrade_scripts/scripts/mail/16.0.1.10/pre-migration.py
+++ b/openupgrade_scripts/scripts/mail/16.0.1.10/pre-migration.py
@@ -229,3 +229,4 @@ def migrate(env, version):
     mail_channel_channel_type_required(env)
     scheduled_date_set_empty_strings_to_null(env)
     mail_channel_private_compatibility(env)
+    mail_channel_unset_wrong_group_public_id(env)


### PR DESCRIPTION
Execute the function that was already written

Solves the following:

`odoo.schema: Table 'mail_channel': unable to add constraint 'mail_channel_group_public_id_check' as CHECK (channel_type = 'channel' OR group_public_id IS NULL) `