### PR TITLE
[15.0][OU-FIX] point_of_sale: No journal code duplication

### DIFF
--- a/openupgrade_scripts/scripts/point_of_sale/15.0.1.0.1/post-migration.py
+++ b/openupgrade_scripts/scripts/point_of_sale/15.0.1.0.1/post-migration.py
@@ -14,12 +14,12 @@ def _update_pos_payment_method_journal(env):
             ("type", "=", "bank"),
         ]
     )
-    for method in payment_methods:
+    for i, method in enumerate(payment_methods):
         method.journal_id = env["account.journal"].create(
             {
                 "type": "bank",
                 "name": f"[openupgrade] Journal for {method.name}",
-                "code": "POS_BANK",
+                "code": "POS%s" % i,
                 "company_id": method.company_id.id,
                 "sequence": 99,
             }


### PR DESCRIPTION
If there's more than one payment method without journal, there was a crash due to journal code duplication. This commit fixes that giving a unique journal code.

@Tecnativa 