### PR TITLE
[17.0][FIX] hr_attendance: unlink instead removing groups 

### DIFF
--- a/openupgrade_scripts/scripts/hr_attendance/17.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_attendance/17.0.2.0/post-migration.py
@@ -62,8 +62,8 @@ def hr_attendance_menus(env):
     env.ref("hr_attendance.menu_hr_attendance_root").write(
         {
             "groups_id": [
-                Command.delete(group_hr_attendance.id),
-                Command.delete(group_hr_attendance_kiosk.id),
+                Command.unlink(group_hr_attendance.id),
+                Command.unlink(group_hr_attendance_kiosk.id),
             ]
         }
     )
@@ -71,7 +71,7 @@ def hr_attendance_menus(env):
     env.ref("hr_attendance.menu_hr_attendance_kiosk_no_user_mode").write(
         {
             "groups_id": [
-                Command.delete(group_hr_attendance_kiosk.id),
+                Command.unlink(group_hr_attendance_kiosk.id),
             ]
         }
     )


### PR DESCRIPTION
that are linked somewhere else !

followup of https://github.com/OCA/OpenUpgrade/pull/5035.

But at the moment I've not figure out if  my database is still wrongly using those `res.group` records somewhere else or if the upgrade script just needs to unlink (at least this helps me in the mean time)?

 @victoralmau I'm wondering what's do you think about it?