### PR TITLE
[19.0][OU-IMP] purchase_order_qty_change_no_recompute: Merged into purchase

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -46,6 +46,8 @@ merged_modules = {
     # odoo/enterprise
     # OCA/project
     "project_task_add_very_high": "project",
+    # OCA/purchase-workflow
+    "purchase_order_qty_change_no_recompute": "purchase",
     # OCA/sale-workflow
     "sale_order_warn_message": "sale",
 }


### PR DESCRIPTION
OCA module [purchase_order_qty_change_no_recompute](https://github.com/OCA/purchase-workflow/tree/18.0/purchase_order_qty_change_no_recompute) got its functionality implemented in Odoo core.
[Commit 4561a9a](https://github.com/odoo/odoo/commit/4561a9a4438eefbe137fa1aef68faef02205a45b)

@pedrobaeza ping
@Tecnativa
TT61959