### PR TITLE
[17.0][OU-FIX] account: map column chart_template_id

### DIFF
--- a/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
@@ -508,7 +508,7 @@ def _map_chart_template_id_to_chart_template(
     `l10n_` prefix removed (usually the country's iso code)
     """
     env.cr.execute(
-        f"""SELECT m.id, CONCAT(imd.module, '.', imd.name)
+        f"""SELECT m.{coa_m2o}, CONCAT(imd.module, '.', imd.name)
             FROM {model_table} m
                 JOIN ir_model_data imd
                     ON imd.model='account.chart.template'


### PR DESCRIPTION
This PR fixes an issue with account post-migration script where company_id is retrieved instead of chart_template_id column for mapping with new field chart_template.

Split from #5163