### PR TITLE
[18.0] openupgrade_framework: several issues concerning module installation

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/__init__.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/__init__.py
@@ -1,2 +1,3 @@
 from . import ir_model
+from . import ir_module
 from . import ir_ui_view

--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_module.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_module.py
@@ -1,0 +1,33 @@
+# Copyright Odoo Community Association (OCA)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+
+from odoo.addons.base.models.ir_module import Module
+
+
+def update_list(self):
+    """
+    Mark auto_install modules as to install if all their dependencies are some kind of
+    installed.
+    Ignore localization modules that are set to auto_install
+    """
+    Module.update_list._original_method(self)
+    new_auto_install_modules = self.browse([])
+    for module in self.env["ir.module.module"].search(
+        [
+            ("auto_install", "=", True),
+            ("state", "=", "uninstalled"),
+            ("name", "not like", ("l10n_%")),
+        ]
+    ):
+        if all(
+            state in ("to upgrade", "to install", "installed")
+            for state in module.dependencies_id.mapped("state")
+        ):
+            new_auto_install_modules |= module
+    if new_auto_install_modules:
+        new_auto_install_modules.button_install()
+
+
+update_list._original_method = Module.update_list
+Module.update_list = update_list

--- a/openupgrade_framework/odoo_patch/odoo/modules/__init__.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/__init__.py
@@ -1,1 +1,1 @@
-from . import graph, migration
+from . import graph, loading, migration

--- a/openupgrade_framework/odoo_patch/odoo/modules/loading.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/loading.py
@@ -1,0 +1,33 @@
+# Copyright Odoo Community Association (OCA)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import inspect
+
+import odoo.modules.loading
+
+
+def load_openerp_module(module_name):
+    """
+    Run pre-migration scripts of addons being installed
+    """
+    frame = inspect.currentframe()
+    while frame.f_back:
+        frame = frame.f_back
+        f_locals = frame.f_locals
+
+        expected_locals = (
+            "new_install",
+            "needs_update",
+            "package",
+            "migrations",
+            "env",
+        )
+        if all(expected_local in f_locals for expected_local in expected_locals):
+            if f_locals["needs_update"] and f_locals["new_install"]:
+                f_locals["migrations"].migrate_module(f_locals["package"], "pre")
+                f_locals["env"].flush_all()
+
+    odoo.modules.loading.load_openerp_module._original_method(module_name)
+
+
+load_openerp_module._original_method = odoo.modules.loading.load_openerp_module
+odoo.modules.loading.load_openerp_module = load_openerp_module

--- a/openupgrade_framework/odoo_patch/odoo/modules/migration.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/migration.py
@@ -15,9 +15,11 @@ def migrate_module(self, pkg, stage):
     to_install = pkg.state == "to install"
     if to_install:
         pkg.state = "to upgrade"
+        pkg.installed_version = "0.0"
     MigrationManager.migrate_module._original_method(self, pkg, stage)
     if to_install:
         pkg.state = "to install"
+        pkg.installed_version = None
 
 
 def _get_files(self):


### PR DESCRIPTION
see https://github.com/OCA/OpenUpgrade/pull/5128/files#r2174688424

This fixes several issues:
- auto_install addons weren't actually installed by OpenUpgrade (the addon in the link above is only installed because sale_event pulls it)
- pre scripts weren't run for newly installed addons
- no migration scripts were run for newly installed addons