### PR TITLE
[MIG] l10n_it_riba: Rename to l10n_it_riba_oca

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -56,7 +56,7 @@ renamed_modules = {
     # OCA/l10n-italy
     "assets_management": "l10n_it_asset_management",
     "l10n_it_account_balance_eu": "l10n_it_financial_statement_eu",
-    "l10n_it_ricevute_bancarie": "l10n_it_riba",
+    "l10n_it_ricevute_bancarie": "l10n_it_riba_oca",
     # OCA/...
 }
 


### PR DESCRIPTION
The existing module conflicts with a new module named exactly l10n_it_riba in Odoo Enterprise.

We are implementing the migration in https://github.com/OCA/l10n-italy/pull/4856, I will set this as ready for review when the linked PR is merged.