### PR TITLE
[18.0][OU-FIX] website_mass_mailing: Manage changes on newsletter

### DIFF
--- a/openupgrade_scripts/scripts/website_mass_mailing/18.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/website_mass_mailing/18.0.1.0/post-migration.py
@@ -1,0 +1,35 @@
+# Copyright 2026 Dixmit Consulting
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from lxml import etree
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    new_snippet = env.ref("website_mass_mailing.s_newsletter_subscribe_form")
+    views = env["ir.ui.view"].search(
+        [
+            (
+                "arch_db",
+                "ilike",
+                'class="s_newsletter_subscribe_form s_newsletter_list js_subscribe"',
+            ),
+            ("website_id", "!=", False),
+        ]
+    )
+    for view in views:
+        root = etree.fromstring(view.arch_db)
+        for node in root.cssselect(".s_newsletter_subscribe_form"):
+            new_node = new_snippet._get_combined_arch().getchildren()[0]
+            button = node.cssselect(".js_subscribe_btn")
+            if button:
+                new_node.cssselect(".js_subscribe_btn")[0].text = button[0].text
+            thanks = node.cssselect(".js_subscribed_btn")
+            if thanks:
+                new_node.xpath("//*[hasclass('js_subscribed_wrap')]/p")[0].text = (
+                    " " + thanks[0].text
+                )
+            # TODO: Check what happens with translations
+            node.getparent().replace(node, new_node)
+        view.arch_db = etree.tostring(root)

--- a/openupgrade_scripts/scripts/website_mass_mailing/18.0.1.0/upgrade_analysis.txt
+++ b/openupgrade_scripts/scripts/website_mass_mailing/18.0.1.0/upgrade_analysis.txt
@@ -1,0 +1,4 @@
+---Models in module 'website_mass_mailing'---
+---Fields in module 'website_mass_mailing'---
+---XML records in module 'website_mass_mailing'---
+---nothing has changed in this module--

--- a/openupgrade_scripts/scripts/website_mass_mailing/18.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_mass_mailing/18.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,5 @@
+---Models in module 'website_mass_mailing'---
+---Fields in module 'website_mass_mailing'---
+---XML records in module 'website_mass_mailing'---
+---nothing has changed in this module--
+# NOTHING TO DO


### PR DESCRIPTION
When migrating from 17 to 18, I found out that the snippets for newsletter have changed and an error was raised because it was expecting an element that doesn't exist.

This fixes it, but maybe you know a better way for handling this :wink: 

On 17
https://github.com/odoo/odoo/blob/17.0/addons/website_mass_mailing/views/snippets_templates.xml#L24

On 18
https://github.com/odoo/odoo/blob/18.0/addons/website_mass_mailing/views/snippets_templates.xml#L25