### PR TITLE
[18.0][OU-FIX] account: Correctly populate code_store using Root Company ID fr…

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
@@ -147,8 +147,10 @@ def account_account_code_fields(env):
     """
     env.cr.execute(
         """
-        UPDATE account_account
-        SET code_store=json_build_object(company_id, code)
+        UPDATE account_account aa
+        SET code_store=json_build_object(split_part(rc.parent_path, '/', 1), aa.code)
+        FROM res_company rc
+        WHERE aa.company_id = rc.id
         """
     )
 


### PR DESCRIPTION
## Description
Fixes the account code migration script to correctly populate the `code_store` field using the Root Company ID instead of the immediate company ID.
## Issue
During migration from Odoo 17 to 18, account codes were disappearing for child companies in a company hierarchy. The issue was that `code_store` was being populated with the specific `company_id` as the key, but Odoo 18's `account.account._compute_code` expects the key to be the Root Company ID.
## Solution
Updated the SQL query in `account_account_code_fields()` to use `split_part(rc.parent_path, '/', 1)` to extract the Root Company ID from the `parent_path` field.