### PR TITLE
[18.0][FIX]openupgrade_framework: Fix Nonetype Error when install_filename …

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
@@ -94,7 +94,7 @@ def _inverse_arch(self):
     """
     if "install_filename" in self._context:
         path_info = get_resource_from_path(self._context["install_filename"])
-        if path_info[0] == "openupgrade_scripts":
+        if path_info and path_info[0] == "openupgrade_scripts":
             self = self.with_context(
                 {k: v for k, v in self._context.items() if k != "install_filename"}
             )


### PR DESCRIPTION
…path does not exist

In my doodba insrtance, migrating this week to v18 fail since this commit :https://github.com/OCA/OpenUpgrade/commit/527770f0f38691b8a14a17a750dffdebb22caa44

```
path_info = get_resource_from_path(self._context["install_filename"])
if path_info[0] == "openupgrade_scripts":
```

Although the install_filename key exists in self._context, the function get_resource_from_path returns None for my environment. Consequently, attempting to access path_info[0] raises an error (e.g., TypeError: 'NoneType' object is not subscriptable), which breaks the migration process.

A necessary fix would be to add a check for the existence of path_info before attempting to access its elements: