### PR TITLE
[18.0][OU-FIX] account: drop account_root view

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/pre-migration.py
@@ -42,6 +42,15 @@ _new_columns = [
 ]
 
 
+def _drop_sql_views(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DROP VIEW IF EXISTS account_root
+        """,
+    )
+
+
 def rename_selection_option(env):
     openupgrade.logged_query(
         env.cr,
@@ -218,6 +227,7 @@ def migrate(env, version):
         openupgrade.rename_fields(env, field_renames_l10n_dk_bookkeeping)
     openupgrade.rename_fields(env, field_renames)
     openupgrade.add_columns(env, _new_columns)
+    _drop_sql_views(env)
     update_account_move_amount_untaxed_in_currency_signed(env)
     update_account_move_checked(env)
     fill_account_move_preferred_payment_method_line_id(env)

--- a/openupgrade_scripts/scripts/account/18.0.1.3/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/upgrade_analysis_work.txt
@@ -12,6 +12,9 @@ new model account.move.send.wizard [transient]
 new model account.secure.entries.wizard [transient]
 # NOTHING TO DO
 
+obsolete model account.root [sql_view]
+# DONE: pre-migration: drop view if exists
+
 ---Fields in module 'account'---
 account      / account.account          / _order                        : _order is now 'code, placeholder_code' ('code, company_id')
 account      / account.account          / code_mapping_ids (one2many)   : NEW relation: account.code.mapping


### PR DESCRIPTION
account_root view is not stored in DB anymore in v18. account.root model was moved from account_account.py to its own file account_root.py and the init function creating VIEW in DB was removed at the same time : 
https://github.com/odoo/odoo/commit/854c3b27aa5476c208572f19e64f8f3364bfc381


Not sure why this it not detected in upgrade_analysis.txt though (probably because model still exists but is not using SQL VIEW anymore).

I am not sure if I should add information somewhere (adding entries in upgrade_analysis_work.txt for instance) ?
