### PR TITLE
[14.0][FIX] avoid overwriting uom rounding

### DIFF
--- a/openupgrade_scripts/scripts/uom/14.0.1.0/noupdate_changes.xml
+++ b/openupgrade_scripts/scripts/uom/14.0.1.0/noupdate_changes.xml
@@ -18,7 +18,7 @@
     <field name="name">in</field>
   </record>
   <record id="product_uom_kgm" model="uom.uom">
-    <field name="rounding" eval="0.01"/>
+    <!-- <field name="rounding"/> -->
     <!-- <field name="uom_type">reference</field> -->
   </record>
   <record id="product_uom_lb" model="uom.uom">
@@ -43,7 +43,7 @@
     <field name="name">qt (US)</field>
   </record>
   <record id="product_uom_unit" model="uom.uom">
-    <field name="rounding" eval="0.01"/>
+    <!-- <field name="rounding"/> -->
     <!-- <field name="uom_type">reference</field> -->
   </record>
 </odoo>

--- a/openupgrade_scripts/scripts/uom/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/uom/14.0.1.0/post-migration.py
@@ -3,6 +3,22 @@
 from openupgradelib import openupgrade
 
 
+def change_default_uom_rounding(env):
+    # in 13.0, the default value for the rounding field of these units is set
+    # to 0.001 in uom_data.xml. this is removed in 14.0, so it falls back to
+    # the default value of the field, which is 0.01. the rounding on these
+    # units is reset here to their default value if the value hasn’t change,
+    # to match how it would be if the database was created in 14.0, which is
+    # what is expected from openupgrade.
+    for ref in ("uom.product_uom_unit", "uom.product_uom_kgm"):
+        uom = env.ref(ref, raise_if_not_found=False)
+        if not uom:
+            continue
+        if uom.rounding == 0.001:
+            uom.rounding = 0.01
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env.cr, "uom", "14.0.1.0/noupdate_changes.xml")
+    change_default_uom_rounding(env)


### PR DESCRIPTION
update noupdate_changes.xml and avoid overwriting uom rounding values.

the values of the `rounding` field were present for `product_uom_unit` and `product_uom_kgm` in the `uom` module data at some point, but [this commit](https://github.com/OCA/OCB/commit/460ec0402a2352a5b179d81935f7230f6bc97cb7) removed them.