### PR TITLE
[16.0][OU-FIX] base_address_extended: regexp fix

### DIFF
--- a/openupgrade_scripts/scripts/base_address_extended/16.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/base_address_extended/16.0.1.1/pre-migration.py
@@ -49,7 +49,7 @@ def migrate(env, _version):
         FROM (
             SELECT
                 id,
-                regexp_match(street, '^(.*?)(?:\\s([0-9][0-9\\S]*))?(?: - (.+))?$') AS rgx
+                regexp_match(street, E'^(.*?)(?:\\s+(\\d[\\d\\S]*))?(?:\\s+-\\s+(.+))?$') AS rgx
             FROM res_partner
             WHERE street IS NOT NULL
         ) AS sub


### PR DESCRIPTION
when trying to run OpenUpgrade to 16.0, I got this error:

```
    )   and I get this error:   File "/odoo/external-src/openupgrade/openupgrade_framework/odoo_patch/odoo/modules/migration.py", line 18, in migrate_module
    MigrationManager.migrate_module._original_method(self, pkg, stage)
  File "/odoo/src/odoo/modules/migration.py", line 189, in migrate_module
    migrate(self.cr, installed_version)
  File "/env/lib/python3.10/site-packages/openupgradelib/openupgrade.py", line 2400, in wrapped_function
    func(
  File "/odoo/external-src/openupgrade/openupgrade_scripts/scripts/base_address_extended/16.0.1.1/pre-migration.py", line 41, in migrate
    openupgrade.logged_query(
  File "/env/lib/python3.10/site-packages/openupgradelib/openupgrade.py", line 1750, in logged_query
    cr.execute(query, args)
  File "/odoo/src/odoo/sql_db.py", line 321, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.InvalidRegularExpression: invalid regular expression: invalid escape \ sequence 
```

Deepseek suggested me several solutions and the one that could run for me was the one of this patch. Deepseek explanations:

-  Used E'' string literal which properly interprets backslash escapes
-  Doubled the backslashes for Python string interpretation
-  Simplified digit matching with \d


Disclaimer: I made no functional test. I will see if I have data I could check eventually.

versions:

Postgres server 13
psycopg2==2.9.5
Python 3.10.12


cc @etobella 