### PR TITLE
[18.0][OU-FIX] account: Fix SQL error in post-migration script on PostgreSQL 13

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
@@ -85,7 +85,7 @@ def fill_res_partner_property_x_payment_method_line_id(env):
         FROM (
             SELECT
             SPLIT_PART(ip.res_id, ',', 2)::integer res_id,
-            JSON_OBJECT_AGG(ip.company_id, sub.id) value
+            JSON_OBJECT_AGG(ip.company_id, sub.id) AS "value"
             FROM ir_property ip
             JOIN LATERAL (
                 SELECT *


### PR DESCRIPTION
During migration from Odoo 17.0 to 18.0 with a demo database and PostgreSQL 13, the following SQL error occurs:

`syntax error at or near "value"
LINE 5: JSON_OBJECT_AGG(ip.company_id, sub.id) value`

The alias for the JSON_OBJECT_AGG result column was missing the `AS` keyword, which causes a syntax error in PostgreSQL versions prior to 14. This patch adds the missing `AS "value"` to ensure compatibility with PostgreSQL 13.

This fixes the post-migration step in `account/migrations/18.0.1.0/post-migration.py` by making the SQL statement syntactically valid on PostgreSQL 13.