### PR TITLE
[14.0][OU-FIX] fix account.partial.reconcile currency

### DIFF
--- a/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/14.0.1.1/pre-migration.py
@@ -677,22 +677,22 @@ def fill_partial_reconcile_currency(env):
         env.cr,
         """
         UPDATE account_partial_reconcile apr
-        SET debit_currency_id = COALESCE(am.currency_id, rc.currency_id)
-        FROM account_move am,
+        SET debit_currency_id = COALESCE(aml.currency_id, rc.currency_id)
+        FROM account_move_line aml,
             res_company rc
-        WHERE am.id = apr.debit_move_id
-            AND rc.id = am.company_id
+        WHERE aml.id = apr.debit_move_id
+            AND rc.id = aml.company_id
         """,
     )
     openupgrade.logged_query(
         env.cr,
         """
         UPDATE account_partial_reconcile apr
-        SET credit_currency_id = COALESCE(am.currency_id, rc.currency_id)
-        FROM account_move am,
+        SET credit_currency_id = COALESCE(aml.currency_id, rc.currency_id)
+        FROM account_move_line aml,
             res_company rc
-        WHERE am.id = apr.credit_move_id
-            AND rc.id = am.company_id
+        WHERE aml.id = apr.credit_move_id
+            AND rc.id = aml.company_id
         """,
     )
 


### PR DESCRIPTION
fix queries pre-filling the `debit_currency_id` and `credit_currency_id` fields of `account.partial.reconcile` records: `debit_move_id` and `credit_move_id` are `many2one` fields to `account.move.line`, not to `account.move`. this resulted in null columns, ignoring the records when computing `account.move.line.amount_residual` in odoo 16.

here is how to fix existing data:

```python
self.env.cr.execute(
    """
    update account_partial_reconcile as apr
    set debit_currency_id = coalesce(aml.currency_id, rc.currency_id)
    from account_move_line as aml,
        res_company as rc
    where
        debit_currency_id is null and
        aml.id = apr.debit_move_id and
        rc.id = aml.company_id
    """
)
self.env.cr.execute(
    """
    update account_partial_reconcile as apr
    set credit_currency_id = coalesce(aml.currency_id, rc.currency_id)
    from account_move_line as aml,
        res_company as rc
    where
        credit_currency_id is null and
        aml.id = apr.credit_move_id and
        rc.id = aml.company_id
    """
)
self.env["account.move.line"].search(
    [
        ("reconciled", "=", False),
        "|",
        ("matched_credit_ids", "!=", False),
        ("matched_debit_ids", "!=", False),
    ]
)._compute_amount_residual()
```