### PR TITLE
[17.0][OU-FIX] account: Avoid the error when executing the migrate_translations_to_jsonb method

### DIFF
--- a/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Viindoo Technology Joint Stock Company (Viindoo)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from openupgradelib import openupgrade
+from openupgradelib import openupgrade, openupgrade_160
 
 from odoo import models
 
@@ -558,6 +558,15 @@ def _rename_coa_elements_xmlids(env):
         )
 
 
+def _convert_account_tax_description(env):
+    # Deliberately call migrate_translations_to_jsonb instead of
+    # convert_column_translatable to support the case you have translate=True on
+    # the field in v16 (l10n_multilang compatibility).
+    openupgrade_160.migrate_translations_to_jsonb(
+        env, [("account.tax", "invoice_label")]
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     _account_payment_term_migration(env)
@@ -583,3 +592,4 @@ def migrate(env, version):
     _map_chart_template_id_to_chart_template(env, "res_company")
     _map_chart_template_id_to_chart_template(env, "account_report")
     _rename_coa_elements_xmlids(env)
+    _convert_account_tax_description(env)

--- a/openupgrade_scripts/scripts/account/17.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/pre-migration.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Viindoo Technology Joint Stock Company (Viindoo)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-from openupgradelib import openupgrade, openupgrade_160
+from openupgradelib import openupgrade
 
 _fields_renames = [
     (
@@ -70,12 +70,6 @@ def _generic_coa_rename_xml_id(env):
 def _convert_account_tax_description(env):
     openupgrade.rename_columns(
         env.cr, {"account_tax": [("description", "invoice_label")]}
-    )
-    # Deliberately call migrate_translations_to_jsonb instead of
-    # convert_column_translatable to support the case you have translate=True on
-    # the field in v16 (l10n_multilang compatibility).
-    openupgrade_160.migrate_translations_to_jsonb(
-        env, [("account_tax", "invoice_label")]
     )
 
 


### PR DESCRIPTION
Avoid the error when executing the migrate_translations_to_jsonb method

Related to https://github.com/OCA/OpenUpgrade/pull/5355

Fixes #5368 

Please @pedrobaeza and @hbrunn can you review it?

@Tecnativa