### PR TITLE
[15.0][OU-FIX] web: fix report_footer migration

### DIFF
--- a/openupgrade_scripts/scripts/web/15.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/web/15.0.1.0/post-migration.py
@@ -21,7 +21,6 @@ def migrate(env, version):
     vs v15 https://github.com/odoo/odoo/blob/3a28e5b0adbb36bdb1155a6854cdfbe4e7f9b187/addons/web/views/report_templates.xml#L319
     """  # noqa: B950
     for company in env["res.company"].search([]):
-        wizard = env["base.document.layout"].with_company(company).create({})
         # We define what the footer should have as it had v14
         # https://github.com/odoo/odoo/blob/cc0060e889603eb2e47fa44a8a22a70d7d784185/addons/web/views/report_templates.xml#L362  # noqa: B950
         report_footer = '<ul class="list-inline">'
@@ -34,13 +33,16 @@ def migrate(env, version):
         if company.vat:
             vat_label = company.country_id.vat_label or "Tax ID"
             report_footer += f'<li class="list-inline-item"><i class="fa fa-building-o" role="img"/>{vat_label}: <span>{company.vat}</span></li>'  # noqa: B950
-        report_footer = "</ul>"
+        report_footer += "</ul>"
         # Add the extra text (if any) with a separating line
         if company.report_footer:
             report_footer += "<hr>" + company.report_footer
+        company_details = (
+            env["base.document.layout"].with_company(company)._default_company_details()
+        )
         company.write(
             {
                 "report_footer": report_footer,
-                "company_details": wizard.company_details,
+                "company_details": company_details,
             }
         )


### PR DESCRIPTION
There were two issues with the previous migration scripts

1. A missing += meant half the script was overwritten
2. Creating a `base.document.layout` model meant the default report footer was immediately applied to the company, so the result for companies without a pre-existing footer would effectively be duplicated information