### PR TITLE
[18.0][OU-ADD] product_supplierinfo_for_customer: Renamed to product_customerinfo

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -7,6 +7,10 @@ renamed_modules = {
     "account_accountant": "accountant",
     # odoo
     # odoo/enterprise
+    # OCA/product-attribute
+    "product_supplierinfo_for_customer": "product_customerinfo",
+    # OCA/sale-workflow
+    "product_supplierinfo_for_customer_sale": "product_customerinfo_sale",
     # OCA/...
 }
 


### PR DESCRIPTION
Related to: https://github.com/OCA/product-attribute/pull/1880

product_supplierinfo_for_customer_sale renamed to product_customerinfo_sale
Related to: https://github.com/OCA/sale-workflow/pull/3591

@Tecnativa @pedrobaeza @MiquelRForgeFlow  could you please review this?

TT54235
