### PR TITLE
[17.0][OU-ADD] loyalty_initial_date_validity + sale_loyalty_initial_date_validity: Merged into loyalty

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -65,6 +65,7 @@ merged_modules = {
     "purchase_discount": "purchase",
     # OCA/sale-promotion
     "loyalty_initial_date_validity": "loyalty",
+    "sale_loyalty_initial_date_validity": "sale_loyalty",
     # OCA/social
     "mail_activity_plan": "mail",
     "mass_mailing_custom_unsubscribe_event": "mass_mailing",

--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -63,6 +63,8 @@ merged_modules = {
     "maintenance_plan_employee": "maintenance",
     # OCA/purchase-workflow
     "purchase_discount": "purchase",
+    # OCA/sale-promotion
+    "loyalty_initial_date_validity": "loyalty",
     # OCA/social
     "mail_activity_plan": "mail",
     "mass_mailing_custom_unsubscribe_event": "mass_mailing",


### PR DESCRIPTION
Merged into `loyalty` (https://github.com/odoo/odoo/blob/178cd38dfd08ea55582b3bd8642c835d6ab7784b/addons/loyalty/models/loyalty_program.py#L56)

Merged into `sale_loyalty` (https://github.com/odoo/odoo/blob/178cd38dfd08ea55582b3bd8642c835d6ab7784b/addons/sale_loyalty/models/sale_order.py#L464 + https://github.com/odoo/odoo/blob/178cd38dfd08ea55582b3bd8642c835d6ab7784b/addons/sale_loyalty/models/sale_order.py#L477)

@Tecnativa TT54445