### PR TITLE
[18.0][OU-REM] Deleted 18.0 modules

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -2,6 +2,16 @@
 to help the matching process
 """
 
+# Deleted modules
+deleted_modules = [
+    # odoo
+    "pos_mercury",
+    "spreadsheet_dashboard_purchase",
+    "spreadsheet_dashboard_purchase_stock",
+    "website_twitter",
+    # OCA/...
+]
+
 # Renamed modules is a mapping from old module name to new module name
 renamed_modules = {
     # odoo


### PR DESCRIPTION
#5336

List from https://oca.github.io/OpenUpgrade/coverage_analysis/modules170-180.html when got X with no status