### PR TITLE
[19.0][FIX] base: populate default_user_group.implied_ids before dele…

### DIFF
--- a/openupgrade_scripts/scripts/base/19.0.1.3/post-migration.py
+++ b/openupgrade_scripts/scripts/base/19.0.1.3/post-migration.py
@@ -99,6 +99,7 @@ def _init_default_user_group(env):
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env, "base", "19.0.1.3/noupdate_changes_work.xml")
+    _init_default_user_group(env)
     openupgrade.delete_records_safely_by_xml_id(
         env,
         ["base.ir_filters_delete_own_rule", "base.default_user"],
@@ -108,4 +109,3 @@ def migrate(env, version):
     _ir_actions_server_html_value(env)
     _ir_filters_user_ids(env)
     _res_lang(env)
-    _init_default_user_group(env)


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                    
  `_init_default_user_group` reads `default_user.group_ids` to populate                                                                                                                                                                                                                                                                                             
  `default_user_group.implied_ids`. The previous ordering deleted                                                                                                                                                                                                                                                                                                   
  `base.default_user` first, so `env.ref(..., raise_if_not_found=False)`                                                                                                                                                                                                                                                                                            
  returned `None`, the helper short-circuited, and `implied_ids` was left empty.
                                                                                                                                                                                                                                                                                                                                                                    
  Result: users created post-migration did not inherit the default group set.                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                                                    
## Fix                                                         
  Move `_init_default_user_group(env)` before the
  `delete_records_safely_by_xml_id` call that removes `base.default_user`.
                                                                                                                                                                                                                                                                                                                                                                    
  ## Verification
                                                                                                                                                                                                                                                                                                                                                                    
  Tested against two Odoo 18 production backups:                                                                                                                                                                                                                                                                                                                    
   
  | Run | Backup     | OpenUpgrade        | `default_user_group.implied_ids` |                                                                                                                                                                                                                                                                                      
  |-----|------------|--------------------|----------------------------------|
  | A   | 2026-04-21 | original           | 0                                |                                                                                                                                                                                                                                                                                      
  | B   | 2026-04-21 | patched            | 37                               |                                                                                                                                                                                                                                                                                      
  | A   | 2026-04-24 | reverted           | 0                                |                                                                                                                                                                                                                                                                                      
  | B   | 2026-04-24 | patched (same DB)  | 37                               |                                                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                                                                                    
  A/B/A/B on the same database confirms the behavior is tied solely to this                                                                                                                                                                                                                                                                                         
  call ordering. The source `default_user.group_ids` count (37) is preserved                                                                                                                                                                                                                                                                                        
  end-to-end only when the patch is applied. 