### PR TITLE
[15.0][IMP] merge mass_operation_abstract into base

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -100,6 +100,8 @@ merged_modules = {
     "stock_account_product_cost_security": "product_cost_security",
     # OCA/server-tools
     "base_jsonify": "jsonifier",
+    # OCA/server-ux
+    "mass_operation_abstract": "base",
     # OCA/stock-logistics-reporting
     "stock_inventory_valuation_pivot": "stock_account",
     # OCA/stock-logistics-warehouse


### PR DESCRIPTION
this one is obsolete as all the mass operation addons are implemented as server actions by 15.0

See https://github.com/OCA/server-ux/pull/472 https://github.com/OCA/server-ux/pull/603 https://github.com/OCA/server-ux/pull/671