### PR TITLE
[FIX] website: update website_menu record rule domain for Odoo 19

### DIFF
--- a/openupgrade_scripts/scripts/website/19.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website/19.0.1.0/post-migration.py
@@ -1,0 +1,18 @@
+from openupgradelib import openupgrade
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE ir_rule
+        SET domain_force = '["|", ("group_ids", "=", False), ("group_ids", "in", user.all_group_ids.ids)]'
+        WHERE id IN (
+            SELECT res_id 
+            FROM ir_model_data 
+            WHERE model = 'ir.rule' 
+              AND module = 'website' 
+              AND name = 'website_menu'
+        )
+        """
+    )


### PR DESCRIPTION
### Problem
During migration from 18.0 to 19.0, the record rule `website.website_menu` 
causes an AttributeError because it still references `user.groups_id`. 
In Odoo 19, this field has been renamed/replaced by `group_ids` and 
the standard XML now uses `all_group_ids`.

### Solution
Added a post-migration script in the website module to update the 
`domain_force` of the `website_menu` rule to use `user.all_group_ids.ids`.

### Testing
Verified on a database migration from 18.0 -> 19.0. Before this fix, 
the registry failed to load; after the fix, the instance starts correctly.