### PR TITLE
[18.0][FIX] don't set install_filename when loading views from openupgrade_scripts

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
@@ -5,6 +5,7 @@ import logging
 
 from odoo import api
 from odoo.exceptions import ValidationError
+from odoo.modules.module import get_resource_from_path
 from odoo.tools import mute_logger
 
 from odoo.addons.base.models.ir_ui_view import NameManager, View
@@ -85,6 +86,21 @@ def _check_field_paths(self, node, field_paths, model_name, use):
         pass
 
 
+def _inverse_arch(self):
+    """
+    Remove install_filename from context if it's from openupgrade_scripts.
+    Without this, arch_fs will point to openupgrade_scripts' file which most likely
+    won't exist when the migrated database is deployed, which breaks resetting views
+    """
+    if "install_filename" in self._context:
+        path_info = get_resource_from_path(self._context["install_filename"])
+        if path_info[0] == "openupgrade_scripts":
+            self = self.with_context(
+                {k: v for k, v in self._context.items() if k != "install_filename"}
+            )
+    return _inverse_arch._original_method(self)
+
+
 _check_xml._original_method = View._check_xml
 View._check_xml = _check_xml
 check._original_method = NameManager.check
@@ -93,3 +109,5 @@ _raise_view_error._original_method = View._raise_view_error
 View._raise_view_error = _raise_view_error
 _check_field_paths._original_method = View._check_field_paths
 View._check_field_paths = _check_field_paths
+_inverse_arch._original_method = View._inverse_arch
+View._inverse_arch = _inverse_arch

--- a/openupgrade_scripts/scripts/hr_recruitment/tests/test_arch_fs.py
+++ b/openupgrade_scripts/scripts/hr_recruitment/tests/test_arch_fs.py
@@ -1,0 +1,16 @@
+from odoo.tests import TransactionCase
+
+from odoo.addons.openupgrade_framework import openupgrade_test
+
+
+@openupgrade_test
+class TestArchFs(TransactionCase):
+    def test_arch_fs(self):
+        """
+        Test that we didn't overwrite arch_fs with the path to the
+        noupdate changes file
+        """
+        self.assertNotIn(
+            "openupgrade_scripts",
+            self.env.ref("hr_recruitment.candidate_hired_template").arch_fs,
+        )


### PR DESCRIPTION
Remove install_filename from context if it's from openupgrade_scripts.
Without this, arch_fs will point to openupgrade_scripts' file which most likely
won't exist when the migrated database is deployed, which breaks resetting views

see #5437

@remi-filament please verify this fixes your issue for v18, and then cherry pick to v17 without the test