### PR TITLE
[18.0][OU-FIX] hr_holidays: rename private_name to name throw an error

### DIFF
--- a/openupgrade_scripts/scripts/hr_holidays/18.0.1.6/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_holidays/18.0.1.6/pre-migration.py
@@ -174,6 +174,8 @@ def split_employee_leaves(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
+    if openupgrade.column_exists(env.cr, "hr_leave_allocation", "name"):  # from 13.0
+        openupgrade.rename_columns(env.cr, {"hr_leave_allocation": [("name", False)]})
     openupgrade.rename_columns(env.cr, _column_renames)
     openupgrade.add_columns(env, _column_adds)
     refill_hr_leave_request_hours(env)


### PR DESCRIPTION
In 17.0 exists private_name and name