### PR TITLE
[17.0][OU-FIX] account_edi_ubl_cii: Handle EDI formats

### DIFF
--- a/openupgrade_scripts/scripts/account_edi_ubl_cii/17.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/account_edi_ubl_cii/17.0.1.0/post-migration.py
@@ -1,0 +1,20 @@
+# Copyright 2025 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    xmlids = [
+        "edi_efff_1",
+        "edi_facturx_1_0_05",
+        "edi_nlcius_1",
+        "edi_ubl_2_1",
+        "ubl_a_nz",
+        "ubl_bis3",
+        "ubl_de",
+        "ubl_sg",
+    ]
+    openupgrade.delete_records_safely_by_xml_id(
+        env, [f"account_edi_ubl_cii.{x}" for x in xmlids]
+    )

--- a/openupgrade_scripts/scripts/account_edi_ubl_cii/17.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account_edi_ubl_cii/17.0.1.0/upgrade_analysis_work.txt
@@ -19,6 +19,8 @@ DEL account.edi.format: account_edi_ubl_cii.ubl_a_nz
 DEL account.edi.format: account_edi_ubl_cii.ubl_bis3
 DEL account.edi.format: account_edi_ubl_cii.ubl_de
 DEL account.edi.format: account_edi_ubl_cii.ubl_sg
+# DONE: post-migration: Try to delete them cleanly (and if not, marked as noupdate=1 for not being removed)
+
 NEW ir.ui.view: account_edi_ubl_cii.account_move_send_form
 NEW ir.ui.view: account_edi_ubl_cii.res_config_settings_view_form
 NEW ir.ui.view: account_edi_ubl_cii.res_partner_view_search


### PR DESCRIPTION
These data are noupdate=0, so they are tried to be removed by the standard ORM update. If they have been put in any invoice (which is very likely), on the regular update, they will saying

```
ERROR: update or delete on table "account_edi_format" violates foreign key constraint "account_edi_document_edi_format_id_fkey" on table "account_edi_document"
DETAIL:  Key (id)=(NNN) is still referenced from table "account_edi_document".
```

For avoiding this, we delete them safely with the openupgradelib method.

@Tecnativa