### PR TITLE
[17.0][FIX] avoid test failures resulting from not yet migrated localizations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,14 @@ jobs:
           echo Set the modules as not installable if they are not in the following list : $MODULES_OLD
           echo Running $REQUEST
           psql $DB -c "$REQUEST"
+          echo Set chart template to generic for companies with charts from not yet migrated localizations
+          REQUEST="update res_company set chart_template_id=(
+            select res_id from ir_model_data where module='l10n_generic_coa' and name='configurable_chart_template'
+          ) where id in (
+            select res_id from ir_model_data where model='res.company' and module not in
+            ('$(echo $MODULES_OLD | sed -e "s/,/','/g")')
+          )"
+          psql $DB -c "$REQUEST"
           ADDONS_PATHS="\
               $GITHUB_WORKSPACE/odoo/addons \
               $GITHUB_WORKSPACE/odoo/odoo/addons \


### PR DESCRIPTION
since https://github.com/OCA/OCB/commit/562aca595a6502764e74530a2b8ba70200332a02, the translations of localizations of [the](https://github.com/OCA/OCB/blob/16.0/addons/l10n_ae/demo/demo_company.xml) [companies](https://github.com/OCA/OCB/blob/16.0/addons/l10n_br/demo/demo_company.xml) created by the v16 demo data are actually loaded in account's [register_hook](https://github.com/OCA/OCB/blob/17.0/addons/account/models/ir_module.py#L89), which fails eventually if a localization hasn't been migrated yet.

I don't think we should deactivate the translation loading altogether, because that's a nice sanity check for localizations when we have them.

I also don't think we should modify the account migration script, as our current problem is an artifact of not having localizations migrated yet, which will go away once that's the case. So handling this in the test script seems the way to go to me.