### PR TITLE
[UPD] adapt to new cronjobs, simplify branch initialization

### DIFF
--- a/docsource/100_maintain_repository.rst
+++ b/docsource/100_maintain_repository.rst
@@ -6,6 +6,8 @@ The following documentation is for OpenUpgrade Maintainers.
 Set up the branch for a new Odoo release
 ----------------------------------------
 
+Wait until the new branch was created via an entry in https://github.com/OCA/repo-maintainer-conf, then run the following script:
+
 .. literalinclude:: maintainer_scripts/setup_new_branch.sh
   :language: shell
 
@@ -18,16 +20,12 @@ Manual changes
 
 * Run the module migration, see https://github.com/OCA/OpenUpgrade/wiki/Crude-script-to-create-the-full-analysis-between-two-versions-of-Odoo. Run with Odoo configuration option module_coverage_file_folder = <some folder>.
 
-* On success, propose the migration of ``upgrade_analysis`` into server-tools, and the analysis files into ``openupgrade_scripts``.
+* Add the coverage file from the step above (e.g. docsource/modules170-180.rst)
 
-* Add a coverage file (e.g. docsource/modules170-180.rst)
+* On success, propose the migration of ``upgrade_analysis`` into server-tools
 
-* In the ``OpenUpgrade``/``documentation`` branch, add a new line in ``build_openupgrade_docs``.
+* PR adding a job for the new version in ``.github/workflows/generate-analysis-cron.yml`` on the current default branch of OpenUpgrade
 
-* Push a test database for the old release to GitHub (see https://github.com/OCA/OpenUpgrade/wiki/How-to-create-a-reference-database)
+* PR adding a job for the new version in ``.github/workflows/generate-testdb-cron.yml`` on the current default branch of OpenUpgrade
 
 * Execute the technical migration of ``openupgrade_framework``.
-
-* Check files in .github/workflows for any required changes.
-
-* Once development starts on the new edition's migration scripts, change the default branch for new PRs at https://github.com/OCA/OpenUpgrade/settings/branches.

--- a/docsource/maintainer_scripts/setup_new_branch.sh
+++ b/docsource/maintainer_scripts/setup_new_branch.sh
@@ -1,8 +1,11 @@
+#!/bin/bash
+set -e
 # Configuration
-export PREV=16.0 OLD=17.0 NEW=18.0
+export PREV=17.0 OLD=18.0 NEW=19.0
 
 git clone https://github.com/OCA/OpenUpgrade --single-branch -b $OLD
 cd OpenUpgrade
+git fetch origin $NEW:$NEW
 
 NODOTPREV=${PREV/\./}         # e.g. 16.0 -> 160
 NODOTDOLD=${OLD/\./}          # e.g. 17.0 -> 170
@@ -10,45 +13,40 @@ NODOTNEW=${NEW/\./}           # e.g. 18.0 -> 180
 ESCAPEDPREV=${PREV/\./\\\.}   # e.g. 16.0 -> 16\.0
 ESCAPEDOLD=${OLD/\./\\\.}     # e.g. 17.0 -> 17\.0
 
-# Create a new empty branch
-git checkout --orphan $NEW
-git rm -rf .
-git commit --allow-empty --no-verify -m "[INIT] $NEW: Initialize branch"
-git push origin $NEW
-
 # Create a dedicated branch
-git checkout -b $NEW-initialize
+git checkout $NEW -b $NEW-initialize
 
-# Recover all the code from the old branch,
-# - Remove coverage docsource file from old version
-# - openupgrade_framework will be migrated in a future PR.
-# - Remove scripts from old version
+# Recover code from the old branch:
+# - bare openupgrade_scripts
+# - openupgrade-specific github actions
 git format-patch --keep-subject --stdout $NEW..$OLD -- \
-    ':!docsource' \
-    ':!openupgrade_framework' \
+    openupgrade_scripts \
     ':!openupgrade_scripts/scripts' \
     ':!openupgrade_scripts/apriori.py' \
+    .github \
+    ':!.github/workflows/pre-commit.yml' \
+    ':!.github/workflows/stale.yml' \
+    ':!.github/workflows/test.yml' \
+    .prettierignore \
 | git am -3 --keep
 
 # Replace No-Dot Syntax (140, 150, ...)
-sed -i "s/$NODOTDOLD/$NODOTNEW/g" .github/workflows/*
-sed -i "s/$NODOTPREV/$NODOTDOLD/g" .github/workflows/*
+sed -i "s/$NODOTDOLD/$NODOTNEW/g" .github/workflows/{documentation-commit.yml,test-migration.yml}
+sed -i "s/$NODOTPREV/$NODOTDOLD/g" .github/workflows/{documentation-commit.yml,test-migration.yml}
 
-# Replace Doted Syntax (14.0, 15.0, ...)
+# Replace Dotted Syntax (14.0, 15.0, ...)
 sed -i "s/$ESCAPEDOLD/$NEW/g" \
-    .github/workflows/* \
-    .pylintrc* \
-    README.md \
+    .github/workflows/{documentation-commit.yml,test-migration.yml} \
     openupgrade_scripts/readme/*
 
 # Reset version in manifest file
-sed -i "s/17\.0\(\.[[:digit:]]\)\{3\}/$NEW\.1\.0\.0/g" openupgrade_scripts/__manifest__.py
+sed -i "s/$ESCAPEDOLD\(\.[[:digit:]]\)\{3\}/$NEW\.1\.0\.0/g" openupgrade_scripts/__manifest__.py
 
 sed -i "s/$ESCAPEDPREV/$OLD/g" \
-    .github/workflows/* \
+    .github/workflows/{documentation-commit.yml,test-migration.yml} \
     openupgrade_scripts/readme/*
 
-git commit -am "[INIT] $NEW: Replace version numbers." --no-verify
+git commit -am "[UPD] $NEW: Replace version numbers." --no-verify
 
 # Initialize apriori.py file
 cat << EOF > ./openupgrade_scripts/apriori.py
@@ -87,3 +85,7 @@ EOF
 
 git add ./openupgrade_scripts/apriori.py
 git commit -am "[INIT] $NEW: Initialize apriori.py file." --no-verify
+
+pre-commit run -a || pre-commit run -a
+git add .
+git commit -am "[FIX] $NEW: pre-commit"


### PR DESCRIPTION
as I propose to make OpenUpgrade behave more like a standard OCA repo, here the changes coming with this, and also I propose to rely on the cronjobs for unpleasant work.

Note that the script won't run for 18.0 because I renamed the test.yml file, if you want to test the script, add

```bash
FILTER_BRANCH_SQUELCH_WARNING=1 git filter-branch --tree-filter '[ -f .github/workflows/test.yml ] && mv .github/workflows/test.yml .github/workflows/test-migration.yml || true' 18.0
```

after line 7, that's what I did