### PR TITLE
[17.0][OU-IMP] web: web_pwa_customize compatibility

### DIFF
--- a/openupgrade_scripts/scripts/web/17.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/web/17.0.1.0/pre-migration.py
@@ -6,7 +6,8 @@ from openupgradelib import openupgrade
 
 @openupgrade.migrate()
 def migrate(env, version):
-    web_pwa_oca_installed = env["ir.config_parameter"].get_param("pwa.manifest.name")
+    ICP = env["ir.config_parameter"]
+    web_pwa_oca_installed = ICP.get_param("pwa.manifest.name")
     if web_pwa_oca_installed:
         openupgrade.rename_fields(
             env,
@@ -27,3 +28,17 @@ def migrate(env, version):
             WHERE key = 'pwa.manifest.name'
             """,
         )
+        # Deduce whether it is necessary to install web_pwa_customize based on the
+        # values previously defined in web_pwa_oca and the values that web will now use.
+        short_name = ICP.get_param("pwa.manifest.short_name")
+        background_color = ICP.get_param("pwa.manifest.background_color")
+        theme_color = ICP.get_param("pwa.manifest.theme_color")
+        if short_name or background_color != "#714B67" or theme_color != "#714B67":
+            openupgrade.logged_query(
+                env.cr,
+                """
+                UPDATE ir_module_module
+                SET state = 'to install'
+                WHERE name = 'web_pwa_customize'
+                """,
+            )


### PR DESCRIPTION
`web_pwa_customize` compatibility

If "custom" values (different from those used by web) were used, `web_pwa_customize` will be installed to maintain functionality.

PR proposed to Odoo to include this data: https://github.com/odoo/odoo/pull/187362

Locked by:
- [x] `web_pwa_customize`: https://github.com/OCA/web/pull/2986

Related to https://github.com/OCA/OpenUpgrade/pull/4660

Please @pedrobaeza can you review it?

@Tecnativa TT51658