### PR TITLE
[18.0][IMP] analysis cronjob v19 + improvements

### DIFF
--- a/.github/workflows/generate-analysis-cron.yml
+++ b/.github/workflows/generate-analysis-cron.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   generate-analysis18:
+    name: Generate analysis 18.0
     if: |
       github.repository == 'OCA/OpenUpgrade' && (github.event_name == 'schedule' || github.ref_name == '18.0') ||
       github.event_name == 'workflow_dispatch' && (inputs.version == '18.0' || inputs.version == 'all')
@@ -28,3 +29,12 @@ jobs:
     with:
       from_version: "17.0"
       to_version: "18.0"
+  generate-analysis19:
+    name: Generate analysis 19.0
+    if: |
+      github.repository == 'OCA/OpenUpgrade' && (github.event_name == 'schedule' || github.ref_name == '19.0') ||
+      github.event_name == 'workflow_dispatch' && (inputs.version == '19.0' || inputs.version == 'all')
+    uses: ./.github/workflows/generate-analysis.yml
+    with:
+      from_version: "18.0"
+      to_version: "19.0"

--- a/.github/workflows/generate-analysis-cron.yml
+++ b/.github/workflows/generate-analysis-cron.yml
@@ -8,10 +8,22 @@ on:
   schedule:
     # every monday at 04:00
     - cron: "0 4 * * 1"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        required: true
+        type: choice
+        options:
+        - all
+        - 18.0
+        - 19.0
 
 jobs:
   generate-analysis18:
-    if: github.repository == 'OCA/OpenUpgrade' && (github.event_name == 'schedule' || github.ref_name == '18.0')
+    if: |
+      github.repository == 'OCA/OpenUpgrade' && (github.event_name == 'schedule' || github.ref_name == '18.0') ||
+      github.event_name == 'workflow_dispatch' && (inputs.version == '18.0' || inputs.version == 'all')
     uses: ./.github/workflows/generate-analysis.yml
     with:
       from_version: "17.0"

--- a/.github/workflows/generate-analysis.yml
+++ b/.github/workflows/generate-analysis.yml
@@ -194,7 +194,9 @@ jobs:
           " > "$PR_BODY"
 
           for module in $(
-            git -C $OPENUPGRADE_DIR status --short | awk '{print $2}' | awk -F/ '{print $3}' | sort -u
+            git -C $OPENUPGRADE_DIR status --short | awk '{print $2}' |\
+            grep --invert-match upgrade_general_log.txt |\
+            awk -F/ '{print $3}' | sort -u
           ); do
             if grep -qE "\<$module\>.*\<((Done)|(No))" $OPENUPGRADE_DIR/docsource/modules*; then
               echo Done module $module was updated

--- a/.github/workflows/generate-analysis.yml
+++ b/.github/workflows/generate-analysis.yml
@@ -101,6 +101,8 @@ jobs:
           pip install -r openupgrade-$FROM_VERSION/requirements.txt
           # this is for l10n_eg_edi_eta which crashes without it
           pip install asn1crypto
+          # this is for cloud_storage_google
+          pip install google-auth
           odoo -s -c odoo-$FROM_VERSION.cfg --addons-path server-tools-$FROM_VERSION,openupgrade-$FROM_VERSION --stop-after-init
       - name: Install current Odoo
         run: |


### PR DESCRIPTION
this needs to go into the v18 branch because cronjobs only run on the default branch.

While being at it, I added the possibility to run this manually and to not flag the base module as changed when only the upgrade_general_log.txt file has changed.

It's fine to merge this now, but the v19 analysis will only work when:

- [x] https://github.com/OCA/server-tools/pull/3395 is merged
- [x] https://github.com/OCA/repo-maintainer-conf/pull/113 is merged and a yet to be created PR has added the empty openupgrade_scripts module