### PR TITLE
[17.0][OU-ADD] l10n_es_dua: Merged into l10n_es

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -42,6 +42,7 @@ merged_modules = {
     # OCA/hr-attendance
     "hr_attendance_geolocation": "hr_attendance",
     # OCA/l10n-spain
+    "l10n_es_dua": "l10n_es",
     "l10n_es_irnr": "l10n_es",
     "l10n_es_irnr_sii": "l10n_es_aeat_sii_oca",
     # OCA/maintenance


### PR DESCRIPTION
- FP lines are already XML-ID cleaned by current code.
- The FP has the same XML-ID name.
- Rename XML-IDs of the DUA products.
- Archive DUA compensation product (not needed anymore).
- Rename XML-IDs of the tax groups and taxes.

@Tecnativa TT49875