### PR TITLE
[17.0][OU-FIX] website_sale: Adjust B2B/B2C visibility per website

### DIFF
--- a/openupgrade_scripts/scripts/website_sale/17.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/website_sale/17.0.1.1/post-migration.py
@@ -1,7 +1,21 @@
 # Copyright 2025 Tecnativa - Pilar Vargas
+# Copyright 2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from openupgradelib import openupgrade
+
+
+def _adjust_website_default_b2b_b2c(env):
+    """Previously, B2B/B2C prices visibility was set in a global way through 2
+    accounting groups that were inherited to "Internal user" group. Now, these groups
+    have disappeared, and this can be configured at website level directly. We switch
+    from the default value "tax_excluded" if we detect the B2C group was put before.
+    This can be done because the groups haven't been yet removed in this phase.
+    """
+    group_b2c = env.ref("account.group_show_line_subtotals_tax_included")
+    group_internal = env.ref("base.group_user")
+    if group_b2c in group_internal.implied_ids:
+        env["website"].search([]).show_line_subtotals_tax_selection = "tax_included"
 
 
 @openupgrade.migrate()
@@ -26,3 +40,4 @@ def migrate(env, version):
               AND ir.product_downloadable
             """,
         )
+    _adjust_website_default_b2b_b2c(env)

--- a/openupgrade_scripts/scripts/website_sale/17.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale/17.0.1.1/upgrade_analysis_work.txt
@@ -14,9 +14,11 @@ website_sale / res.company              / website_sale_onboarding_payment_provid
 website_sale / sale.order               / access_point_address (json)   : NEW
 website_sale / website                  / currency_id (many2one)        : not related anymore
 website_sale / website                  / currency_id (many2one)        : now a function
-website_sale / website                  / show_line_subtotals_tax_selection (selection): NEW required, selection_keys: ['tax_excluded', 'tax_included'], hasdefault: default
 website_sale_delivery / sale.order               / amount_delivery (float)       : not stored anymore
 # NOTHING TO DO
+
+website_sale / website                  / show_line_subtotals_tax_selection (selection): NEW required, selection_keys: ['tax_excluded', 'tax_included'], hasdefault: default
+# DONE: post-migration: Switch default value "tax_excluded" if previous group account.group_show_line_subtotals_tax_included was selected.
 
 website_sale / product.tag              / visible_on_ecommerce (boolean): NEW hasdefault: default
 # DONE post-migration: Set to False so as not to change the behaviour of the website with new things.


### PR DESCRIPTION
Previously, B2B/B2C prices visibility was set in a global way through 2 accounting groups that were inherited to "Internal user" group. Now, these groups have disappeared, and this can be configured at website level directly. We switch from the default value "tax_excluded" if we detect the B2C group was put before. This can be done because the groups haven't been yet removed in this phase.

@Tecnativa 