### PR TITLE
[17.0][FIX] restaurant.printer should be in pos_restaurant script

### DIFF
--- a/openupgrade_scripts/scripts/point_of_sale/17.0.1.0.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/point_of_sale/17.0.1.0.1/pre-migration.py
@@ -1,14 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from openupgradelib import openupgrade
 
-_models_renames = [
-    ("restaurant.printer", "pos.printer"),
-]
-
-_tables_renames = [
-    ("restaurant_printer", "pos_printer"),
-]
-
 _field_renames = [
     ("pos.order.line", "pos_order_line", "mp_skip", "skip_change"),
 ]
@@ -68,8 +60,6 @@ def fill_pos_payment_method_sequence(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.rename_models(env.cr, _models_renames)
-    openupgrade.rename_tables(env.cr, _tables_renames)
     openupgrade.rename_fields(env, _field_renames)
     precreate_pos_config_auto_validate_terminal_payment(env)
     fill_pos_order_config_id(env)

--- a/openupgrade_scripts/scripts/pos_restaurant/17.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/pos_restaurant/17.0.1.0/pre-migration.py
@@ -1,0 +1,16 @@
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+_models_renames = [
+    ("restaurant.printer", "pos.printer"),
+]
+
+_tables_renames = [
+    ("restaurant_printer", "pos_printer"),
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.rename_models(env.cr, _models_renames)
+    openupgrade.rename_tables(env.cr, _tables_renames)


### PR DESCRIPTION
As restaurant.printer model is in pos_restaurant, the rename models/tables should be in right script