### PR TITLE
[19.0][FIX] website: make sure website.snippets and website.snippet_options are not deleted

### DIFF
--- a/openupgrade_scripts/scripts/website/19.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/website/19.0.1.0/pre-migration.py
@@ -21,6 +21,22 @@ def website_menu_url(env):
     )
 
 
+def qweb_templates_remove_inherit_id(env):
+    """
+    Central snippet related qweb templates were provided by web_editor v18, and website
+    inherited from them. Now with web_editor being merged into html_editor, we need
+    to disentangle those templates from their parents, as in v19, website is where
+    snippets are introduced, and they would be deleted if inheritance wasn't removed
+    during cleanup of xmlids
+    """
+    xmlids = [
+        "website.snippets",
+        "website.snippet_options",
+    ]
+    sum(map(env.ref, xmlids), env["ir.ui.view"]).write({"inherit_id": False})
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     website_menu_url(env)
+    qweb_templates_remove_inherit_id(env)


### PR DESCRIPTION
Central snippet related qweb templates were provided by web_editor v18, and website
inherited from them. Now with web_editor being merged into html_editor, we need
to disentangle those templates from their parents, as in v19, website is where
snippets are introduced, and they would be deleted if inheritance wasn't removed
during cleanup of xmlids