### PR TITLE
[16.0][OU-FIX] website: Exclude survey models from BS conversion

### DIFF
--- a/openupgrade_scripts/scripts/website/16.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/website/16.0.1.0/end-migration.py
@@ -45,6 +45,8 @@ def convert_field_html_string_bootstrap_4to5(env):
         "mailing.mailing",
         "account.invoice.send",
         "mail.alias",
+        "survey.survey",
+        "survey.question",
     ]
     # We could want to refine a certain field logic to discard a good bunch of records
     field_special_domain = {


### PR DESCRIPTION
They don't insert website blocks, and coming from non sanitized content, they can give an error.

@Tecnativa