### PR TITLE
[17.0][FIX] account: copy imd entry without ir.model.data's random name mechanism

### DIFF
--- a/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
@@ -3,6 +3,8 @@
 
 from openupgradelib import openupgrade
 
+from odoo import models
+
 from odoo.addons.base.models.ir_property import TYPE2FIELD as ir_property_TYPE2FIELD
 
 _deleted_xml_records = [
@@ -418,8 +420,13 @@ def _account_tax_group_migration(env):
             )
 
             if tax_group_name:
-                new_imd = imd.copy({"res_id": new_tax_group.id})
-                new_imd.write({"name": f"{company_id}_{tax_group_name}"})
+                models.BaseModel.copy(
+                    imd,
+                    {
+                        "res_id": new_tax_group.id,
+                        "name": f"{company_id}_{tax_group_name}",
+                    },
+                )
 
             openupgrade.logged_query(
                 env.cr,


### PR DESCRIPTION
this avoids the [override](https://github.com/OCA/OCB/blob/17.0/odoo/addons/base/models/ir_model.py#L2231) that causes tests to fail randomly in docker container, probably some entropy issue