### PR TITLE
Revert "[18.0][OU-FIX] account: Don't autocheck_on_post by default"

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/pre-migration.py
@@ -28,7 +28,7 @@ field_renames_l10n_dk_bookkeeping = [
 _new_columns = [
     ("account.bank.statement.line", "company_id", "many2one"),
     ("account.bank.statement.line", "journal_id", "many2one"),
-    ("account.journal", "autocheck_on_post", "boolean", False),
+    ("account.journal", "autocheck_on_post", "boolean", True),
     ("account.move", "amount_untaxed_in_currency_signed", "float"),
     ("account.move", "checked", "boolean"),
     ("account.move", "preferred_payment_method_line_id", "many2one"),

--- a/openupgrade_scripts/scripts/account/18.0.1.3/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/upgrade_analysis_work.txt
@@ -60,7 +60,7 @@ account      / account.group            / parent_path (char)            : DEL
 # NOTHING TO DO
 
 account      / account.journal          / autocheck_on_post (boolean)   : NEW hasdefault: default
-# DONE: pre-migration: pre-created and filled with default=False for preserving previous behavior
+# DONE: pre-migration: pre-created and filled
 
 account      / account.journal          / sale_activity_note (text)     : DEL
 account      / account.journal          / sale_activity_type_id (many2one): DEL relation: mail.activity.type


### PR DESCRIPTION
Reverts OCA/OpenUpgrade#5427

The logic has been inverted, so it's correct that they are marked as True by default:

https://github.com/odoo/odoo/commit/242e1a04fc97131ccc28905de58011127f078e30

@Tecnativa