### PR TITLE
[17.0][FIX] account: Only set res_field=invoice_pdf_report_file on customer invoice/refunds

### DIFF
--- a/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/17.0.1.2/post-migration.py
@@ -117,6 +117,7 @@ def _am_update_invoice_pdf_report_file(env):
             res_id = am.id
         FROM account_move am
         WHERE am.message_main_attachment_id = ia.id
+        AND am.move_type IN ('out_invoice', 'out_refund')
         """,
     )
 


### PR DESCRIPTION
Current behavior: On ir.attachment of invoices, 'res_field' is set to 'invoice_pdf_report_file' on all invoices that have 'message_main_attachment_id'
New behavior: only do that for customer invoices and refunds

Why ? Because supplier invoices/refunds can also have 'message_main_attachment_id', for example when you click on the "Upoad" button of the purchase journal on the accounting dashboard and you upload a PDF file. And we don't want res_field='invoice_pdf_report_file' on attachments of supplier invoice/refunds !