### PR TITLE
[16.0][OU-FIX] loyalty pre-migration: Change False to None for loyalty date migration

### DIFF
--- a/openupgrade_scripts/scripts/loyalty/16.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/loyalty/16.0.1.0/pre-migration.py
@@ -819,7 +819,7 @@ def migrate(env, version):
                     "date",
                     "date",
                     "loyalty",
-                    False,
+                    None,
                 )
             ],
         )


### PR DESCRIPTION
# Commit Change Explanation

### Fix: Changed `False` to `None` for Default Value in `expiration_date` Column

#### Problem:
In the previous migration script, the `expiration_date` column was being added to the `loyalty_card` table with a default value of `False`. However, the column is of type `date`, and `False` is a boolean value. This resulted in the following error when attempting to execute the query:

**ERROR: column "expiration_date" is of type date but default expression is of type boolean  
HINT: You will need to rewrite or cast the expression.**

The error occurred because PostgreSQL was unable to apply a boolean value (`False`) to a column of type `date`, as they are incompatible types.

#### Solution:
To resolve the issue, I modified the migration script to set the default value of the `expiration_date` column to `None`, which is the appropriate default for a `date` field in Odoo (representing a `NULL` value). The change was made in the `openupgrade.add_fields` function as follows:

```python
openupgrade.add_fields(
    env,
    [
        (
            "expiration_date",
            "loyalty.card",
            "loyalty_card",
            "date",
            "date",
            "loyalty",
            None,
        )
    ],
)
