### PR TITLE
[18.0][OU-FIX] point_of_sale: Prevent error when sale module is not installed

### DIFF
--- a/openupgrade_scripts/scripts/point_of_sale/18.0.1.0.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/point_of_sale/18.0.1.0.2/pre-migration.py
@@ -65,18 +65,10 @@ def migrate(env, version):
     openupgrade.add_columns(
         env,
         [
-            ("sale.order.line", "technical_price_unit", "float"),
             ("pos.order", "amount_difference", "float", None, "pos_order"),
             ("pos.order.line", "price_type", "selection", "original", "pos_order_line"),
             ("pos.printer", "company_id", "many2one", None, "pos_printer"),
         ],
-    )
-    openupgrade.logged_query(
-        env.cr,
-        """
-        UPDATE sale_order_line
-        SET technical_price_unit = price_unit
-        """,
     )
     openupgrade.logged_query(
         env.cr,


### PR DESCRIPTION
This case is already handled in the migration script of the sale module. See: https://github.com/OCA/OpenUpgrade/blob/8ff8356dda92caefb532c5a37f718dada0682c5d/openupgrade_scripts/scripts/sale/18.0.1.2/pre-migration.py#L21-L31

Complementary to https://github.com/OCA/OpenUpgrade/pull/5104

<img width="1042" height="323" alt="image" src="https://github.com/user-attachments/assets/9e983c36-1c81-4da9-9f21-97e92708e7cb" />

@Tecnativa @pedrobaeza @MiquelRForgeFlow could you please review this?