### PR TITLE
[18.0][REV+OU-FIX] openupgrade_framework: Revert version assignation + event_product: remove decorator

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/modules/migration.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/migration.py
@@ -15,11 +15,9 @@ def migrate_module(self, pkg, stage):
     to_install = pkg.state == "to install"
     if to_install:
         pkg.state = "to upgrade"
-        pkg.installed_version = "0.0"
     MigrationManager.migrate_module._original_method(self, pkg, stage)
     if to_install:
         pkg.state = "to install"
-        pkg.installed_version = None
 
 
 def _get_files(self):

--- a/openupgrade_scripts/scripts/event_product/18.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/event_product/18.0.1.0/pre-migration.py
@@ -14,7 +14,8 @@ XMLID_TO_RENAME = [
 ]
 
 
-@openupgrade.migrate()
-def migrate(env, version):
+def migrate(cr, version):
+    # Done without the openupgrade decorator to force its execution when this module
+    # is auto-installed as dependency of event_sale
     xmlid_renames = [(f"event_sale.{x}", f"event_product.{x}") for x in XMLID_TO_RENAME]
-    openupgrade.rename_xmlids(env.cr, xmlid_renames)
+    openupgrade.rename_xmlids(cr, xmlid_renames)


### PR DESCRIPTION
- Revert "[FIX] openupgrade_framework: manipulate versions to actually run scripts"

- event_product: Adapt to run it always
    
  `@openupgrade.migrate` decorator avoids to execute the script if version is none. As we have reverted the openupgrade_framework patch that modifies the version, we avoid the side effect and get this script working removing the decorator.