### PR TITLE
[18.0][OU-IMP] mail: Define the appropriate delay_from value (similar to v17)

### DIFF
--- a/openupgrade_scripts/scripts/mail/18.0.1.18/post-migration.py
+++ b/openupgrade_scripts/scripts/mail/18.0.1.18/post-migration.py
@@ -71,12 +71,17 @@ def mail_activity_plan_template_delay(env):
     """
     Define the appropriate values for delay_count and delay_unit as
     defined in mail_activity_type to have the same behavior as in v17.
+    All records are defined with delay_from=after_plan_date because
+    that was the behavior up to v17.
     """
     openupgrade.logged_query(
         env.cr,
         """
         UPDATE mail_activity_plan_template t
-        SET delay_count = at.delay_count, delay_unit = at.delay_unit
+        SET
+            delay_count = at.delay_count,
+            delay_unit = at.delay_unit,
+            delay_from = 'after_plan_date'
         FROM mail_activity_type at
         WHERE t.activity_type_id = at.id;
         """,

--- a/openupgrade_scripts/scripts/mail/18.0.1.18/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/mail/18.0.1.18/upgrade_analysis_work.txt
@@ -51,9 +51,11 @@ mail         / mail.activity            / user_tz (selection)           : NEW se
 # NOTHING TO DO: change comes from base
 
 mail         / mail.activity.plan.template / delay_count (integer)         : NEW hasdefault: default
-mail         / mail.activity.plan.template / delay_from (selection)        : NEW required, selection_keys: ['after_plan_date', 'before_plan_date'], hasdefault: default
 mail         / mail.activity.plan.template / delay_unit (selection)        : NEW required, selection_keys: ['days', 'months', 'weeks'], hasdefault: default
 # DONE: Define the appropriate value based on the value of mail_activity_type
+
+mail         / mail.activity.plan.template / delay_from (selection)        : NEW required, selection_keys: ['after_plan_date', 'before_plan_date'], hasdefault: default
+# DONE: All records are defined with delay_from=after_plan_date because that was the behavior up to v17
 
 mail         / mail.canned.response     / description (char)            : NEW
 mail         / mail.canned.response     / group_ids (many2many)         : NEW relation: res.groups


### PR DESCRIPTION
Define the appropriate delay_from value (similar to v17)

Related to https://github.com/OCA/OpenUpgrade/pull/5506/changes/a39f30352d48bd352aa983d50e3455081a2236d1

@Tecnativa TT61045