### PR TITLE
[PERF] account: optimize migration performance by pre-creating column and bulk transferring invoice_date

### DIFF
--- a/openupgrade_scripts/scripts/account/17.0.1.2/pre-migration.py
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/pre-migration.py
@@ -195,6 +195,26 @@ def _pre_create_early_pay_discount_computation(env):
     )
 
 
+def _pre_account_move_line_invoice_date_computation(env):
+    """Avoid triggering the computed method"""
+    openupgrade.logged_query(
+        env.cr,
+        """
+        ALTER TABLE account_move_line
+        ADD COLUMN IF NOT EXISTS invoice_date DATE;
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move_line aml
+        SET invoice_date = am.invoice_date
+        FROM account_move am
+        WHERE am.invoice_date IS NOT NULL AND aml.move_id = am.id;
+        """,
+    )
+
+
 def _decouple_obsolete_tables(env):
     """
     Remove all foreign keys held by and pointed to template tables
@@ -280,6 +300,7 @@ def migrate(env, version):
     _account_report_update_figure_type(env)
     _account_tax_repartition_line_merge_repartition_lines_m2o(env)
     _pre_create_early_pay_discount_computation(env)
+    _pre_account_move_line_invoice_date_computation(env)
     _decouple_obsolete_tables(env)
     _pre_create_account_report_active(env)
     _remove_obsolete_constraints(env)

--- a/openupgrade_scripts/scripts/account/17.0.1.2/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/upgrade_analysis_work.txt
@@ -167,7 +167,7 @@ account      / account.move.line        / display_type (selection)      : select
 # NOTHING TO DO: new feature "Discount allocation" https://github.com/odoo/odoo/pull/133286
 
 account      / account.move.line        / invoice_date (date)           : NEW isrelated: related, stored
-# NOTHING TO DO: ORM resolves by SQL this filling being a direct related field with 1 level depth.
+# DONE: pre-migration: Pre-create the column for avoiding triggering the compute and transfer data from account moves to all the account move lines.
 
 account      / account.move.line        / tax_audit (char)              : DEL
 # NOTHING TO DO: deprecated


### PR DESCRIPTION
Pre-create the target column to avoid triggering compute() during update,
and perform a direct bulk data transfer from account_move to account_move_line.
This avoids ORM overhead, reduces heap rewrites, and prevents unnecessary
recomputation on 15M move lines.

Performance result:
- Previous approach: ~2 hours
- Optimized approach: ~15 minutes (~8x faster)