### PR TITLE
[18.0] [OU-ADD] apriori: document_page_group merged into document_page_access_group

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -54,6 +54,8 @@ merged_modules = {
     "stock_landed_costs_company": "stock_landed_costs",
     "website_sale_product_configurator": "website_sale",
     # odoo/enterprise
+    # OCA/knowledge
+    "document_page_group": "document_page_access_group",
     # OCA/l10n-france
     "l10n_fr_pos_cert_update_draft_order_line": "l10n_fr_pos_cert",
     # OCA/sale-workflow


### PR DESCRIPTION
Due to https://github.com/OCA/knowledge/issues/502 document_page_group is not needed and can be merged into document_page_access_group which has already been migrated

@etobella 