### PR TITLE
[17.0] [OU-FIX] account: Rename account.tax.group XML-IDs always + noupdate + module name

### DIFF
--- a/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
@@ -389,7 +389,6 @@ def _account_tax_group_migration(env):
         SELECT tax_group_id, array_agg(DISTINCT(company_id))
             FROM account_tax
         GROUP BY tax_group_id
-        HAVING COUNT(DISTINCT company_id) > 1
         """
     )
 
@@ -403,8 +402,13 @@ def _account_tax_group_migration(env):
             limit=1,
         )
         tax_group_name = imd.name
-        imd.write({"name": f"{first_company_id}_{imd.name}"})
-
+        imd.write(
+            {
+                "name": f"{first_company_id}_{imd.name}",
+                "noupdate": True,
+                "module": "account",
+            }
+        )
         for company_id in company_ids:
             if company_id == first_company_id:
                 continue


### PR DESCRIPTION
This contains 3 patches:

- Rename account.tax.group XML-IDs even if only 1 company:

  Current code is discarding the renaming of the account.tax.group XML-IDs if there is only company using them, which is not correct, and leads to incorrect references.

  Removing the HAVING clause is enough for triggering the renaming without touching the rest of the code.

- Force noupdate=1 on account.tax.group XML-ID entries:

  Previous generic account.tax.group XML-ID may be noupdate=0, but company-wide should be forcely noupdate=1, so we write that forced value.

- Force module account:

  The company-wide created account.tax.group have XML-ID with module "account", no matter the source module that is injecting such group, so we have to switch the module of all the ir.model.data entries.

@Tecnativa 