### PR TITLE
[OU-FIX] product: avoid reserved SQL keyword "sequence"

### DIFF
--- a/openupgrade_scripts/scripts/product/18.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/product/18.0.1.2/post-migration.py
@@ -12,7 +12,7 @@ def product_document_sequence(env):
         env.cr,
         """
         UPDATE product_document
-        SET sequence=seq.sequence
+        SET sequence=seq.seq
         FROM
         (
             SELECT

--- a/openupgrade_scripts/scripts/product/18.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/product/18.0.1.2/post-migration.py
@@ -12,22 +12,23 @@ def product_document_sequence(env):
         env.cr,
         """
         UPDATE product_document
-        SET sequence=sequence.sequence
+        SET sequence = "sequence".sequence
         FROM
         (
             SELECT
-            product_document.id, row_number() OVER (
+            product_document.id,
+            row_number() OVER (
                 PARTITION BY ir_attachment.res_id, ir_attachment.res_model
                 ORDER BY ir_attachment.name
-            ) sequence
+            ) AS sequence
             FROM
             product_document
             JOIN ir_attachment
-            ON product_document.ir_attachment_id=ir_attachment.id
-        ) sequence
+            ON product_document.ir_attachment_id = ir_attachment.id
+        ) AS "sequence"
         WHERE
-        sequence.id=product_document.id
-        AND product_document.sequence IS NULL
+        "sequence".id = product_document.id
+        AND product_document.sequence IS NULL;
         """,
     )
 

--- a/openupgrade_scripts/scripts/product/18.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/product/18.0.1.2/post-migration.py
@@ -12,23 +12,22 @@ def product_document_sequence(env):
         env.cr,
         """
         UPDATE product_document
-        SET sequence = "sequence".sequence
+        SET sequence=seq.sequence
         FROM
         (
             SELECT
-            product_document.id,
-            row_number() OVER (
+            product_document.id, row_number() OVER (
                 PARTITION BY ir_attachment.res_id, ir_attachment.res_model
                 ORDER BY ir_attachment.name
-            ) AS sequence
+            ) AS seq
             FROM
             product_document
             JOIN ir_attachment
-            ON product_document.ir_attachment_id = ir_attachment.id
-        ) AS "sequence"
+            ON product_document.ir_attachment_id=ir_attachment.id
+        ) AS seq
         WHERE
-        "sequence".id = product_document.id
-        AND product_document.sequence IS NULL;
+        seq.id=product_document.id
+        AND product_document.sequence IS NULL
         """,
     )
 


### PR DESCRIPTION
When running OpenUpgrade 18.0 on PostgreSQL, queries using  `row_number(...) sequence` raise a syntax error due to unquoted alias names with postgres version 13.0

This PR fixes:
- `sequence` → `"sequence"`

to ensure compatibility with PostgreSQL reserved keywords and avoid `syntax error at or near ...`.

This patch unblocks migration from Odoo 17.0 to 18.0 for affected modules (, `product`) with postgres 13.0.