### PR TITLE
[17.0][OU-FIX] analytic: Fine-tune "Projects" plan finding

### DIFF
--- a/openupgrade_scripts/scripts/analytic/17.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/analytic/17.0.1.2/pre-migration.py
@@ -12,7 +12,9 @@ def _fill_config_parameter_analytic_project_plan(env):
     If not, we check if there's already an existing ir.model.data entry for projects
     according standard data (also pre-filled externally).
 
-    Finally, if not found, we get the first existing plan.
+    Finally, if not found, we will put the next available ID, as regular ORM update
+    process will load the record "analytic.analytic_plan_projects", and creates the
+    record that belongs to the "Projects" plan.
     """
     if env["ir.config_parameter"].get_param("analytic.project_plan", False):
         return
@@ -21,7 +23,7 @@ def _fill_config_parameter_analytic_project_plan(env):
     )
     plan_id = imd.res_id
     if not plan_id:
-        env.cr.execute("SELECT min(id) FROM account_analytic_plan")
+        env.cr.execute("SELECT last_value + 1 FROM account_analytic_plan_id_seq;")
         plan_id = env.cr.fetchone()[0]
     env["ir.config_parameter"].set_param("analytic.project_plan", str(plan_id))
 


### PR DESCRIPTION
Instead of selecting the first available plan, that can lead to an error if there's none, if we are on that part of the flow, we are sure the plan will be created through XML data, so we set the next available ID.

From the comment https://github.com/OCA/OpenUpgrade/pull/4920#discussion_r2032931116

@Tecnativa