### PR TITLE
[18.0][OU-FIX] base: add missing SQL to fix view mode in ir_act_window_view

### DIFF
--- a/openupgrade_scripts/scripts/base/18.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/18.0.1.3/pre-migration.py
@@ -40,6 +40,10 @@ def _fix_list_view_mode(cr):
         WHERE view_mode ~ '(^|,)tree(,|$)'
         """,
     )
+    openupgrade.logged_query(
+        cr,
+        "UPDATE ir_act_window_view SET view_mode = 'list' WHERE view_mode = 'tree'",
+    )
 
 
 def _fix_serbian_res_lang_record(cr):


### PR DESCRIPTION
add missing SQL to fix view mode in ir_act_window_view

Related to https://github.com/OCA/OpenUpgrade/pull/4977/changes/4fd5fa06bb590c5a5cc897ff6aeb59cf0f37ddd9

Please @pedrobaeza and @carlos-lopez-tecnativa can you review it?

@Tecnativa