### PR TITLE
[18.0][OU-ADD] apriori: stock_picking_batch_extended_account renamed to stock_picking_batch_account

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -43,6 +43,7 @@ renamed_modules = {
     # OCA/stock-logistics-workflow
     "stock_picking_type_shipping_policy": "stock_picking_type_force_move_type",
     "stock_picking_batch_extended_account": "stock_picking_batch_account",
+    "stock_picking_batch_extended_account_sale_type": "stock_picking_batch_account_sale_type",  # noqa: E501
     # OCA/web
     "web_widget_product_label_section_and_note": "web_widget_product_label_section_and_note_name_visibility",  # noqa: E501
     # OCA/...

--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -42,6 +42,7 @@ renamed_modules = {
     "sale_product_set_sale_by_packaging": "product_set_sell_only_by_packaging",
     # OCA/stock-logistics-workflow
     "stock_picking_type_shipping_policy": "stock_picking_type_force_move_type",
+    "stock_picking_batch_extended_account": "stock_picking_batch_account",
     # OCA/web
     "web_widget_product_label_section_and_note": "web_widget_product_label_section_and_note_name_visibility",  # noqa: E501
     # OCA/...


### PR DESCRIPTION
Rename `stock_picking_batch_extended_account` renamed to `stock_picking_batch_account` [PR # 2287](https://github.com/OCA/stock-logistics-workflow/pull/2287)
Rename `stock_picking_batch_extended_account_sale_type` to `stock_picking_batch_account_sale_type` [PR # 2288](https://github.com/OCA/stock-logistics-workflow/pull/2288)

@pedrobaeza @CarlosRoca13
@Tecnativa
TT54333
TT54332