### PR TITLE
[17.0][OU-FIX] hr_recruitment: Ensure order is preserved

### DIFF
--- a/openupgrade_scripts/scripts/hr_recruitment/17.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_recruitment/17.0.1.1/pre-migration.py
@@ -1,4 +1,5 @@
 # Copyright 2025 Le Filament (https://le-filament.com)
+# Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from openupgradelib import openupgrade
 
@@ -6,17 +7,9 @@ from openupgradelib import openupgrade
 def _fill_sequence_hr_applicant_refuse_reason(cr):
     openupgrade.logged_query(
         cr,
-        """
-        ALTER TABLE hr_applicant_refuse_reason
-            ADD COLUMN IF NOT EXISTS sequence INTEGER DEFAULT 10;
-        """,
+        "ALTER TABLE hr_applicant_refuse_reason ADD COLUMN IF NOT EXISTS sequence int4",
     )
-    openupgrade.logged_query(
-        cr,
-        """
-        ALTER TABLE hr_applicant_refuse_reason ALTER COLUMN sequence DROP DEFAULT;
-        """,
-    )
+    openupgrade.logged_query(cr, "UPDATE hr_applicant_refuse_reason SET sequence=id")
 
 
 @openupgrade.migrate(use_env=False)

--- a/openupgrade_scripts/scripts/hr_recruitment/17.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/hr_recruitment/17.0.1.1/upgrade_analysis_work.txt
@@ -20,10 +20,8 @@ hr_recruitment / hr.applicant             / rating_ids (one2many)         : NEW 
 # NOTHING TO DO: new fields
 
 hr_recruitment / hr.applicant.refuse.reason / _order                        : _order is now 'sequence' ('id')
-# NOTHING TO DO: new field sequence used to order
-
 hr_recruitment / hr.applicant.refuse.reason / sequence (integer)            : NEW hasdefault: default
-# DONE: pre-migration: pre-create column with default value
+# DONE: pre-migration: pre-create column and assign id as sequence for preserving previous order
 
 hr_recruitment / hr.job                   / applicant_properties_definition (properties_definition): NEW
 # NOTHING TO DO: new properties field


### PR DESCRIPTION
Complement of #4703 

The only way to do it is to set the sequence with the old order criteria: the id.

@Tecnativa TT50074