### PR TITLE
[17.0][OU] mass_mailing_custom_unsubscribe_event merge into mass_mailing

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -57,6 +57,7 @@ merged_modules = {
     "purchase_discount": "purchase",
     # OCA/social
     "mail_activity_plan": "mail",
+    "mass_mailing_custom_unsubscribe_event": "mass_mailing",
     # OCA/stock-logistics-warehouse
     "stock_lot_filter_available": "stock",
     # OCA/web


### PR DESCRIPTION
From this version, Odoo has it's own complete unsubscription system which is compatible with any sending model.

With this proposal OCA/social#1623 mass_mailing_custom_unsubscribe also would converge into the mainstream workflow.

cc @Tecnativa TT49918