### PR TITLE
[17.0][OU-IMP] maintenance: Compatibility with maintenance_plan

### DIFF
--- a/openupgrade_scripts/scripts/maintenance/17.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/maintenance/17.0.1.0/pre-migration.py
@@ -1,6 +1,22 @@
-# Copyright 2024 Tecnativa - Víctor Martínez
+# Copyright 2024-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from openupgradelib import openupgrade
+
+
+def _maintenance_plan(env):
+    """Rename the fields if the maintenance_plan module was installed."""
+    if openupgrade.column_exists(env.cr, "maintenance_request", "note"):
+        openupgrade.rename_fields(
+            env,
+            [
+                (
+                    "maintenance.request",
+                    "maintenance_request",
+                    "note",
+                    "instruction_text",
+                ),
+            ],
+        )
 
 
 def _maintenance_request_company_id(env):
@@ -34,3 +50,4 @@ def _maintenance_request_company_id(env):
 @openupgrade.migrate()
 def migrate(env, version):
     _maintenance_request_company_id(env)
+    _maintenance_plan(env)


### PR DESCRIPTION
Compatibility with `maintenance_plan`

If the `note` field already exists in `maintenance.request` (https://github.com/OCA/maintenance/blob/737814f92df2ab795cc8645b308a84c81b302bc0/maintenance_plan/models/maintenance_request.py#L19C5-L19C9), it must be renamed to the `instruction_text` field in core (https://github.com/odoo/odoo/blob/757e8aac673f5d5546d3e79bc156409671eb7191/addons/maintenance/models/maintenance.py#L256C5-L256C21).

Please @pedrobaeza can you review it?

@Tecnativa TT58142