### PR TITLE
[17.0][OU-FIX] openupgrade_framework: Exclude l10n_es [$5.4]

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/modules/migration.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/migration.py
@@ -24,7 +24,7 @@ def _get_files(self):
     """Turns out Odoo SA sometimes add migration scripts that interfere with
     OpenUpgrade. Those we filter out here"""
     MigrationManager._get_files._original_method(self)
-    to_exclude = [("analytic", "1.2")]
+    to_exclude = [("analytic", "1.2"), ("l10n_es", "5.4")]
     for addon, version in to_exclude:
         self.migrations.get(addon, {}).get("module", {}).pop(version, None)
 


### PR DESCRIPTION
The Odoo script for updating the tax is not thought for being run in OpenUpgrade pipeline, causing crashes like this:

```
2025-04-03 18:25:54,965 1 INFO prod odoo.modules.migration: module l10n_es: Running migration [$5.4] end-migrate
2025-04-03 18:25:58,390 1 ERROR prod odoo.sql_db: bad query: UPDATE "account_fiscal_position_account" SET "account_dest_id" = 482, "account_src_id" = 1469, "write_date" = '2025-04-03 18:24:17.769469', "write_uid" = 1 WHERE id IN (2)
ERROR: duplicate key value violates unique constraint "account_fiscal_position_account_account_src_dest_uniq"
DETAIL:  Key (position_id, account_src_id, account_dest_id)=(3, 1469, 482) already exists.
```

As we are running account_chart_update after the migration for a proper CoA update, let's skip this script.

@Tecnativa 