### PR TITLE
[17.0][OU-IMP] website_event: Add script to insert default event questions for old events

### DIFF
--- a/openupgrade_scripts/scripts/website_event/17.0.1.4/post-migration.py
+++ b/openupgrade_scripts/scripts/website_event/17.0.1.4/post-migration.py
@@ -1,8 +1,43 @@
-# Copyright 2024 Tecnativa - Pilar Vargas
+# Copyright 2024-2025 Tecnativa - Pilar Vargas
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from openupgradelib import openupgrade
+from psycopg2.extras import Json
+
+
+def fill_event_question(env):
+    # Query ‘name’, ‘email’, ‘phone’ fields of ‘res.partner’ with their translations
+    env.cr.execute(
+        """
+        SELECT imf.name, imf.field_description
+        FROM ir_model_fields AS imf
+        JOIN ir_model AS im ON imf.model_id = im.id
+        WHERE im.model = 'res.partner'
+        AND imf.name IN ('name', 'email', 'phone')
+    """
+    )
+    field_descriptions = dict(env.cr.fetchall())
+    question_types = [
+        ("name", True),
+        ("email", True),
+        ("phone", False),
+    ]
+    for qtype, mandatory in question_types:
+        title_json = field_descriptions.get(qtype)
+        env.cr.execute(
+            """
+            INSERT INTO event_question (
+                event_id, title, question_type,
+                is_mandatory_answer, once_per_order,
+                sequence, create_date, write_date
+            )
+            SELECT ee.id, %s, %s, %s, FALSE, 10, now(), now()
+            FROM event_event AS ee
+        """,
+            (Json(title_json), qtype, mandatory),
+        )
 
 
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env, "website_event", "17.0.1.4/noupdate_changes.xml")
+    fill_event_question(env)


### PR DESCRIPTION
In version 16, the default questions in the registration form, such as ‘Name’, ‘Email’ and ‘Phone’, were directly visible in the registration form view for users. However, in Odoo v17, although those questions are automatically created in new events as records in the event.question template, they are not inserted in existing events, causing a lack of consistency in the registration form.
This script solves that problem by adding those questions by default to all existing events, ensuring that they have the same behaviour as new events. For the translations, instead of defining them manually, the script takes advantage of existing translations in the ir.model.fields table for the name, email and phone fields of the res.partner model.

cc @Tecnativa TT51546

@pedrobaeza @victoralmau please review