### PR TITLE
[16.0][OU-FIX] base_address_extended: regexp fix

### DIFF
--- a/openupgrade_scripts/scripts/base_address_extended/16.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/base_address_extended/16.0.1.1/pre-migration.py
@@ -49,7 +49,7 @@ def migrate(env, _version):
         FROM (
             SELECT
                 id,
-                regexp_match(street, '^(.*?)(?:\\s([0-9][0-9\\S]*))?(?: - (.+))?$') AS rgx
+                regexp_match(street, '^(.*?)(?:\\s([0-9][0-9^\\s]*))?(?: - (.+))?$') AS rgx
             FROM res_partner
             WHERE street IS NOT NULL
         ) AS sub


### PR DESCRIPTION
Supersedes https://github.com/OCA/OpenUpgrade/pull/5009.

See:

In v13: https://www.postgresql.org/docs/13/functions-matching.html
```
\S 	[^[:space:]]
Within bracket expressions, \d, \s, and \w lose their outer brackets, and \D, \S, and \W are illegal. (So, for example, [a-c\d] is equivalent to [a-c[:digit:]]. Also, [a-c\D], which is equivalent to [a-c^[:digit:]], is illegal.)
```

In v15: https://www.postgresql.org/docs/15/functions-matching.html
```
\S 	matches any non-whitespace character, like [^[:space:]]
The class-shorthand escapes also work within bracket expressions, although the definitions shown above are not quite syntactically valid in that context. For example, [a-c\d] is equivalent to [a-c[:digit:]].
```