### PR TITLE
[18.0][MIG] spreadsheet_dashboard_purchase -> spreadsheet_dashboard_purchase_oca

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -7,6 +7,7 @@ renamed_modules = {
     # odoo
     "l10n_es_pos_tbai": "l10n_es_edi_tbai_pos",
     "mrp_subonctracting_landed_costs": "mrp_subcontracting_landed_costs",
+    "spreadsheet_dashboard_purchase": "spreadsheet_dashboard_purchase_oca",
     "website_sale_picking": "website_sale_collect",
     "website_form_project": "website_project",
     # odoo/enterprise

--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -8,6 +8,7 @@ renamed_modules = {
     "l10n_es_pos_tbai": "l10n_es_edi_tbai_pos",
     "mrp_subonctracting_landed_costs": "mrp_subcontracting_landed_costs",
     "spreadsheet_dashboard_purchase": "spreadsheet_dashboard_purchase_oca",
+    "spreadsheet_dashboard_purchase_stock": "spreadsheet_dashboard_purchase_stock_oca",
     "website_sale_picking": "website_sale_collect",
     "website_form_project": "website_project",
     # odoo/enterprise


### PR DESCRIPTION
Supersedes https://github.com/OCA/OpenUpgrade/pull/5347.

Handles https://github.com/OCA/spreadsheet/pull/67.