### PR TITLE
[15.0][OU-FIX] repair: copy repair_order.state column before updating its data

### DIFF
--- a/openupgrade_scripts/scripts/repair/15.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/repair/15.0.1.0/post-migration.py
@@ -14,7 +14,7 @@ def migrate(env, version):
     )
     openupgrade.map_values(
         env.cr,
-        "state",
+        openupgrade.get_legacy_name("state"),
         "state",
         [("invoice_except", "2binvoiced")],
         table="repair_order",

--- a/openupgrade_scripts/scripts/repair/15.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/repair/15.0.1.0/pre-migration.py
@@ -12,3 +12,7 @@ def migrate(env, version):
     openupgrade.convert_field_to_html(
         env.cr, "repair_order", "quotation_notes", "quotation_notes"
     )
+    openupgrade.copy_columns(
+        env.cr,
+        {"repair_order": [("state", None, None)]},
+    )


### PR DESCRIPTION
This will also avoid an error log by using `map_values` with the same source and target.

NOTE: I checked all calls to `map_values` in 15.0, it was the only one.

Relates to:
- https://github.com/OCA/openupgradelib/pull/431

cc @StefanRijnhart @pedrobaeza @fanchlegal