### PR TITLE
[17.0][IMP] account_edi_ubl_cii: Optimize end-script

### DIFF
--- a/openupgrade_scripts/scripts/account_edi_ubl_cii/17.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/account_edi_ubl_cii/17.0.1.0/end-migration.py
@@ -3,10 +3,13 @@ from openupgradelib import openupgrade
 
 
 def _res_partner_compute_fields_values(env):
-    res_partner = env["res.partner"].with_context(active_test=False).search([])
-    res_partner._compute_ubl_cii_format()
-    res_partner._compute_peppol_endpoint()
-    res_partner._compute_peppol_eas()
+    partners = (
+        env["res.partner"]
+        .with_context(active_test=False)
+        .search(["|", ("country_id", "!=", False), ("vat", "!=", False)])
+    )
+    partners._compute_ubl_cii_format()
+    partners._compute_peppol_eas()
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
- Don't do the compute if the initial conditions (VAT or country) are not set.
- Don't compute 2 times peppol_endpoint, as it's already triggered by the computation of peppol_eas.

@Tecnativa 