### PR TITLE
[18.0][OU-FIX] account: safe account_lock check

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
@@ -19,7 +19,8 @@ def handle_lock_dates(env):
         WHERE name = 'account_lock'
         """
     )
-    account_lock_state = env.cr.fetchone()[0]
+    row = env.cr.fetchone()
+    account_lock_state = row and row[0] or ""
     if account_lock_state == "installed":
         openupgrade.logged_query(
             env.cr,


### PR DESCRIPTION
The query may not return results, giving:

```
  File ".../scripts/account/18.0.1.3/post-migration.py", line 157, in migrate
    handle_lock_dates(env)
  File ".../scripts/account/18.0.1.3/post-migration.py", line 22, in handle_lock_dates
    account_lock_state = env.cr.fetchone()[0]
TypeError: 'NoneType' object is not subscriptable
```

@Tecnativa 