### PR TITLE
[18.0][FIX] openupgrade_framework: fix return value for update_list method patch

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_module.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_module.py
@@ -11,7 +11,7 @@ def update_list(self):
     installed.
     Ignore localization modules that are set to auto_install
     """
-    Module.update_list._original_method(self)
+    result = Module.update_list._original_method(self)
     new_auto_install_modules = self.browse([])
     for module in self.env["ir.module.module"].search(
         [
@@ -27,6 +27,7 @@ def update_list(self):
             new_auto_install_modules |= module
     if new_auto_install_modules:
         new_auto_install_modules.button_install()
+    return result
 
 
 update_list._original_method = Module.update_list


### PR DESCRIPTION
since [`update_list` will be called by other module](https://github.com/odoo/odoo/blob/c0183a81a9150c987522a7803a6e4598c0e72b7c/odoo/addons/base/wizard/base_module_update.py#L16), it will be better to keep the original return value