### PR TITLE
[18.0][OU-FIX] stock: fill picking type default locations in end-migration

### DIFF
--- a/openupgrade_scripts/scripts/stock/18.0.1.1/end-migration.py
+++ b/openupgrade_scripts/scripts/stock/18.0.1.1/end-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2025 ForgeFlow S.L. (https://www.forgeflow.com)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from openupgradelib import openupgrade
+
+
+def fill_stock_picking_type_default_locations(env):
+    picking_types = env["stock.picking.type"].search(
+        [("default_location_src_id", "=", False)]
+    )
+    picking_types._compute_default_location_src_id()
+    picking_types = env["stock.picking.type"].search(
+        [("default_location_dest_id", "=", False)]
+    )
+    picking_types._compute_default_location_dest_id()
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    fill_stock_picking_type_default_locations(env)

--- a/openupgrade_scripts/scripts/stock/18.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/stock/18.0.1.1/post-migration.py
@@ -88,23 +88,11 @@ def _set_inter_company_locations(env):
             inter_company_location.sudo().write({"active": False})
 
 
-def fill_stock_picking_type_default_locations(env):
-    picking_types = env["stock.picking.type"].search(
-        [("default_location_src_id", "=", False)]
-    )
-    picking_types._compute_default_location_src_id()
-    picking_types = env["stock.picking.type"].search(
-        [("default_location_dest_id", "=", False)]
-    )
-    picking_types._compute_default_location_dest_id()
-
-
 @openupgrade.migrate()
 def migrate(env, version):
     convert_company_dependent(env)
     _create_default_new_types_for_all_warehouses(env)
     _set_inter_company_locations(env)
-    fill_stock_picking_type_default_locations(env)
     openupgrade.load_data(env, "stock", "18.0.1.1/noupdate_changes.xml")
     openupgrade.delete_records_safely_by_xml_id(
         env, ["stock.property_stock_customer", "stock.property_stock_supplier"]

--- a/openupgrade_scripts/scripts/stock/18.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/stock/18.0.1.1/upgrade_analysis_work.txt
@@ -48,7 +48,7 @@ stock        / stock.picking.type       / _order                        : _order
 
 stock        / stock.picking.type       / default_location_dest_id (many2one): now required
 stock        / stock.picking.type       / default_location_src_id (many2one): now required
-# DONE: post-migration: assured is filled by calling computes
+# DONE: end-migration: assured is filled by calling computes
 
 stock        / stock.picking.type       / favorite_user_ids (many2many) : NEW relation: res.users
 # NOTHING TO DO: new feature

--- a/openupgrade_scripts/scripts/stock/tests/test_migration.py
+++ b/openupgrade_scripts/scripts/stock/tests/test_migration.py
@@ -1,10 +1,13 @@
-from odoo.tests import TransactionCase
+import unittest
+
+from odoo.tests.common import TransactionCase
 
 from odoo.addons.openupgrade_framework import openupgrade_test
 
 
 @openupgrade_test
 class TestStockMigration(TransactionCase):
+    @unittest.skip("Should be executed at end-migration")
     def test_picking_type_required_fields(self):
         """Test that newly required fields are set"""
         for picking_type in self.env["stock.picking.type"].search([]):


### PR DESCRIPTION
Other modules like `stock_dropshipping` and `repair` customize the default.