### PR TITLE
[17.0][OU-FIX] hr_attendance: Add the 'User: Read his own attendances' permission to the appropriate users.

### DIFF
--- a/openupgrade_scripts/scripts/hr_attendance/17.0.2.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_attendance/17.0.2.0/pre-migration.py
@@ -8,10 +8,6 @@ _xmlid_renames = [
         "hr_attendance.group_hr_attendance_user",
         "hr_attendance.group_hr_attendance_officer",
     ),
-    (
-        "hr_attendance.group_hr_attendance_kiosk",
-        "hr_attendance.group_hr_attendance_own_reader",
-    ),
 ]
 
 


### PR DESCRIPTION
Add the 'User: Read his own attendances' permission to the appropriate users.

The new permission 'User: Read his own attendances' is required for all existing users, otherwise, when trying to access 'Last month' smart-button of their employee tab they will get an access error.

The old `hr_attendance.group_hr_attendance_kiosk` permission does not replace this new one exactly.
https://github.com/odoo/odoo/blob/97d8fdbcd363e17569ac420049989959258aa0b7/addons/hr_attendance/security/hr_attendance_security.xml#L14

**Before**
![ejemplo](https://github.com/user-attachments/assets/e96b422d-95fa-4c47-90aa-122d109a2671)

@Tecnativa