### PR TITLE
[16.0][OU-IMP] analytic: Define the appropriate value for the root_plan_id field in the analytical accounts.

### DIFF
--- a/openupgrade_scripts/scripts/analytic/16.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/analytic/16.0.1.1/post-migration.py
@@ -6,3 +6,7 @@ def migrate(env, version):
     openupgrade.delete_records_safely_by_xml_id(
         env, ["analytic.analytic_tag_comp_rule", "analytic.analytic_group_comp_rule"]
     )
+    # Define the appropriate value for the root_plan_id field. Necessary for accounts
+    # that previously had an account.analytic.group defined.
+    accounts = env["account.analytic.account"].search([("root_plan_id", "=", False)])
+    accounts._compute_root_plan()


### PR DESCRIPTION
Define the appropriate value for the `root_plan_id` field in the analytical accounts.

Necessary for accounts that previously had an account.analytic.group defined.

@Tecnativa TT56324