### PR TITLE
[18.0][OU-ADD] web_widget_product_label_section_and_note: Renamed to web_widget_product_label_section_and_note_name_visibility

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -20,6 +20,8 @@ renamed_modules = {
     "sale_product_set_sale_by_packaging": "product_set_sell_only_by_packaging",
     # OCA/stock-logistics-workflow
     "stock_picking_type_shipping_policy": "stock_picking_type_force_move_type",
+    # OCA/web
+    "web_widget_product_label_section_and_note": "web_widget_product_label_section_and_note_name_visibility",  # noqa: E501
     # OCA/...
 }
 


### PR DESCRIPTION
Related to: https://github.com/OCA/web/pull/3165
`web_widget_product_label_section_and_note` renamed to `web_widget_product_label_section_and_note_name_visibility`

TT56065
@Tecnativa @pedrobaeza @MiquelRForgeFlow could you please review this?