### PR TITLE
[15.0][FIX] account: remove conflicting `am.move_type = 'entry'` condition in `tax_tag_invert` update logic

### DIFF
--- a/openupgrade_scripts/scripts/account/15.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/15.0.1.2/pre-migration.py
@@ -185,7 +185,7 @@ def _fast_fill_account_move_line_tax_tag_invert(env):
                 ON aml.id = tax_rel.account_move_line_id
             LEFT JOIN account_account_tag_account_move_line_rel tag_rel
                 ON aml.id = tag_rel.account_move_line_id
-            WHERE am.move_type = 'entry' AND aml.tax_repartition_line_id IS NULL
+            WHERE am.move_type != 'entry' AND aml.tax_repartition_line_id IS NULL
                 AND tax_rel.account_move_line_id IS NULL
         ) sub
         WHERE sub.id = aml.id""",


### PR DESCRIPTION
Removed the am.move_type = 'entry' condition from the subquery, as it conflicts with the am.move_type IN ('out_invoice', 'in_refund', 'out_receipt') condition used in the CASE WHEN clause. Since entry is not part of that set, the condition always evaluates to FALSE, rendering the tax_tag_invert update ineffective.

This fix ensures that only the relevant move types are considered and the update logic functions as intended.
