### PR TITLE
[19.0][IMP] hr: set contract start date to employee's create date

### DIFF
--- a/openupgrade_scripts/scripts/hr/19.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/hr/19.0.1.1/post-migration.py
@@ -68,12 +68,12 @@ def fill_hr_version(env):
         f"""
         INSERT INTO hr_version
         (
-            employee_id, date_version,
+            employee_id, date_version, contract_date_start,
             last_modified_uid, last_modified_date, hr_responsible_id,
             {", ".join(fields)}
         )
         SELECT
-            id, create_date,
+            id, create_date, create_date,
             write_uid, write_date, {env.ref("base.user_admin").id},
             {", ".join(fields)}
         FROM hr_employee


### PR DESCRIPTION
this one is more an rfc: When migrating a database without hr_contract, all employees end up without a contract start date. Any code looking for active versions will treat those employees as inactive, so it might be a good idea to set some date.

On the other hand, this will most likely be a wrong date, so that's an argument for not doing it and having HR managers fill in the correct date afterwards.