### PR TITLE
[15.0][OU-FIX] mail: channel_all_employees doesn't need to be modified

### DIFF
--- a/openupgrade_scripts/scripts/mail/15.0.1.5/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/mail/15.0.1.5/noupdate_changes.xml
@@ -9,22 +9,32 @@
   <!--<record id="base.partner_root" model="res.partner">
     <field name="email"/>
   </record>-->
+  <!--
   <record id="channel_all_employees" model="mail.channel">
     <field name="group_ids" eval="[Command.link(ref('base.group_user'))]"/>
   </record>
+  -->
+  <!--
   <record id="ir_rule_mail_notifications_group_user" model="ir.rule">
     <field name="groups" eval="[Command.link(ref('base.group_user')), Command.link(ref('base.group_portal'))]"/>
   </record>
+  -->
   <record id="mail_activity_data_call" model="mail.activity.type">
     <field name="category">phonecall</field>
   </record>
+  <!--
   <record id="mail_activity_rule_user" model="ir.rule">
     <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
   </record>
+  -->
+  <!--
   <record id="mail_channel_rule" model="ir.rule">
     <field name="groups" eval="[Command.link(ref('base.group_user')), Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
   </record>
+  -->
+  <!--
   <record id="mail_message_subtype_rule_public" model="ir.rule">
     <field name="groups" eval="[Command.link(ref('base.group_portal')), Command.link(ref('base.group_public'))]"/>
   </record>
+  -->
 </odoo>


### PR DESCRIPTION
We don't need to change this as the change between 14 and 15 is the same (they changed the nomenclature but it is technically the same).

https://github.com/odoo/odoo/blob/14.0/addons/mail/data/mail_channel_data.xml#L29-L31
https://github.com/odoo/odoo/blob/15.0/addons/mail/data/mail_channel_data.xml#L28-L30