### PR TITLE
[18.0][OU-FIX] l10n_fr: let's upgrade l10n_fr_account

### DIFF
--- a/openupgrade_scripts/scripts/l10n_fr/18.0.2.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/l10n_fr/18.0.2.1/pre-migration.py
@@ -678,10 +678,10 @@ _xmlids_renames = [
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_xmlids(env.cr, _xmlids_renames)
-    openupgrade.logged_query(  # just in case `account_fr_fec` was not installed
+    openupgrade.logged_query(  # to update 2 problematic tax accounts in l10n_fr_account
         env.cr,
         """
         UPDATE ir_module_module
-        SET state='to install'
+        SET state='to upgrade'
         WHERE name = 'l10n_fr_account' AND state='uninstalled'""",
     )

--- a/openupgrade_scripts/scripts/l10n_fr_account/18.0.2.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/l10n_fr_account/18.0.2.2/pre-migration.py
@@ -14,11 +14,9 @@ table_renames = [
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.rename_models(env.cr, model_renames)
-    openupgrade.rename_tables(env.cr, table_renames)
-    openupgrade.delete_records_safely_by_xml_id(
-        env,
-        [
-            "l10n_fr_fec.account_fr_fec_rule",
-        ],
-    )
+    if openupgrade.table_exists(env.cr, "account_fr_fec"):
+        openupgrade.rename_models(env.cr, model_renames)
+        openupgrade.rename_tables(env.cr, table_renames)
+        openupgrade.delete_records_safely_by_xml_id(
+            env, ["l10n_fr_fec.account_fr_fec_rule"]
+        )


### PR DESCRIPTION
Fixes https://github.com/OCA/OpenUpgrade/pull/5090.

Let's see the cases:

Case 1:
- v17: `l10n_fr` installed, `l10n_fr_fec` not installed.
- v18: `l10n_fr` migrates, and sets 'to install' `l10n_fr_account`. Then `l10n_fr_account` is installed (but scripts of `l10n_fr_account` are not executed, which is wrong. We need them to fix tax accounts). **Fixed** by putting "to upgrade". We also check if `l10n_fr_fec` was installed.

Case 2:
- v17: `l10n_fr` installed, `l10n_fr_fec` is installed.
- v18: In base, `l10n_fr_fec` data is merged into `l10n_fr_account`. `l10n_fr` migrates and then `l10n_fr_account` migrates.