### PR TITLE
[18.0][FIX] generate-{analysis,testdb}: pin version of google-auth

### DIFF
--- a/.github/workflows/generate-analysis.yml
+++ b/.github/workflows/generate-analysis.yml
@@ -102,7 +102,7 @@ jobs:
           # this is for l10n_eg_edi_eta which crashes without it
           pip install asn1crypto
           # this is for cloud_storage_google
-          pip install google-auth
+          pip install "google-auth<2.48.0"
           odoo -s -c odoo-$FROM_VERSION.cfg --addons-path server-tools-$FROM_VERSION,openupgrade-$FROM_VERSION --stop-after-init
       - name: Install current Odoo
         run: |
@@ -118,6 +118,8 @@ jobs:
           pip install -r openupgrade-$TO_VERSION/requirements.txt
           # this is for l10n_eg_edi_eta which crashes without it
           pip install asn1crypto
+          # this is for cloud_storage_google
+          pip install "google-auth<2.48.0"
           odoo -s -c odoo-$TO_VERSION.cfg --addons-path server-tools-$TO_VERSION,openupgrade-$TO_VERSION --stop-after-init
       - name: Create previous Odoo database
         env:

--- a/.github/workflows/generate-testdb.yml
+++ b/.github/workflows/generate-testdb.yml
@@ -45,7 +45,7 @@ jobs:
           # this is for l10n_eg_edi_eta which crashes without it
           pip install asn1crypto
           # this is for cloud_storage_google
-          pip install google-auth
+          pip install "google-auth<2.48.0"
           # this is for account_peppol
           pip install phonenumbers
           # for pushing release


### PR DESCRIPTION
the [new version](https://github.com/googleapis/google-auth-library-python/blob/main/CHANGELOG.md) of google-auth depends on cryptography which [messes up](https://github.com/OCA/OpenUpgrade/actions/runs/21578408549/job/62170574838#step:10:139) the builds