### PR TITLE
[17.0][FIX] analytic: rename account.analytic.plan#default_applicability

### DIFF
--- a/openupgrade_scripts/scripts/analytic/17.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/analytic/17.0.1.2/post-migration.py
@@ -60,19 +60,12 @@ def _analytic_plan_update_applicability_into_property(env):
     in all companies as the company_id field was shifted from account.analytic.plan
     to account.analytic.applicability
     """
-    env.cr.execute(
-        """
-        SELECT id, default_applicability FROM account_analytic_plan
-        WHERE default_applicability != 'optional'
-        """
+    openupgrade.convert_to_company_dependent(
+        env,
+        "account.analytic.plan",
+        openupgrade.get_legacy_name("default_applicability"),
+        "default_applicability",
     )
-    values = dict(env.cr.fetchall())
-    for company in env["res.company"].search([]):
-        env["ir.property"].with_company(company)._set_multi(
-            "default_applicability",
-            "account.analytic.plan",
-            values,
-        )
 
 
 @openupgrade.migrate()

--- a/openupgrade_scripts/scripts/analytic/17.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/analytic/17.0.1.2/pre-migration.py
@@ -55,3 +55,7 @@ def migrate(env, version):
     openupgrade.copy_columns(
         env.cr, {"account_analytic_plan": [("company_id", None, None)]}
     )
+    # Rename default_applicability which is going to become a property
+    openupgrade.rename_columns(
+        env.cr, {"account_analytic_plan": [("default_applicability", None)]}
+    )


### PR DESCRIPTION
as leaving the column will cause problems in the v18 migration.

Then we can also use openupgrade.convert_to_company_dependent

Fixes #5041