### PR TITLE
[18.0][OU-FIX] mail: avoid crash when parameter mail.restrict.template.rendering already exists in the database

### DIFF
--- a/openupgrade_scripts/scripts/mail/18.0.1.18/pre-migration.py
+++ b/openupgrade_scripts/scripts/mail/18.0.1.18/pre-migration.py
@@ -20,6 +20,29 @@ field_renames = [
 ]
 
 
+def create_imd_entry_for_config_param(env):
+    """
+    If database has config parameter mail.restrict.template.rendering already
+    set, create an ir.model.data entry for it to avoid trying to create it a
+    second time
+    """
+    param = env["ir.config_parameter"].search(
+        [("key", "=", "mail.restrict.template.rendering")]
+    )
+    if param and not env.ref(
+        "mail.restrict_template_rendering", raise_if_not_found=False
+    ):
+        env["ir.model.data"].create(
+            {
+                "name": "restrict_template_rendering",
+                "module": "mail",
+                "model": param._name,
+                "res_id": param.id,
+                "noupdate": True,
+            }
+        )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_models(env.cr, model_renames)
@@ -34,3 +57,4 @@ def migrate(env, version):
             )
         ],
     )
+    create_imd_entry_for_config_param(env)


### PR DESCRIPTION
earlier versions allowed to set config parameter [mail.restrict.template.rendering](https://github.com/OCA/OCB/blob/17.0/addons/mail/models/res_config_settings.py#L27), but as the config wizard doesn't create an xmlid for it, Odoo will try to create a duplicate parameter in v18 (and crash) where this is set [by default](https://github.com/OCA/OCB/blob/18.0/addons/mail/data/ir_config_parameter_data.xml#L8)