### PR TITLE
[18.0][OU-FIX] purchase_stock: Don't use an unexisting field

### DIFF
--- a/openupgrade_scripts/scripts/purchase_stock/18.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/purchase_stock/18.0.1.2/pre-migration.py
@@ -33,7 +33,7 @@ def fill_purchase_order_line_group_id(env):
         WHERE pol.order_id = po.id AND pol.group_id IS NULL
         """,
     )
-    if openupgrade.table_exists(env.cr, "sale_order_line"):
+    if openupgrade.column_exists(env.cr, "purchase_order_line", "sale_line_id"):
         openupgrade.logged_query(
             env.cr,
             """


### PR DESCRIPTION
`sale_line_id` in `purchase.order.line` is added by `sale_purchase`, so it can't be used only testing if `sale_order_line` exists (added by `sale`).

Let's do the explicit condition.

@Tecnativa 