### PR TITLE
[18.0][ADD] install phonenumbers in ci as it's a hard dependency for account_peppol by now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,8 @@ jobs:
           # this is for v16 l10n_eg_edi_eta which crashes without it
           pip install asn1crypto
           pip install coverage
+          # this is for account_peppol
+          pip install phonenumbers
       - name: Test data
         run: |
           if test -n "$(ls openupgrade/openupgrade_scripts/scripts/*/tests/data*.py 2> /dev/null)"; then


### PR DESCRIPTION
CI for PRs that pull enough modules to make account_peppol installable [fails](https://github.com/OCA/OpenUpgrade/actions/runs/15109467131/job/42465452794?pr=5007#step:13:496) without this