### PR TITLE
[16.0][OU-IMP] sale_purchase: rename deprecated column

### DIFF
--- a/openupgrade_scripts/scripts/sale_purchase/16.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/sale_purchase/16.0.1.0/post-migration.py
@@ -71,6 +71,10 @@ def convert_service_to_purchase_to_company_dependent(env):
         """,
         {"field_id": service_to_purchase_field_id},
     )
+    openupgrade.rename_columns(
+        env.cr,
+        {"product_template": [("service_to_purchase", None)]},
+    )
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
It's better this way. If not, when you migrate to v18, you will get an error during the module load, as the column will exist and ORM will try to set it as jsonb (See https://github.com/OCA/OpenUpgrade/pull/5123).