### PR TITLE
[16.0][OU-REM] Deleted 16.0 modules

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -131,6 +131,20 @@ merged_modules = {
     "web_tree_image_tooltip": "web",
 }
 
+# Deleted modules
+deleted_modules = [
+    # odoo
+    "google_drive",
+    "google_spreadsheet",
+    "l10n_it_edi_sdicoop",
+    "l10n_sa_invoice",
+    "payment_alipay",
+    "payment_ogone",
+    "payment_payulatam",
+    "payment_payumoney",
+    # OCA/...
+]
+
 # only used here for upgrade_analysis
 renamed_models = {
     # odoo


### PR DESCRIPTION
#5336

List from https://oca.github.io/OpenUpgrade/coverage_analysis/modules150-160.html when got X with no status