### PR TITLE
[17.0][OU-REM] Deleted 17.0 modules

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -83,6 +83,17 @@ merged_modules = {
     # OCA/...
 }
 
+# Deleted modules
+deleted_modules = [
+    # odoo
+    "l10n_ae_pos",
+    "l10n_it_edi_pa",
+    "l10n_lu_peppol_id",
+    "l10n_pl_jpk",
+    "website_payment_paypal",
+    # OCA/...
+]
+
 # only used here for upgrade_analysis
 renamed_models = {
     # odoo


### PR DESCRIPTION
#5336

List from https://oca.github.io/OpenUpgrade/coverage_analysis/modules160-170.html when got X with no status