### PR TITLE
[19.0][OU-IMP] sale_order_warn_message: Merge into sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -46,7 +46,8 @@ merged_modules = {
     # odoo/enterprise
     # OCA/project
     "project_task_add_very_high": "project",
-    # OCA/...
+    # OCA/sale-workflow
+    "sale_order_warn_message": "sale",
 }
 
 # only used here for upgrade_analysis


### PR DESCRIPTION
OCA module [sale_order_warn_message](https://github.com/OCA/sale-workflow/tree/18.0/sale_order_warn_message) got its functionality implemented in Odoo core.

https://github.com/odoo/odoo/blob/19.0/addons/sale/models/sale_order.py#L828

@pedrobaeza ping

@Tecnativa
TT61963