### PR TITLE
[18.0][FIX] openupgrade_framework: _process_ondelete skip fields without ondelete attribute

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_model.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_model.py
@@ -74,12 +74,18 @@ IrModelRelation._module_data_uninstall = _module_data_uninstall
 
 
 def _process_ondelete(self):
-    """Don't break on missing models when deleting their selection fields"""
+    """Don't break on missing models or wrong field types
+    when deleting their selection fields"""
     to_process = self.browse([])
     for selection in self:
         try:
-            self.env[selection.field_id.model]  # pylint: disable=pointless-statement
-            to_process += selection
+            model_name = selection.field_id.model
+            field = selection.field_id
+            # Validate that the model exists
+            # and that the field has an ondelete attribute
+            self.env[model_name]  # pylint: disable=pointless-statement
+            if hasattr(field, "ondelete"):
+                to_process += selection
         except KeyError:
             continue
     return IrModelSelection._process_ondelete._original_method(to_process)

--- a/openupgrade_scripts/scripts/hr_holidays/18.0.1.6/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_holidays/18.0.1.6/pre-migration.py
@@ -28,15 +28,6 @@ def refill_hr_leave_request_hours(env):
         WHERE {old_request_hour_to} IS NOT NULL;
         """,
     )
-    openupgrade.logged_query(
-        env.cr,  # to avoid AttributeError: 'Float' object has no attribute 'ondelete'
-        """
-        DELETE FROM ir_model_fields_selection imfs
-        USING ir_model_fields imf
-        WHERE imfs.field_id = imf.id AND imf.model = 'hr.leave'
-        AND imf.name in ('request_hour_from', 'request_hour_to')
-        """,
-    )
 
 
 def update_states(env):


### PR DESCRIPTION
## Context and Issue

In OCA/OpenUpgrade 18.0, the `openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_model.py` file overrides `_process_ondelete`. When it encounters a field without an `ondelete` attribute, it crashes:

AttributeError: 'Float' object has no attribute 'ondelete'

How to Reproduce

    Checkout branch 18.0 and install OpenUpgrade in Odoo 18.

    Run odoo --update=all on a database that triggers selection field deletion.

    Observe the above AttributeError.

CLA

I confirm that I have signed the OCA Contributor License Agreement.