### PR TITLE
[17.0][OU-FIX] l10n_es_dua: Remove XML-ID for "DUA compensación" product

### DIFF
--- a/openupgrade_scripts/scripts/l10n_es/17.0.5.4/pre-migration.py
+++ b/openupgrade_scripts/scripts/l10n_es/17.0.5.4/pre-migration.py
@@ -90,6 +90,17 @@ def _handle_dua_transition(env):
     record = env.ref("l10n_es.producto_dua_compensacion", False)
     if record:
         record.active = False
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM ir_model_data
+        WHERE module='l10n_es'
+        AND name IN (
+            'producto_dua_compensacion',
+            'producto_dua_compensacion_product_template'
+        )
+        """,
+    )
     # Tax groups
     imds = env["ir.model.data"].search(
         [


### PR DESCRIPTION
If not, the system tries to remove it being noupdate=0, and changing it to noupdate=1 is not worth, as that product is no longer needed.

@Tecnativa 