### PR TITLE
[18.0][OU-FIX] hr_holidays: do not duplicate multi employee leaves

### DIFF
--- a/openupgrade_scripts/scripts/hr_holidays/18.0.1.6/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_holidays/18.0.1.6/pre-migration.py
@@ -51,7 +51,7 @@ def update_states(env):
         env.cr,
         """
         UPDATE hr_leave_allocation
-        SET state = 'cancel'
+        SET state = 'refuse'
         WHERE active IS DISTINCT FROM TRUE
         """,
     )
@@ -77,7 +77,26 @@ def update_allocation_validation_type(env):
 
 
 def split_employee_leaves(env):
+    """
+    Confirmed leave or allocation already have duplicated leave for each employee
+    Since multi employee leave / allocation are not allowed anymore,
+    these should be removed
+    Draft (= 'confirm' state) are the only ones which have not yet
+    been duplicated and therefore should be transformed
+    """
     for table in ["hr_leave", "hr_leave_allocation"]:
+        # First remove all multi-employee leaves / allocations
+        # already confirmed or refused
+        openupgrade.logged_query(
+            env.cr,
+            f"""
+            DELETE FROM {table}
+            WHERE state IN ('refuse', 'validate1', 'validate', 'cancel') AND (
+                (holiday_type = 'employee' AND multi_employee)
+                OR holiday_type IN ('company', 'category', 'department'))
+            """,
+        )
+        # Then for the remaining ones we transform existing data for each employee
         env.cr.execute(
             f"""
             SELECT column_name
@@ -106,7 +125,7 @@ def split_employee_leaves(env):
             SELECT leave.id, 'company', array_agg(he.id) as employee_ids
             FROM {table} AS leave
             JOIN hr_employee he ON he.company_id = leave.mode_company_id
-            WHERE leave.holiday_type = 'company'
+            WHERE leave.holiday_type = 'company' and he.active = True
             GROUP BY leave.id
             """
         )
@@ -117,7 +136,8 @@ def split_employee_leaves(env):
             SELECT leave.id, 'category', array_agg(rel.employee_id) as employee_ids
             FROM {table} AS leave
             JOIN employee_category_rel rel ON rel.category_id = leave.category_id
-            WHERE leave.holiday_type = 'category'
+            JOIN hr_employee he ON he.id = rel.employee_id
+            WHERE leave.holiday_type = 'category' and he.active = True
             GROUP BY leave.id
             """
         )
@@ -128,7 +148,7 @@ def split_employee_leaves(env):
             SELECT leave.id, 'department', array_agg(he.id) as employee_ids
             FROM {table} AS leave
             JOIN hr_employee he ON he.department_id = leave.department_id
-            WHERE leave.holiday_type = 'department'
+            WHERE leave.holiday_type = 'department' and he.active = True
             GROUP BY leave.id
             """
         )

--- a/openupgrade_scripts/scripts/hr_holidays/18.0.1.6/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/hr_holidays/18.0.1.6/upgrade_analysis_work.txt
@@ -24,7 +24,7 @@ hr_holidays  / hr.leave                 / parent_id (many2one)          : DEL re
 hr_holidays  / hr.leave.allocation      / parent_id (many2one)          : DEL relation: hr.leave.allocation
 hr_holidays  / hr.leave                 / employee_id (many2one)        : now required
 hr_holidays  / hr.leave.allocation      / employee_id (many2one)        : now required
-# DONE: pre-migration: split leaves, one for each employee
+# DONE: pre-migration: split leaves / allocations, one for each employee (only for draft leaves / allocations)
 
 hr_holidays  / hr.leave                 / report_note (text)            : DEL
 # NOTHING TO DO: deprecated (https://github.com/odoo/odoo/commit/ca34732081b1ce6c339dd941abb9696861d95878)
@@ -39,7 +39,7 @@ hr_holidays  / hr.leave                 / active (boolean)              : DEL
 hr_holidays  / hr.leave.allocation      / active (boolean)              : DEL
 hr_holidays  / hr.leave                 / state (selection)             : selection_keys added: [cancel], removed: [draft]
 hr_holidays  / hr.leave.allocation      / state (selection)             : selection_keys added: [validate1] (most likely nothing to do)
-# DONE: pre-migration: set state = 'cancel' if archived. Also, 'draft' set to 'confirm' for leaves
+# DONE: pre-migration: set state = 'cancel' for leaves / 'refuse' for allocations if archived. Also, 'draft' set to 'confirm' for leaves
 
 hr_holidays  / hr.leave.accrual.level   / accrual_validity (boolean)    : NEW
 hr_holidays  / hr.leave.accrual.level   / accrual_validity_count (integer): NEW hasdefault: default


### PR DESCRIPTION
Multi-employee leaves and allocations once validated already created duplicate leave / allocation for each employee.
Current script by rewriting multi-employee leave / allocation to final employees was creating duplicate leave / allocation causing all leave counters to be wrong.

The duplication is only done in case leave / allocation is in 'to approve' state, otherwise the multi-employee leave / allocation is deleted.