### PR TITLE
[15.0] [IMP] Update pre-commit packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,23 +28,23 @@ repos:
         language: fail
         files: "\\.rej$"
   - repo: https://github.com/oca/maintainer-tools
-    rev: 7d8a9f9ad73db0976fb03cbee43d953bc29b89e9
+    rev: 7a4cec2599267d03bcea6f7502c3abee8f42259f
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
       - id: oca-fix-manifest-website
         args: ["https://github.com/OCA/OpenUpgrade"]
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.3.1
     hooks:
       - id: autoflake
         args: ["-i", "--ignore-init-module-imports"]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 25.1.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.6.2
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         name: prettier (with plugin-xml)
@@ -55,7 +55,7 @@ repos:
           - --plugin=@prettier/plugin-xml
         files: \.(css|htm|html|js|json|jsx|less|md|scss|toml|ts|xml|yaml|yml)$
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.15.0
+    rev: v9.25.1
     hooks:
       - id: eslint
         verbose: true
@@ -85,7 +85,7 @@ repos:
       - id: mixed-line-ending
         args: ["--fix=lf"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v3.19.1
     hooks:
       - id: pyupgrade
         args: ["--keep-percent-format"]
@@ -98,11 +98,11 @@ repos:
           - --settings=.
         exclude: /__init__\.py$
   - repo: https://github.com/acsone/setuptools-odoo
-    rev: 3.1.0
+    rev: "3.3"
     hooks:
       - id: setuptools-odoo-make-default
   - repo: https://github.com/PyCQA/flake8
-    rev: 3.9.2
+    rev: 7.2.0
     hooks:
       - id: flake8
         name: flake8 except __init__.py
@@ -114,7 +114,7 @@ repos:
         files: /__init__\.py$
         additional_dependencies: ["flake8-bugbear==20.1.4"]
   - repo: https://github.com/PyCQA/pylint
-    rev: v2.11.1
+    rev: v3.3.6
     hooks:
       - id: pylint
         name: pylint with optional checks
@@ -123,7 +123,7 @@ repos:
           - --exit-zero
         verbose: true
         additional_dependencies: &pylint_deps
-          - pylint-odoo==5.0.4
+          - pylint-odoo==9.3.2
       - id: pylint
         name: pylint with mandatory checks
         args:

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,12 +3,12 @@ load-plugins=pylint_odoo
 score=n
 
 [ODOOLINT]
-readme_template_url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
-manifest_required_authors=Odoo Community Association (OCA)
-manifest_required_keys=license
-manifest_deprecated_keys=description,active
-license_allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
-valid_odoo_versions=15.0
+readme-template-url="https://github.com/OCA/maintainer-tools/blob/master/template/module/README.rst"
+manifest-required-authors=Odoo Community Association (OCA)
+manifest-required-keys=license
+manifest-deprecated-keys=description,active
+license-allowed=AGPL-3,GPL-2,GPL-2 or any later version,GPL-3,GPL-3 or any later version,LGPL-3
+valid-odoo-versions=15.0
 
 [MESSAGES CONTROL]
 disable=all
@@ -64,6 +64,38 @@ enable=anomalous-backslash-in-string,
     use-vim-comment,
     wrong-tabs-instead-of-spaces,
     xml-syntax-error,
+    attribute-string-redundant,
+    character-not-valid-in-resource-link,
+    consider-merging-classes-inherited,
+    context-overridden,
+    create-user-wo-reset-password,
+    dangerous-filter-wo-user,
+    dangerous-qweb-replace-wo-priority,
+    deprecated-data-xml-node,
+    deprecated-openerp-xml-node,
+    duplicate-po-message-definition,
+    except-pass,
+    invalid-commit,
+    manifest-maintainers-list,
+    missing-newline-extrafiles,
+    missing-readme,
+    missing-return,
+    odoo-addons-relative-import,
+    old-api7-method-defined,
+    po-msgstr-variables,
+    po-syntax-error,
+    renamed-field-parameter,
+    resource-not-exist,
+    str-format-used,
+    # Not applicable for OpenUpgrade: test-folder-imported,
+    translation-contains-variable,
+    translation-positional-used,
+    unnecessary-utf8-coding-comment,
+    website-manifest-key-not-valid-uri,
+    xml-attribute-translatable,
+    xml-deprecated-qweb-directive,
+    xml-deprecated-tree-attribute,
+    external-request-timeout,
     # messages that do not cause the lint step to fail
     consider-merging-classes-inherited,
     create-user-wo-reset-password,
@@ -73,9 +105,9 @@ enable=anomalous-backslash-in-string,
     invalid-commit,
     missing-manifest-dependency,
     missing-newline-extrafiles,
-    missing-readme,
+    # Not applicable for OpenUpgrade: missing-readme,
     no-utf8-coding-comment,
-    odoo-addons-relative-import,
+    # Not applicable for OpenUpgrade: odoo-addons-relative-import,
     old-api7-method-defined,
     redefined-builtin,
     too-complex,

--- a/openupgrade_framework/odoo_patch/odoo/api.py
+++ b/openupgrade_framework/odoo_patch/odoo/api.py
@@ -16,7 +16,7 @@ class FakeRecord:
     def __init__(self):
         self._name = "ir.model.data"
         self.ids = []
-        self.browse = lambda l: None
+        self.browse = lambda x: None
 
     def __isub__(self, other):
         return None

--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -1,4 +1,4 @@
-""" Encode any known changes to the database here
+"""Encode any known changes to the database here
 to help the matching process
 """
 

--- a/openupgrade_scripts/scripts/point_of_sale/15.0.1.0.1/post-migration.py
+++ b/openupgrade_scripts/scripts/point_of_sale/15.0.1.0.1/post-migration.py
@@ -6,7 +6,8 @@ from openupgradelib import openupgrade
 def _update_pos_payment_method_journal(env):
     """From now on, a journal is required when the transactions aren't splitted. If we
     don't set a journal in these cases, the session closing won't be made properly for
-    these methods. Cash payment methos already had a jornal set, but bank ones didn't."""
+    these methods. Cash payment methos already had a jornal set, but bank ones didn't.
+    """
     payment_methods = (
         env["pos.payment.method"]
         .search(

--- a/openupgrade_scripts/scripts/website/15.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website/15.0.1.0/post-migration.py
@@ -35,10 +35,12 @@ def extract_footer_copyright_company_name(env):
             )
             new_arch = re.sub(
                 main_copyright_pattern,
-                website_layout_matches[0]
-                if website_layout_matches
-                else f'<span class="o_footer_copyright_name mr-2">'
-                f"Copyright © {Markup.escape(website.company_id.name)}</span>",
+                (
+                    website_layout_matches[0]
+                    if website_layout_matches
+                    else f'<span class="o_footer_copyright_name mr-2">'
+                    f"Copyright © {Markup.escape(website.company_id.name)}</span>"
+                ),
                 main_copyright_arch,
             )
             main_copyright_view.with_context(website_id=website.id).arch = new_arch


### PR DESCRIPTION
# Context

I'm currently working to improve the script for the migration of mail templates (to include migration of elif tags).
However, as I was trying to commit my modifications ( `git commit` ), the `pre-commit` hooks ran (with Python 3.11, the default version on Debian 12) but failed, with the following error : 


```forbidden files......................................(no files to check)Skipped
Update pre-commit excluded addons........................................Passed
Fix the manifest website key.........................(no files to check)Skipped
autoflake................................................................Passed
black....................................................................Passed
prettier (with plugin-xml)...........................(no files to check)Skipped
eslint...............................................(no files to check)Skipped
- hook id: eslint
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
check for case conflicts.................................................Passed
check docstring is first.................................................Passed
check that executables have shebangs.................(no files to check)Skipped
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
check xml............................................(no files to check)Skipped
mixed line ending........................................................Passed
pyupgrade................................................................Passed
isort except __init__.py.................................................Passed
Generate default setup.py for an addons directory........................Passed
flake8 except __init__.py................................................Passed
flake8 only __init__.py..............................(no files to check)Skipped
pylint with optional checks..............................................Failed
- hook id: pylint
- duration: 0.04s
- exit code: 1

Traceback (most recent call last):
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
             ^^^^^^^^^^^^
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/__init__.py", line 21, in run_pylint
    from pylint.lint import Run as PylintRun
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/lint/__init__.py", line 76, in <module>
    from pylint.lint.parallel import check_parallel
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/lint/parallel.py", line 8, in <module>
    from pylint import reporters
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/reporters/__init__.py", line 26, in <module>
    from pylint import utils
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/utils/__init__.py", line 46, in <module>
    from pylint.utils.ast_walker import ASTWalker
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/utils/ast_walker.py", line 7, in <module>
    from astroid import nodes
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/astroid/__init__.py", line 51, in <module>
    from astroid.nodes import node_classes, scoped_nodes
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/astroid/nodes/__init__.py", line 27, in <module>
    from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (Ellipsis)
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 47, in <module>
    from astroid import decorators, mixins, util
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/astroid/decorators.py", line 27, in <module>
    import wrapt
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/wrapt/__init__.py", line 10, in <module>
    from .decorators import (adapter_factory, AdapterFactory, decorator,
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/wrapt/decorators.py", line 34, in <module>
    from inspect import ismethod, isclass, formatargspec
ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/lib/python3.11/inspect.py)

pylint with mandatory checks.............................................Failed
- hook id: pylint
- exit code: 1

Traceback (most recent call last):
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/bin/pylint", line 8, in <module>
    sys.exit(run_pylint())
             ^^^^^^^^^^^^
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/__init__.py", line 21, in run_pylint
    from pylint.lint import Run as PylintRun
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/lint/__init__.py", line 76, in <module>
    from pylint.lint.parallel import check_parallel
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/lint/parallel.py", line 8, in <module>
    from pylint import reporters
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/reporters/__init__.py", line 26, in <module>
    from pylint import utils
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/utils/__init__.py", line 46, in <module>
    from pylint.utils.ast_walker import ASTWalker
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/pylint/utils/ast_walker.py", line 7, in <module>
    from astroid import nodes
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/astroid/__init__.py", line 51, in <module>
    from astroid.nodes import node_classes, scoped_nodes
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/astroid/nodes/__init__.py", line 27, in <module>
    from astroid.nodes.node_classes import (  # pylint: disable=redefined-builtin (Ellipsis)
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/astroid/nodes/node_classes.py", line 47, in <module>
    from astroid import decorators, mixins, util
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/astroid/decorators.py", line 27, in <module>
    import wrapt
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/wrapt/__init__.py", line 10, in <module>
    from .decorators import (adapter_factory, AdapterFactory, decorator,
  File "/home/lena/.cache/pre-commit/repo0iznp5h2/py_env-python3/lib/python3.11/site-packages/wrapt/decorators.py", line 34, in <module>
    from inspect import ismethod, isclass, formatargspec
ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/lib/python3.11/inspect.py)```

This happens because the Pylint version defined in the config file, pylint v2.11.1, uses  the `formatargspec` method, removed from Python 3.11 onward.

And so, since the last update to these packages was 2 years ago (based on the last commit on the `.pre-commit.config.yaml` file), I propose that we update the packages used by pre-commit in this branch as to make it compatible with more recent Python versions.

# Changes

- Updated the versions of pre-commit packages using `pre-commit autoupdate`
- Updated pylintodoo version to 9.3.2
- Ran `pre-commit run -a` to reformat files
- Modified `api.py` file to rename a `l` variable to `x`, like in the 18.0 branch