### PR TITLE
[16.0][FIX] Crash when company_registry already exists on res_partner

### DIFF
--- a/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/16.0.1.3/pre-migration.py
@@ -169,6 +169,8 @@ def migrate(cr, version):
         "WHERE r.view_id=v.id AND v.inherit_id IS NOT NULL AND v.mode != 'primary'"
     )
     # pre-create res.partner~company_registry
-    openupgrade.logged_query(cr, "ALTER TABLE res_partner ADD company_registry VARCHAR")
+    openupgrade.logged_query(
+        cr, "ALTER TABLE res_partner ADD IF NOT EXISTS company_registry VARCHAR"
+    )
     # update all translatable fields
     update_translatable_fields(cr)


### PR DESCRIPTION
The bug happens when the module l10n_fr_siret from OCA/l10n-france is already installed because this module defines a field company_registry on res_partner in v15 cf https://github.com/OCA/l10n-france/blob/15.0/l10n_fr_siret/models/res_partner.py#L128