### PR TITLE
[16.0][OU-FIX] delivery: ZIP prefixes compatible pattern

### DIFF
--- a/openupgrade_scripts/scripts/delivery/16.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/delivery/16.0.1.0/post-migration.py
@@ -139,9 +139,10 @@ def numerical_range_to_prefixes(min_, max_):
             else:
                 any_digit_count += 1
         if any_digit_count:
-            pattern += r"\d"
+            pattern += "[0-9]"
         if any_digit_count > 1:
             pattern += f"{{{any_digit_count}}}"
+        pattern += "$"
         subpatterns.append(pattern)
         start = stop + 1
     return subpatterns


### PR DESCRIPTION
- `\d` special character that means "any digit" is  not compatible when being serialized in PG, so we need the alternative way of expressing this: `[0-9]`.
- Not putting ending character `$`, the prefix can match any ZIP with the explicit prefix, but containing something more, which is not something wanted, so we restrict it putting the character at the end.

Examples of conversions:

- From 94500 to 94599: ['9450[0-9]$', '945[1-9][0-9]$']
- From 66000 to 62999: ['6[6-2][0-9]{3}$']
- From 94150 to 94250: ['9415[0-9]$', '941[6-9][0-9]$', '942[0-4][0-9]$', '94250$']
- From 84300 to 84300: ['84300$']

@Tecnativa