### PR TITLE
[12.0] [FIX] openupgrade_records: error on install

### DIFF
--- a/odoo/addons/openupgrade_records/views/generate_records_wizard.xml
+++ b/odoo/addons/openupgrade_records/views/generate_records_wizard.xml
@@ -8,12 +8,10 @@
             <form string="OpenUpgrade Generate Records Wizard">
                 <field name="state" invisible="1"/>
                 <group states="init" colspan="4">
-                    <label string="This will reinitialize all the modules installed on this database. Do not continue if you use this database in production."
-                           />
+                    <p>This will reinitialize all the modules installed on this database. Do not continue if you use this database in production.</p>
                 </group>
                 <group states="ready" colspan="4">
-                    <label string="Modules initialized and records created"
-                           />
+                    <p>Modules initialized and records created</p>
                 </group>
                 <footer>
                     <button string="Continue"

--- a/odoo/addons/openupgrade_records/views/install_all_wizard.xml
+++ b/odoo/addons/openupgrade_records/views/install_all_wizard.xml
@@ -8,13 +8,11 @@
             <form string="OpenUpgrade Install All Modules Wizard">
                 <field name="state" invisible="1"/>
                 <group states="init" colspan="4">
-                    <label string="This will install all modules on the database. Do not continue if you use this database in production." colspan="4"
-                           />
+                    <p>This will install all modules on the database. Do not continue if you use this database in production.</p>
                     <field name="to_install"/>
                 </group>
                 <group states="ready" colspan="4">
-                    <label string="Modules installed"
-                           />
+                    <p>Modules installed</p>
                 </group>
                 <footer>
                     <button class="btn-primary"


### PR DESCRIPTION

```
    raise ValidationError(_('Invalid view %s definition in %s') % (view.name, view.arch_fs))
odoo.tools.convert.ParseError: "Invalid view view.openupgrade.generate_records_wizard.form definition in openupgrade_records/views/generate_records_wizard.xml
None" while parsing /home/sergio/src/Repos/odoo-dev/OpenUpgrade12/odoo/addons/openupgrade_records/views/generate_records_wizard.xml:4, near
<record id="view_openupgrade_generate_records_wizard_form" model="ir.ui.view">
        <field name="name">view.openupgrade.generate_records_wizard.form</field>
        <field name="model">openupgrade.generate.records.wizard</field>
        <field name="arch" type="xml">
            <form string="OpenUpgrade Generate Records Wizard">
                <field name="state" invisible="1"/>
                <group states="init" colspan="4">
                    <label string="This will reinitialize all the modules installed on this database. Do not continue if you use this database in production."/>
                </group>
                <group states="ready" colspan="4">
                    <label string="Modules initialized and records created"/>
                </group>
                <footer>
                    <button string="Continue" name="generate" type="object" states="init" class="btn-primary"/>
                    <button special="cancel" string="Close" class="btn-default"/>
                </footer>
            </form>
        </field>
    </record>
```