### PR TITLE
[17.0][OU-ADD] web_editor: Migration scripts for 17.0

### DIFF
--- a/openupgrade_scripts/scripts/web_editor/17.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/web_editor/17.0.1.0/post-migration.py
@@ -1,0 +1,17 @@
+from openupgradelib import openupgrade
+
+
+def convert_assets(env):
+    for asset in env["ir.asset"].search([("path", "like", ".custom.")]):
+        path_1, extra = asset.path.split(".custom.", 1)
+        bundle_1, bundle_2, path_2 = extra.split(".", 2)
+        path = f"{path_1}.{path_2}"
+        bundle = f"{bundle_1}.{bundle_2}"
+        new_path = f"/_custom/{bundle}{path}"
+        env["ir.attachment"].search([("url", "=", asset.path)]).write({"url": new_path})
+        asset.write({"path": new_path})
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    convert_assets(env)


### PR DESCRIPTION
On 17, the way of handling edition of assets changed.

We need to modify the values in order to allow edition (migration was not failing, but it raised errors if we want to make a change of colors for example)

https://github.com/odoo/odoo/blob/17.0/addons/web_editor/models/assets.py#L172-L185

https://github.com/odoo/odoo/blob/16.0/addons/web_editor/models/assets.py#L172-L186