### PR TITLE
[18.0][FIX] github workflow: cbor2 issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Requirements Installation
         run: |
           sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version == '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version == '3.10')/\12.0.2\2/" odoo/requirements.txt
+          sed -i -E "s/(^cbor2==)5\.4\.2/\15.6.2/" odoo/requirements.txt
           pip install -q -r odoo/requirements.txt
           pip install -r ./openupgrade/requirements.txt
           pip install -U git+https://github.com/oca/openupgradelib


### PR DESCRIPTION
```yml
WARNING: Requested cbor2==5.4.2 from https://files.pythonhosted.org/packages/d4/ca/b96be94f694155ce58823c38cf8fd1aa620bdc91e2c801713cdb4167b6aa/cbor2-5.4.2.tar.gz (from -r odoo/requirements.txt (line 8)), but installing version 0.0.0
ERROR: Ignored the following yanked versions: 5.4.4
ERROR: Could not find a version that satisfies the requirement cbor2==5.4.2 (from versions: 1.0.0, 1.1.0, 2.0.0, 3.0.0, 3.0.1, 3.0.2, 3.0.3, 3.0.4, 4.0.0, 4.0.1, 4.1.0, 4.1.1, 4.1.2, 5.0.0, 5.0.1, 5.1.0, 5.1.1, 5.1.2, 5.2.0, 5.2.0.post1, 5.3.0, 5.4.0, 5.4.1, 5.4.2, 5.4.2.post1, 5.4.3, 5.4.5, 5.4.6, 5.5.0, 5.5.1, 5.6.0, 5.6.1, 5.6.2, 5.6.3, 5.6.4, 5.6.5)
ERROR: No matching distribution found for cbor2==5.4.2
Error: Process completed with exit
```