### PR TITLE
[18.0][web_tour] Obsolete security rules block login after migration

### DIFF
--- a/openupgrade_scripts/scripts/web_tour/18.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/web_tour/18.0.1.0/end-migration.py
@@ -4,7 +4,8 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version=None):
     """
-    Set consumed tours from legacy table after migration
+    Set consumed tours from legacy table after migration and
+    remove obsolete security rules.
     """
     openupgrade.logged_query(
         env.cr,
@@ -17,5 +18,16 @@ def migrate(env, version=None):
         web_tour_tour
         WHERE web_tour_tour.name=legacy_table.name
         ON CONFLICT DO NOTHING
+        """,
+    )
+
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM ir_rule
+        WHERE model_id = (
+            SELECT id FROM ir_model WHERE model = 'web_tour.tour'
+        )
+        AND domain_force LIKE '%user_id%';
         """,
     )


### PR DESCRIPTION
Impacted versions:
- OpenUpgrade 18.0
- Module web_tour

Steps to reproduce:
1. Migrate a DB from 17.0 to 18.0 with `web_tour` installed.
2. After migration, login fails due to obsolete security rules for model `web_tour.tour`.

Current behavior:
- Login blocked after migration.

Expected behavior:
- Obsolete security rules should be removed during `end-migration.py`.

Proposed fix:
- Update `openupgrade_scripts/scripts/web_tour/18.0.1.0/end-migration.py` to drop security rules for model `web_tour.tour`.

@openupgrade.migrate()
def migrate(env, version=None):
    """
    Set consumed tours from legacy table after migration and
    remove obsolete security rules.
    """
    openupgrade.logged_query(
        env.cr,
        f"""
        INSERT INTO res_users_web_tour_tour_rel
        (res_users_id, web_tour_tour_id)
        SELECT legacy_table.user_id, web_tour_tour.id
        FROM
        {openupgrade.get_legacy_name('web_tour_tour')} legacy_table,
        web_tour_tour
        WHERE web_tour_tour.name=legacy_table.name
        ON CONFLICT DO NOTHING
        """,
    )

    openupgrade.logged_query(
        env.cr,
        """
        DELETE FROM ir_rule
        WHERE model_id = (
            SELECT id FROM ir_model WHERE model = 'web_tour.tour'
        )
        AND domain_force LIKE '%user_id%';
        """,
    )

