### PR TITLE
[14.0][OU-FIX] fix posting bank statements

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/post-migration.py
@@ -335,7 +335,15 @@ def post_statements(env):
         """,
     )
     stmt_ids = list({x[0] for x in env.cr.fetchall()})
-    env["account.bank.statement"].browse(stmt_ids).button_post()
+    # calling .button_post() on all statements together fails with:
+    # File "/odoo_env/src/odoo/addons/account/models/account_move.py", line 1842, in _check_unique_sequence_number  # noqa: B950
+    #     raise ValidationError(_('Posted journal entry must have an unique sequence number per company.\n'  # noqa: B950
+    # odoo.exceptions.ValidationError: Posted journal entry must have an unique sequence number per company.  # noqa: B950
+    # Problematic numbers: 198/100, 198/100, 198/104, 198/104, 198/101, 198/101, 198/102, 198/103, 198/103, 198/102  # noqa: B950
+    # instead, call it one by one.
+    stmts = env["account.bank.statement"].browse(stmt_ids)
+    for stmt in stmts:
+        stmt.button_post()
 
 
 def pass_bank_statement_line_note_to_journal_entry_narration(env):


### PR DESCRIPTION
fix posting bank statements during account post-migration: call `.button_post()` on each statement one by one instead of on all statements to avoid an error.