### PR TITLE
[15.0] [IMP] mail : Added elif migration from jinja to qweb

### DIFF
--- a/openupgrade_scripts/scripts/mail/15.0.1.5/post-migration.py
+++ b/openupgrade_scripts/scripts/mail/15.0.1.5/post-migration.py
@@ -148,6 +148,22 @@ def _migrate_if(string):
     return re.sub(pattern, repl_if, string, flags=re.MULTILINE)
 
 
+def repl_elif(match):
+    """Aux. method. We declare it globally so we don't have scope issues from shell"""
+    (elif_expression,) = match.groups()
+    elif_expression = html.escape(elif_expression)
+    return f'</t>\n<t t-elif="{elif_expression}">'
+
+
+def _migrate_elif(string):
+    """
+    Replace mako elif blocks (while closing previous [el]if block)
+    Example : '% elif (boolean expression):' -> '</t>\n<t t-elif="(boolean expression)">'
+    """
+    pattern = r"%\s?elif\s(.+)\s?:"
+    return re.sub(pattern, repl_elif, string, flags=re.MULTILINE)
+
+
 def repl_for(match):
     """Aux. method. We declare it globally so we don't have scope issues from shell"""
     var_name, loop_expression = match.groups()
@@ -211,6 +227,7 @@ def mako_html_to_qweb(string):
     string = _migrate_if(string)
     string = _migrate_for(string)
     string = _migrate_else(string)
+    string = _migrate_elif(string)
     string = _migrate_end(string)
     string = _migrate_set(string)
     return string


### PR DESCRIPTION
# Context

With the upgrade from Odoo 14.0 to Odoo 15.0, with the decision to transfer from the Jinja/Mako templating language to QWeb, there has been a need to migrate all older templates to the new format - the OpenUpgrade script offers a good script to upgrade older Jinja-based templates to QWeb-based templates

However, I noticed the absence of the migration of the elif tests, depite being both supported in Jinja (and used by my organization)  and in QWeb - this would result in migrated templates such as these this : 

```html
% if False:
hai
% elif True:
helloo
% endif
```
which would end up like the following after the post-migration.py script : 
```html
<t t-if="True">
hai
% elif False:
hello
</t>
```

So, I set out to fix this issue

# Solution 

I added two new functions in the mail/15.0.1.5/post-migration.py file to handle elif scripts : 
- `repl_elif` : Generating a replacement string based on the used expression
- `_migrate_elif` : Finds all occurences of elif's in a given string matching a Jinja/Mako tag, to replace with QWeb tags

(These functions are based on the `repl_if` and `_migrate_if` functions)

I then inserted the `_migrate_elif` function in `mako_html_to_qweb` so that it correctly replaces elif tags

=> I used the script locally on a python console, and it changes Jinja/Mako elif tags to QWeb tags correctly - reprising the example from earlier, this updated script now migrates the following template : 
```html
% if False:
hai
% elif True:
helloo
% endif
```
as the following QWeb template : 
```html
<t t-if="True">
hai
</t>
<t t-elif="False">
hello
</t>
```