### PR TITLE
[18.0][IMP] add a github workflow that generates test databases used in CI

### DIFF
--- a/.github/workflows/generate-testdb-cron.yml
+++ b/.github/workflows/generate-testdb-cron.yml
@@ -1,0 +1,40 @@
+name: Generate test databases - cron and manually
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        type: choice
+        options:
+        - all
+        - 16.0
+        - 17.0
+        - 18.0
+  schedule:
+    # every first of month
+    - cron: "0 4 1 * *"
+
+jobs:
+  generate-testdb18:
+    name: Generate test database 18.0
+    if: (github.repository == 'OCA/OpenUpgrade' && github.event_name == 'schedule') || inputs.version == '18.0' || inputs.version == 'all'
+    uses: ./.github/workflows/generate-testdb.yml
+    with:
+      version: "18.0"
+      exclude_modules: "['payment_alipay', 'payment_ogone', 'payment_payulatam', 'payment_payumoney']"
+  generate-testdb17:
+    name: Generate test database 17.0
+    if: (github.repository == 'OCA/OpenUpgrade' && github.event_name == 'schedule') || inputs.version == '17.0' || inputs.version == 'all'
+    uses: ./.github/workflows/generate-testdb.yml
+    with:
+      version: "17.0"
+      exclude_modules: "['payment_alipay', 'payment_ogone', 'payment_payulatam', 'payment_payumoney']"
+  generate-testdb16:
+    name: Generate test database 16.0
+    if: (github.repository == 'OCA/OpenUpgrade' && github.event_name == 'schedule') || inputs.version == '16.0' || inputs.version == 'all'
+    uses: ./.github/workflows/generate-testdb.yml
+    with:
+      version: "16.0"
+      exclude_modules: "['payment_alipay', 'payment_ogone', 'payment_payulatam', 'payment_payumoney']"

--- a/.github/workflows/generate-testdb.yml
+++ b/.github/workflows/generate-testdb.yml
@@ -1,0 +1,76 @@
+name: Generate test database
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      python_version:
+        default: "3.10"
+        type: string
+      postgres_version:
+        default: "14"
+        type: string
+      exclude_modules:
+        default: "[]"
+        type: string
+      release_tag:
+        default: "databases"
+        type: string
+jobs:
+  generate-testdb:
+    name: Generate test database ${{ inputs.version }}
+    runs-on: ubuntu-22.04
+    container: ghcr.io/oca/oca-ci/py${{ inputs.python_version }}-ocb${{ inputs.version }}:latest
+    env:
+      PGHOST: "postgres"
+      PGPASSWORD: "odoo"
+      PGUSER: "odoo"
+      VERSION: "${{ inputs.version }}"
+      DBNAME: "openupgrade"
+    services:
+      postgres:
+        image: postgres:${{ inputs.postgres_version }}
+        env:
+          POSTGRES_USER: odoo
+          POSTGRES_PASSWORD: odoo
+        ports:
+          - 5432:5432
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install extra dependencies
+        run: |
+          # this is for l10n_eg_edi_eta which crashes without it
+          pip install asn1crypto
+          # this is for cloud_storage_google
+          pip install google-auth
+          # this is for account_peppol
+          pip install phonenumbers
+          # for pushing release
+          apt install gh -y
+      - name: Install all modules and an extra language
+        run: |
+          odoo -d $DBNAME -i base --stop-after-init
+          odoo shell -d $DBNAME <<EOF
+          # be sure attachments go into the database
+          env['ir.config_parameter'].set_param('ir_attachment.location', 'db')
+          env['ir.attachment'].force_storage()
+          env['ir.module.module'].search([
+              ('name', 'not in', ${{ inputs.exclude_modules }}),
+              ('name', 'not ilike', 'test_%'),
+              ('name', 'not ilike', 'hw_%'),
+          ]).button_immediate_install()
+          env.cr.commit()
+          EOF
+          odoo -d $DBNAME --load-language=fr_FR --stop-after-init
+      - name: Dump database
+        run: |
+          pg_dump $DBNAME -Fc -f $VERSION.psql
+      - name: Upload database dump to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config --global --add safe.directory $(pwd)
+          gh release upload ${{ inputs.release_tag }} $VERSION.psql --clobber


### PR DESCRIPTION
In https://github.com/OCA/OpenUpgrade/issues/5370 I claimed that https://github.com/OCA/OpenUpgrade/pull/5355 not failing in CI is because the test databases don't include translations, but that's wrong. Anyways, I spent the morning writing this workflow to have tests databases regenerated regularly, that's a good thing to have in its own right, as there are relevant changes from time to time which might break existing scripts.

You can inspect the results in https://github.com/hbrunn/OpenUpgrade/releases/tag/databases

- [ ] update https://github.com/OCA/OpenUpgrade/blob/documentation/docsource/100_maintain_repository.rst to point to this workflow instead of a non-existing wiki page

Fixes #5370