### PR TITLE
[17.0][OU-ADD] spreadsheet_dashboard: Asing new group to Settings users

### DIFF
--- a/openupgrade_scripts/scripts/spreadsheet_dashboard/17.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/spreadsheet_dashboard/17.0.1.0/post-migration.py
@@ -1,0 +1,18 @@
+# Copyright 2026 Tecnativa - Christian Ramos
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+from odoo import Command
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    group_system = env.ref("base.group_system", False)
+    group_dashboard_manager = env.ref(
+        "spreadsheet_dashboard.group_dashboard_manager", False
+    )
+    if group_system and group_dashboard_manager:
+        group_system.users.write(
+            {"groups_id": [Command.link(group_dashboard_manager.id)]}
+        )


### PR DESCRIPTION
With the new group `spreadsheet_dashboard.group_dashboard_manager` Setting users are no longer able to edit dashboards after migration, unless the group is manually assigned.
Tested locally
@Tecnativa TT60186
@pedrobaeza 