### PR TITLE
[16.0][OU-IMP] base: Pre-create res.partner~company_registry

### DIFF
--- a/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
@@ -168,5 +168,7 @@ def migrate(cr, version):
         "USING ir_ui_view v "
         "WHERE r.view_id=v.id AND v.inherit_id IS NOT NULL AND v.mode != 'primary'"
     )
+    # pre-create res.partner~company_registry
+    openupgrade.logged_query(cr, "ALTER TABLE res_partner ADD company_registry VARCHAR")
     # update all translatable fields
     update_translatable_fields(cr)

--- a/openupgrade_scripts/scripts/base/16.0.1.3/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/upgrade_analysis_work.txt
@@ -28,7 +28,6 @@ base         / res.company              / active (boolean)              : NEW ha
 base         / res.company              / company_registry (char)       : not stored anymore
 base         / res.company              / company_registry (char)       : now related
 base         / res.company              / font (selection)              : selection_keys is now '['Lato', 'Montserrat', 'Open_Sans', 'Oswald', 'Raleway', 'Roboto', 'Tajawal']' ('['Lato', 'Montserrat', 'Open_Sans', 'Oswald', 'Raleway', 'Roboto']')
-base         / res.partner              / company_registry (char)       : NEW hasdefault: compute
 base         / res.partner              / credit_limit (float)          : module is now 'account' ('base')
 base         / res.partner              / credit_limit (float)          : not stored anymore
 base         / res.partner.bank         / allow_out_payment (boolean)   : NEW hasdefault: default
@@ -39,6 +38,9 @@ base         / res.users.deletion       / user_id (many2one)            : NEW re
 base         / res.users.deletion       / user_id_int (integer)         : NEW isfunction: function, stored
 
 # NOTHING TO DO
+
+base         / res.partner              / company_registry (char)       : NEW hasdefault: compute
+# DONE: pre-migration: Pre-create the field for not triggering the compute. Further modules scripts (right now only l10n_be and l10n_ro seems to override the method) have to include the computation, or trigger the computation on end-migration.
 
 ---XML records in module 'base'---
 DEL ir.actions.act_window: base.action_translation


### PR DESCRIPTION
This column is not calculated in the base module (see https://github.com/odoo/odoo/blob/9728a1754424b9e5bfa93ec5d53a5179fa9d7d05/odoo/addons/base/models/res_partner.py#L440) and wasting any time, specially when you have a lot of partners, it's useless, so let's pre-create it.

@Tecnativa 