### PR TITLE
[18.0][OU-ADD] account_invoice_mass_sending: Merged into account

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -62,6 +62,7 @@ merged_modules = {
     "website_sale_product_configurator": "website_sale",
     # odoo/enterprise
     # OCA/account-invoicing
+    "account_invoice_mass_sending": "account",
     "account_invoice_supplierinfo_update_discount": "account_invoice_supplierinfo_update",  # noqa: E501
     # OCA/e-commerce
     "website_sale_product_attachment": "website_sale",


### PR DESCRIPTION
Merged into `account`

The [cron job](https://github.com/odoo/odoo/blob/7c95e2d3d6e55976abbafaa296378cb8ff44bef9/addons/account/data/service_cron.xml#L17C58-L17C67) "Send invoices automatically" already exists in the `account` and will automatically send pending invoices; therefore, you simply need to set the appropriate frequency for the cron job (every 5 minutes, for example).

Please @pedrobaeza can you review it?

@Tecnativa TT54853