### PR TITLE
[18.0][OU-FIX] account: handle credit_limit coming from v15

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/pre-migration.py
@@ -206,6 +206,12 @@ def migrate(env, version):
                 ]
             },
         )
+    if openupgrade.column_exists(env.cr, "res_partner", "credit_limit"):
+        # in v15, this field was not company_dependent
+        openupgrade.rename_columns(
+            env.cr,
+            {"res_partner": [("credit_limit", None)]},
+        )
     if openupgrade.column_exists(
         env.cr, "account_move", "l10n_dk_currency_rate_at_transaction"
     ):


### PR DESCRIPTION
Hi,
In version 15.0 credit_limit was not company dependent meaning there might be a leftover credit_limit column on res_partner table which cause an error when upgrading to 18.0 because of the new jsonb system for company_dependent fields.
Used the same approach as other company dependent fields : renaming the column to legacy name.
