### PR TITLE
[18.0][OU-ADD] hr_attendance_autoclose: Merged into hr_attendance

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -63,6 +63,8 @@ merged_modules = {
     # odoo/enterprise
     # OCA/e-commerce
     "website_sale_product_attachment": "website_sale",
+    # OCA/hr-attendance
+    "hr_attendance_autoclose": "hr_attendance",
     # OCA/knowledge
     "document_page_group": "document_page_access_group",
     # OCA/l10n-france

--- a/openupgrade_scripts/scripts/hr_attendance/18.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_attendance/18.0.2.0/post-migration.py
@@ -1,0 +1,49 @@
+# Copyright 2025 Tecnativa - Víctor Martínez
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+def _hr_attendance_autoclose(env):
+    """If the hr_attendance_autoclose module was installed, we will define
+    the appropriate values in res.company: auto_check_out +
+    auto_check_out_tolerance fields.
+    """
+    if not openupgrade.column_exists(
+        env.cr, "res_company", "hr_attendance_autoclose_reason"
+    ):
+        return
+    env.cr.execute(
+        """
+        UPDATE res_company
+        SET auto_check_out = true, auto_check_out_tolerance = (
+            attendance_maximum_hours_per_day - calendar.hours_per_day
+        )
+        FROM resource_calendar AS calendar
+        WHERE res_company.resource_calendar_id = calendar.id
+        AND res_company.attendance_maximum_hours_per_day IS NOT NULL
+        """
+    )
+    env.cr.execute(
+        """
+        UPDATE hr_attendance ha
+        SET out_mode = 'auto_check_out'
+        FROM hr_employee he, res_company rc,
+            hr_attendance_hr_attendance_reason_rel rel
+        WHERE ha.employee_id = he.id
+        AND he.company_id = rc.id
+        AND rel.hr_attendance_id = ha.id
+        AND rel.hr_attendance_reason_id = rc.hr_attendance_autoclose_reason
+        AND rc.hr_attendance_autoclose_reason IS NOT NULL
+        """
+    )
+    openupgrade.delete_records_safely_by_xml_id(
+        env,
+        [
+            "hr_attendance.check_attendance_cron",
+        ],
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _hr_attendance_autoclose(env)


### PR DESCRIPTION
Merged into `hr_attendance` (Related to https://github.com/OCA/hr-attendance/pull/201 + https://github.com/OCA/hr-attendance/pull/225)

Changes done:
- [x] `hr_attendance`: Migration scripts to properly set the `auto_check_out` + `auto_check_out_tolerance` value fields.
- [x] `hr_attendance`: Set the attendances that have defined the auto-close reasons with `out_mode='auto_check_out'`
- [x] `hr_attendance_reason`: ~Add functionality to be able to define a reason to be set at auto check-out (similar to `hr_attendance_autoclose`).~

Locked by:
- [x] `hr_attendance`: https://github.com/OCA/OpenUpgrade/pull/5255

Please @pedrobaeza can you review it?

@Tecnativa TT55521