### PR TITLE
[17.0][OU-FIX] base: Cover private contact with no name

### DIFF
--- a/openupgrade_scripts/scripts/base/17.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/17.0.1.3/pre-migration.py
@@ -222,6 +222,8 @@ def _handle_partner_private_type(cr):
     openupgrade.copy_columns(cr, _column_copies)
     # Change contact type and erase sensitive information
     query = "type = 'contact'"
+    # name of private contact may be null, which is forbidden by res_partner_check_name
+    query += ", name = COALESCE(name, '*****')"
     for field in [
         "street",
         "street2",


### PR DESCRIPTION
As res_partner_check_name constraint only limits not null names for regular contacts, there may be the case where the private contact has a null name, so when converting it to regular contact, it fails.

Let's put a wildcard name for that cases.

@Tecnativa 