### PR TITLE
[16.0][OU-FIX] purchase_requisition: Proper order group creation (and global) + no delete

### DIFF
--- a/openupgrade_scripts/scripts/purchase_requisition/16.0.0.1/post-migration.py
+++ b/openupgrade_scripts/scripts/purchase_requisition/16.0.0.1/post-migration.py
@@ -1,10 +1,9 @@
-# Copyright 2024 Tecnativa - Pedro M. Baeza
+# Copyright 2024,2025 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
 
 
 def fill_purchase_order_group_from_tenders(env):
-    tender_type = env.ref("purchase_requisition.type_multi")
     openupgrade.logged_query(
         env.cr,
         """
@@ -12,60 +11,33 @@ def fill_purchase_order_group_from_tenders(env):
         ADD COLUMN IF NOT EXISTS old_purchase_requisition_id INTEGER
         """,
     )
+    # Create a group if there is more than one PO per requisition
     openupgrade.logged_query(
         env.cr,
-        f"""
-        INSERT INTO purchase_order_group (old_purchase_requisition_id,
-            create_date, create_uid, write_date, write_uid)
-        SELECT DISTINCT ON (pr.id) pr.id,
-            pr.create_date, pr.create_uid, pr.write_date, pr.write_uid
-        FROM purchase_requisition pr
-        JOIN purchase_order po1 ON po1.requisition_id = pr.id
-        JOIN purchase_order po2 ON po2.requisition_id = pr.id AND po1.id != po2.id
-        -- only create group if there is more than one purchase
-        WHERE pr.type_id = {tender_type.id}
-        RETURNING old_purchase_requisition_id
+        """
+        INSERT INTO purchase_order_group
+        (old_purchase_requisition_id, create_date, create_uid, write_date, write_uid)
+        SELECT
+            t.requisition_id, pr.create_date, pr.create_uid, pr.write_date, pr.write_uid
+        FROM (
+            SELECT *, row_number()
+            over (partition BY requisition_id ORDER BY id) AS rnum
+            FROM purchase_order
+        ) t
+        JOIN purchase_requisition pr ON pr.id = t.requisition_id
+        WHERE t.rnum = 2;
         """,
     )
-    tender_requisition_ids = [x[0] for x in env.cr.fetchall()]
-    if tender_requisition_ids:
-        openupgrade.logged_query(
-            env.cr,
-            """
-            UPDATE purchase_order po
-            SET purchase_group_id = pog.id
-            FROM purchase_order_group pog
-            WHERE po.requisition_id = pog.old_purchase_requisition_id
-            """,
-        )
+    # Assign it to the purchase orders
     openupgrade.logged_query(
         env.cr,
-        f"""
-            SELECT pr.id
-            FROM purchase_requisition pr
-            WHERE pr.type_id = {tender_type.id}
-            """,
+        """
+        UPDATE purchase_order po
+        SET purchase_group_id = pog.id
+        FROM purchase_order_group pog
+        WHERE po.requisition_id = pog.old_purchase_requisition_id
+        """,
     )
-    obsolete_requisition_ids = [x[0] for x in env.cr.fetchall()]
-    if obsolete_requisition_ids:
-        openupgrade.logged_query(
-            env.cr,
-            f"""
-            UPDATE purchase_order po
-            SET requisition_id = NULL
-            FROM purchase_requisition pr
-            WHERE po.requisition_id = pr.id AND pr.type_id = {tender_type.id}
-            """,
-        )
-        openupgrade.logged_query(
-            env.cr,
-            """
-            UPDATE purchase_requisition pr
-            SET state = 'draft'
-            WHERE pr.state not in ('draft', 'cancel')
-            """,
-        )
-        env["purchase.requisition"].browse(obsolete_requisition_ids).unlink()
 
 
 @openupgrade.migrate()

--- a/openupgrade_scripts/scripts/purchase_requisition/16.0.0.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/purchase_requisition/16.0.0.1/upgrade_analysis_work.txt
@@ -1,7 +1,7 @@
 new model purchase.order.group
 purchase_requisition / purchase.order           / purchase_group_id (many2one)  : NEW relation: purchase.order.group
 purchase_requisition / purchase.order.group     / order_ids (one2many)          : NEW relation: purchase.order
-# DONE: post-migration: group purchases by their requisition if it has the deleted type "purchase_requisition.type_multi"
+# DONE: post-migration: group purchases by their requisition if there's more than one PO per requisition
 
 new model purchase.requisition.alternative.warning [transient]
 new model purchase.requisition.create.alternative [transient]


### PR DESCRIPTION
The PO groups weren't created properly before, so the new query is doing the correct job, and doing it for all the requisitions, not only those of one type.

The previous code was also deleting all the requisitions of a deleted type, but doing that, apart from being partial, it's counter-productive, requiring a lot of work with no benefit, so let's keep them.

@Tecnativa 