### PR TITLE
[17.0][OU-FIX] sale: Order state + locked

### DIFF
--- a/openupgrade_scripts/scripts/sale/17.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/sale/17.0.1.2/post-migration.py
@@ -1,24 +1,20 @@
 # Copyright 2024 Viindoo Technology Joint Stock Company (Viindoo)
+# Copyright 2024 Holger Brunn
+# Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openupgradelib import openupgrade
 
 
 def _sale_order_populate_locked_field(env):
-    """
-    Set state of sale orders in state 'done' to 'sale'
-    Lock them if the the group sale.group_auto_done_setting
-    is inherited by the user group
-    """
-    auto_done_group = env.ref("sale.group_auto_done_setting")
+    """Set state of sale orders in state 'done' to 'sale' and lock them."""
     openupgrade.logged_query(
         env.cr,
         """
         UPDATE sale_order
-        SET locked = locked or create_uid = ANY (%s), state = 'sale'
+        SET locked = True, state = 'sale'
         WHERE state = 'done'
         """,
-        (auto_done_group.users.ids,),
     )
 
 

--- a/openupgrade_scripts/scripts/sale/17.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/sale/17.0.1.2/pre-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.copy_columns(env.cr, {"sale_order": [("state", None, None)]})

--- a/openupgrade_scripts/scripts/sale/17.0.1.2/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/sale/17.0.1.2/upgrade_analysis_work.txt
@@ -18,7 +18,7 @@ sale         / res.company              / sale_quotation_onboarding_state (selec
 # NOTHING TO DO
 
 sale         / sale.order               / locked (boolean)              : NEW hasdefault: default
-# DONE post-migration: set locked if SO was created by a user in the auto done group
+# DONE post-migration: set locked if state was done
 
 sale         / sale.order               / activity_user_id (many2one)   : not related anymore
 sale         / sale.order               / activity_user_id (many2one)   : now a function
@@ -29,8 +29,11 @@ sale         / sale.order               / journal_id (many2one)         : NEW re
 sale         / sale.order               / message_main_attachment_id (many2one): DEL relation: ir.attachment
 sale         / sale.order               / prepayment_percent (float)    : NEW hasdefault: compute
 sale         / sale.order               / rating_ids (one2many)         : NEW relation: rating.rating
+# NOTHING TO DO
+
 sale         / sale.order               / state (selection)             : selection_keys is now '['cancel', 'draft', 'sale', 'sent']' ('['cancel', 'done', 'draft', 'sale', 'sent']')
-# DONE post-migration: map state 'done' to 'sale', lock as described above
+# DONE: pre-migration: copy 'state' field for preserving old values
+# DONE: post-migration: map state 'done' to 'sale', lock as described above
 
 sale         / sale.order.line          / price_reduce (float)          : DEL
 # NOTHING TO DO

--- a/openupgrade_scripts/scripts/sale/tests/test_sale_migration.py
+++ b/openupgrade_scripts/scripts/sale/tests/test_sale_migration.py
@@ -7,4 +7,4 @@ from odoo.addons.openupgrade_framework import openupgrade_test
 class TestSaleMigration(TransactionCase):
     def test_sale_order_state(self):
         self.assertEqual(self.env.ref("sale.sale_order_18").state, "sale")
-        self.assertFalse(self.env.ref("sale.sale_order_18").locked)
+        self.assertTrue(self.env.ref("sale.sale_order_18").locked)


### PR DESCRIPTION
- Preserve a copy of the column `state` for any future need, as we modify its values.
- We should only set as locked orders in "done" state. The locking group doesn't matter.

@Tecnativa TT49328