### PR TITLE
[16.0][OU-FIX] website: Do BS conversion with sanitization override + Add website editors to sanitization override group

### DIFF
--- a/openupgrade_scripts/scripts/website/16.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/website/16.0.1.0/end-migration.py
@@ -57,6 +57,16 @@ def convert_field_html_string_bootstrap_4to5(env):
             ]
         },
     }
+    # Certain fields had sanitize=False or other sanitization disablings (like
+    # sanitize_attributes=False or sanitize_form=False), so when converting to BS 5,
+    # we should allow to save the result without re-sanitizing such content. For that,
+    # if the user is not on the sanitize overridable group, we add it, removing it after
+    # conversion
+    group_overridable = False
+    if not env.user._has_group("base.group_sanitize_override"):
+        group_overridable = env.ref("base.group_sanitize_override")
+        env.user.groups_id = [(4, group_overridable.id)]
+    # Search
     fields = env["ir.model.fields"].search(
         [
             ("ttype", "=", "html"),
@@ -75,6 +85,9 @@ def convert_field_html_string_bootstrap_4to5(env):
                     env.cr, env[model]._table, field.name
                 ):
                     convert_field_bootstrap_4to5(env, model, field.name, domain=domain)
+    # Remove the group if applicable
+    if group_overridable:
+        env.user.groups_id = [(3, group_overridable.id)]
 
 
 def rename_t_group_website_restricted_editor(env):

--- a/openupgrade_scripts/scripts/website/16.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website/16.0.1.0/post-migration.py
@@ -4,3 +4,9 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env.cr, "website", "16.0.1.0/noupdate_changes.xml")
+    # Website editors that come from v15, where there was no sanitization, would expect
+    # the same on the new version, or worst: they introduce some content like iframe,
+    # and re-editing that content in 16 leads to lose it when saving it. Thus, let's
+    # add all of them to the override sanitization group for keeping the same behavior.
+    users = env.ref("website.group_website_restricted_editor").users
+    users.groups_id = [(4, env.ref("base.group_sanitize_override").id)]


### PR DESCRIPTION
- Certain fields had sanitize=False or other sanitization disablings (like sanitize_attributes=False or sanitize_form=False), so when converting to BS 5, we should allow to save the result without re-sanitizing such content. For that, if the user is not on the sanitize overridable group, we add it, removing it after conversion.
- Website editors that come from v15, where there was no sanitization, would expect the same on the new version, or worst: they introduced some content like iframe in 15, and re-editing that content in 16 leads to lose it when saving it. Thus, let's add all of them to the override sanitization group for keeping the same behavior.

@Tecnativa