### PR TITLE
[IMP] apriori: l10n_it_vat_statement_communication -> l10n_it_vat_settlement_communication

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -21,6 +21,7 @@ renamed_modules = {
     "pdf_helper": "pdf_xml_attachment",
     # OCA/l10n-italy
     "account_vat_period_end_statement": "l10n_it_account_vat_period_end_settlement",
+    "l10n_it_vat_statement_communication": "l10n_it_vat_settlement_communication",
     # OCA/product-attribute
     "product_packaging_type_vendor": "product_packaging_level_vendor",
     "product_supplierinfo_for_customer": "product_customerinfo",


### PR DESCRIPTION
The rename happened in https://github.com/OCA/l10n-italy/pull/4676.