### PR TITLE
[ADD] pos_sale_order_load renamed into pos_picking_load.

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -36,6 +36,7 @@ renamed_modules = {
     "res_partner_category_multi_company": "partner_category_multi_company",
     # OCA/pos
     "pos_cashback_warning": "pos_cashback",
+    "pos_sale_order_load": "pos_picking_load",
     # OCA/product-attribute
     "product_packaging_type": "product_packaging_level",
     # OCA/project


### PR DESCRIPTION
Rational:
- pos_picking_load exists in V8 and V12.
- in v14, pos_sale_order_load is developped. (comes from odoo/odoo code, https://github.com/OCA/pos/pull/1142)
- in V16, pos_picking_load is ported from V12.
