### PR TITLE
[17.0][OU-ADD] exclude analytic 1.2 migration

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/modules/migration.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/migration.py
@@ -20,5 +20,16 @@ def migrate_module(self, pkg, stage):
         pkg.state = "to install"
 
 
+def _get_files(self):
+    """Turns out Odoo SA sometimes add migration scripts that interfere with
+    OpenUpgrade. Those we filter out here"""
+    MigrationManager._get_files._original_method(self)
+    to_exclude = [("analytic", "1.2")]
+    for addon, version in to_exclude:
+        self.migrations.get(addon, {}).get("module", {}).pop(version, None)
+
+
 migrate_module._original_method = MigrationManager.migrate_module
 MigrationManager.migrate_module = migrate_module
+_get_files._original_method = MigrationManager._get_files
+MigrationManager._get_files = _get_files


### PR DESCRIPTION
[this](https://github.com/odoo/odoo/blob/17.0/addons/analytic/migrations/1.2/pre-migrate.py) migration script will fail in an openupgrade context because at the point it is run, the column to be indexed doesn't exist yet.

Openupgrade creates the column and the correct index at a later point in the post migration script.