### PR TITLE
[18.0][OU-ADD] apriori: product_supplierinfo_import_by_barcode renamed to product_supplierinfo_import

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -17,6 +17,7 @@ renamed_modules = {
     # OCA/product-attribute
     "product_packaging_type_vendor": "product_packaging_level_vendor",
     "product_supplierinfo_for_customer": "product_customerinfo",
+    "product_supplierinfo_import_by_barcode": "product_supplierinfo_import",
     "product_template_tags_code": "product_tags_code",
     "stock_packaging_calculator": "product_packaging_calculator",
     # OCA/project

--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -18,6 +18,7 @@ renamed_modules = {
     "product_packaging_type_vendor": "product_packaging_level_vendor",
     "product_supplierinfo_for_customer": "product_customerinfo",
     "product_supplierinfo_import_by_barcode": "product_supplierinfo_import",
+    "product_supplierinfo_import_by_barcode_margin": "product_supplierinfo_import_margin",  # noqa: E501
     "product_template_tags_code": "product_tags_code",
     "stock_packaging_calculator": "product_packaging_calculator",
     # OCA/project


### PR DESCRIPTION
Renamed in https://github.com/OCA/product-attribute/pull/2020 + https://github.com/OCA/product-attribute/pull/2021

@Tecnativa TT54470 TT54471