### PR TITLE
[18.0][FIX] l10n_fr: typo on res.bank model

### DIFF
--- a/openupgrade_scripts/scripts/l10n_fr/18.0.2.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/l10n_fr/18.0.2.1/pre-migration.py
@@ -14,7 +14,7 @@ def migrate(env, version):
         WHERE module = 'l10n_fr' AND model IN (
             'account.account.tag', 'account.report', 'account.report.column',
             'account.report.expression', 'account.report.line',
-            'ir.config_parameter', 'res_bank')
+            'ir.config_parameter', 'res.bank')
         """,
     )
     openupgrade.logged_query(


### PR DESCRIPTION
Use res.bank iso res_bank in SQL command