### PR TITLE
[14.0][OU-ADD] account_bank_statement_import_qonto: Renamed to account_statement_import_qonto

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -28,6 +28,7 @@ renamed_modules = {
     "account_bank_statement_import_online_transferwise": "account_statement_import_online_transferwise",  # noqa: B950
     "account_bank_statement_import_paypal": "account_statement_import_paypal",
     "account_bank_statement_import_qif": "account_statement_import_qif",
+    "account_bank_statement_import_qonto": "account_statement_import_qonto",
     "account_bank_statement_import_split": "account_statement_import_split",
     "account_bank_statement_import_save_file": "account_statement_import_save_file",
     "account_bank_statement_import_transfer_move": "account_statement_import_transfer_move",  # noqa: B950


### PR DESCRIPTION
The migration was direct to 16.0, but the renaming has happened here in 14. If anytime someone decides to backport the module, it should be renamed in this version, not later.

@Tecnativa