### PR TITLE
[15.0][OU][FIX] point_of_sale: empty journal in bank payment method

### DIFF
--- a/openupgrade_scripts/scripts/point_of_sale/15.0.1.0.1/post-migration.py
+++ b/openupgrade_scripts/scripts/point_of_sale/15.0.1.0.1/post-migration.py
@@ -1,0 +1,31 @@
+# Copyright 2025 Tecnativa
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def _update_pos_payment_method_journal(env):
+    """From now on, a journal is required when the transactions aren't splitted. If we
+    don't set a journal in these cases, the session closing won't be made properly for
+    these methods. Cash payment methos already had a jornal set, but bank ones didn't."""
+    payment_methods = env["pos.payment.method"].search(
+        [
+            ("journal_id", "=", False),
+            ("split_transactions", "=", False),
+            ("type", "=", "bank"),
+        ]
+    )
+    for method in payment_methods:
+        method.journal_id = env["account.journal"].create(
+            {
+                "type": "bank",
+                "name": f"[openupgrade] Journal for {method.name}",
+                "code": "POS_BANK",
+                "company_id": method.company_id.id,
+                "sequence": 99,
+            }
+        )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _update_pos_payment_method_journal(env)


### PR DESCRIPTION
From now on, a journal is required for payment methods when transactions aren't splitted. If we don't set a journal in these case, the session closing won't be made properly for these methods.

cc @Tecnativa @pedrobaeza  TT54971

