### PR TITLE
[18.0][OU-FIX] account: Outstanding accounts

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
@@ -153,11 +153,40 @@ def account_account_code_fields(env):
     )
 
 
+def _handle_outstanding_accounts(env):
+    """On version 17, the outstanding accounts were handled with 2 fields on each
+    res.company.
+
+    Now, they are handled putting specific XML-IDs on them, so we should create that
+    identifiers on the previous referenced accounts.
+    """
+    IMD = env["ir.model.data"]
+    for column in [
+        "account_journal_payment_debit_account_id",
+        "account_journal_payment_credit_account_id",
+    ]:
+        env.cr.execute(
+            f"SELECT id, {column} FROM res_company WHERE {column} IS NOT NULL"
+        )
+        for company_id, account_id in env.cr.fetchall():
+            name = f"{company_id}_{column}"
+            if not IMD.search([("module", "=", "account"), ("name", "=", name)]):
+                IMD.create(
+                    {
+                        "module": "account",
+                        "name": name,
+                        "model": "account.account",
+                        "res_id": account_id,
+                    }
+                )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     handle_lock_dates(env)
     link_payments_to_moves(env)
     account_account_code_fields(env)
+    _handle_outstanding_accounts(env)
     openupgrade.m2o_to_x2m(
         env.cr, env["account.account"], "account_account", "company_ids", "company_id"
     )

--- a/openupgrade_scripts/scripts/account/18.0.1.3/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/upgrade_analysis_work.txt
@@ -211,7 +211,7 @@ account      / product.template         / property_account_income_id (many2one):
 
 account      / res.company              / account_journal_payment_credit_account_id (many2one): DEL relation: account.account
 account      / res.company              / account_journal_payment_debit_account_id (many2one): DEL relation: account.account
-# NOTHING TO DO
+# DONE: post-migration: Put corresponding XML-IDs to the pointed accounts
 
 account      / res.company              / account_price_include (selection): NEW required, selection_keys: ['tax_excluded', 'tax_included'], hasdefault: default
 account      / res.company              / autopost_bills (boolean)      : NEW hasdefault: default


### PR DESCRIPTION
On version 17, the outstanding accounts were handled with 2 fields on each res.company.

Now, they are handled putting specific XML-IDs on them, so we should create that identifiers on the previous referenced accounts.

@Tecnativa TT58856