### PR TITLE
[16.0][OU-ADD] web_chatter_position: Ensure correct values for 'chatter_position'

### DIFF
--- a/openupgrade_scripts/scripts/web_chatter_position/16.0.1.0.0/post-migrate.py
+++ b/openupgrade_scripts/scripts/web_chatter_position/16.0.1.0.0/post-migrate.py
@@ -1,0 +1,20 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    # Field 'chatter_position' was defined in module 'web_responsive' before it was
+    # moved to 'web_chatter_position'. In 'web_responsive' the allowed values have
+    # been ['normal', 'sided'].
+    # In case users installed 'web_chatter_position' along with 'web_responsive' field
+    # 'chatter_position' potentially was already in the db with old values, which are
+    # not supported.
+    # This migration covers this scenario by correcting unsupported values.
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE res_users
+        SET chatter_position = 'auto'
+        WHERE chatter_position not in ('auto', 'bottom', 'sided')
+        """,
+    )


### PR DESCRIPTION
Field 'chatter_position' was defined in module 'web_responsive' before it was moved to 'web_chatter_position'. 
In 'web_responsive' the allowed values have been ['normal', 'sided'] while the allowed values in 'web_chatter_position' are ['auto', 'bottom', 'sided']

In case users installed 'web_chatter_position' along with 'web_responsive', field 'chatter_position' potentially was already in the db with old values, which are not supported.

This migration covers this scenario by correcting unsupported values.

@pedrobaeza  Kindly asking for a review