### PR TITLE
[18.0][OU-FIX] mrp: Force attached_on_mrp on db insert

### DIFF
--- a/openupgrade_scripts/scripts/mrp/18.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/mrp/18.0.2.0/post-migration.py
@@ -18,9 +18,9 @@ def mrp_document_to_product_document(env):
         env.cr,
         f"""
         INSERT INTO product_document
-        (ir_attachment_id, active, sequence, {link_column})
+        (ir_attachment_id, active, sequence, {link_column}, attached_on_mrp)
         SELECT
-        ir_attachment_id, active, 10-COALESCE(priority, '0')::int, id
+        ir_attachment_id, active, 10-COALESCE(priority, '0')::int, id, 'hidden'
         FROM mrp_document
         """,
     )


### PR DESCRIPTION
When applying an DB INSERT INTO, default values are not considered.
Not adding attached_on_mrp end up failing.
As mention in https://github.com/OCA/OpenUpgrade/blob/18.0/openupgrade_scripts/scripts/mrp/18.0.2.0/upgrade_analysis_work.txt#L65C3-L65C132 defaulting to 'hidden'

CC @ForgeFlow @MiquelRForgeFlow @hbrunn 