### PR TITLE
[11.0][IMP] base: Added model_name value insertion in ir.cron migration

### DIFF
--- a/odoo/addons/base/migrations/11.0.1.3/post-migration.py
+++ b/odoo/addons/base/migrations/11.0.1.3/post-migration.py
@@ -80,7 +80,8 @@ def fill_cron_action_server_post(env):
     }
     env.cr.execute("""
         SELECT ic.id, ic.create_uid, ic.create_date, ic.write_uid, ic.args,
-            ic.write_date, ic.name, im.id AS model_id, ic.function
+            ic.write_date, ic.name, im.id AS model_id, ic.function,
+            im.model as model_name
         FROM ir_cron AS ic,
             ir_model AS im
         WHERE
@@ -95,6 +96,7 @@ def fill_cron_action_server_post(env):
             'write_date': act['write_date'],
             'name': act['name'],
             'model_id': act['model_id'],
+            'model_name': act['model_name'],
             'code': 'model.%s%s' % (act['function'], act['args'] or '()'),
         })
         openupgrade.logged_query(
@@ -102,11 +104,11 @@ def fill_cron_action_server_post(env):
             INSERT INTO ir_act_server
               (create_uid, create_date, write_uid, write_date,
                code, state, type, usage, name, model_id,
-               binding_type, sequence)
+               model_name, binding_type, sequence)
             VALUES (
               %(create_uid)s, %(create_date)s, %(write_uid)s, %(write_date)s,
               %(code)s, %(state)s, %(type)s, %(usage)s, %(name)s, %(model_id)s,
-              %(binding_type)s, %(sequence)s
+              %(model_name)s, %(binding_type)s, %(sequence)s
             )
             RETURNING id""", vals,
         )


### PR DESCRIPTION
From Odoo v11.0, `ir.cron` possesses delegated fields from `ir.actions.server` related to models, `model_id` and `model_name`.
The migration script currently assigns the `model_id` value, but not the `model_name`.

This is problematic, as from 11.0's version of base, the `model_name` from `ir.servers.action` is a stored field, and since the server action record is inserted directly as a row in the PSQL table, the `model_name` field is initially set to null, and not recomputed within Odoo to match the `model_id`'s `model` field.

This can cause issues in later versions of Odoo, such as Odoo 16.0, where the `model_name` field is used within the `run` method of `ir.actions.server` in the `base` module.

As such, alongside the server action row insertion, we also set `model_name` to its intended value (`model` from the `ir_model` table).