### PR TITLE
[19.0][FIX] pin setuptools to v81.0

### DIFF
--- a/.github/workflows/documentation-commit.yml
+++ b/.github/workflows/documentation-commit.yml
@@ -52,6 +52,8 @@ jobs:
               unixodbc-dev
       - name: Requirements Installation
         run: |
+          export PIP_CONSTRAINT=pip-constraint.txt
+          echo 'setuptools < 82.0.0' > pip-constraint.txt
           sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version == '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version == '3.10')/\12.0.2\2/" odoo/requirements.txt
           pip install -q -r odoo/requirements.txt
           pip install -r ./requirements.txt

--- a/.github/workflows/generate-analysis.yml
+++ b/.github/workflows/generate-analysis.yml
@@ -93,6 +93,8 @@ jobs:
           wget -q -O- https://github.com/oca/server-tools/archive/refs/heads/$FROM_VERSION.tar.gz | tar -xz
           python -mvenv env-$FROM_VERSION
           . env-$FROM_VERSION/bin/activate
+          export PIP_CONSTRAINT=pip-constraint.txt
+          echo 'setuptools < 82.0.0' > pip-constraint.txt
           pip install ${{ inputs.from_version_requirements }}
           sed -iE '${{ inputs.from_version_requirements_sed }}' OCB-$FROM_VERSION/requirements.txt
           pip install -r OCB-$FROM_VERSION/requirements.txt
@@ -108,6 +110,8 @@ jobs:
           wget -q -O- https://github.com/oca/server-tools/archive/refs/heads/$TO_VERSION.tar.gz | tar -xz
           python -mvenv env-$TO_VERSION
           . env-$TO_VERSION/bin/activate
+          export PIP_CONSTRAINT=pip-constraint.txt
+          echo 'setuptools < 82.0.0' > pip-constraint.txt
           pip install ${{ inputs.to_version_requirements }}
           sed -iE '${{ inputs.to_version_requirements_sed }}' OCB-$TO_VERSION/requirements.txt
           pip install -r OCB-$TO_VERSION/requirements.txt


### PR DESCRIPTION
setuptools finally removed pgk_resources, which some package(s) in Odoo's dependency tree rely on