### PR TITLE
[18.0][FIX] openupgrade_framework: Add decorator for method update_list() after overriding

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_module.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_module.py
@@ -1,10 +1,12 @@
 # Copyright Odoo Community Association (OCA)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from odoo import api
 
 from odoo.addons.base.models.ir_module import Module
 
 
+@api.model
 def update_list(self):
     """
     Mark auto_install modules as to install if all their dependencies are some kind of


### PR DESCRIPTION
**Issue:**
The `update_list()` method of the `ir.module.module` model in native Odoo includes the `@api.model decorator`. After overriding this method, the decorator was omitted, causing an error when the method was triggered via an XML file during the OpenUpgrade process.

**Steps to Reproduce:**

1. Create an XML file with the following content:

```xml
<odoo>
    <function model="ir.module.module" name="update_list" />
</odoo>
```


2. Run the OpenUpgrade command.

**Actual Result:**
During XML file loading, the following error is raised:
```bash
2025-08-23 07:14:51,952 29645 CRITICAL db-upgrade odoo.service.server: Failed to initialize database `db-upgrade`. 
Traceback (most recent call last):
  File "/opt/odoo/code/projects/odoo/odoo/tools/convert.py", line 544, in _tag_root
    f(rec)
  File "/opt/odoo/code/projects/odoo/odoo/tools/convert.py", line 261, in _tag_function
    _eval_xml(self, rec, env)
  File "/opt/odoo/code/projects/odoo/odoo/tools/convert.py", line 188, in _eval_xml
    return odoo.api.call_kw(model, method_name, args, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/odoo/code/projects/odoo/odoo/api.py", line 525, in call_kw
    ids, args = args[0], args[1:]
                ~~~~^^^
IndexError: list index out of range
```

**Expected Result:**
The update_list() method should execute successfully without raising errors when triggered via XML during OpenUpgrade.

**Root Cause:**
Missing @api.model decorator in the overridden update_list() method, causing Odoo’s call_kw to misinterpret arguments.