### PR TITLE
[19.0][OU-IMP] hr: backfill NULL create_date/write_date on hr_employee

### DIFF
--- a/openupgrade_scripts/scripts/hr/19.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr/19.0.1.1/pre-migration.py
@@ -67,6 +67,23 @@ def res_partner_employee(env):
     )
 
 
+def fill_hr_employee_audit_dates(env):
+    env.cr.execute(
+        """
+        UPDATE hr_employee
+        SET create_date = COALESCE(create_date, write_date, TIMESTAMP '2000-01-01')
+        WHERE create_date IS NULL
+        """
+    )
+    env.cr.execute(
+        """
+        UPDATE hr_employee
+        SET write_date = COALESCE(write_date, create_date, TIMESTAMP '2000-01-01')
+        WHERE write_date IS NULL
+        """
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.rename_fields(env, renamed_fields)
@@ -78,4 +95,5 @@ def migrate(env, version):
         openupgrade.rename_fields(env, renamed_fields_hr_contract)
         openupgrade.rename_tables(env.cr, renamed_tables_hr_contract)
         openupgrade.rename_models(env.cr, renamed_models)
+    fill_hr_employee_audit_dates(env)
     res_partner_employee(env)


### PR DESCRIPTION
## What

In the `hr` 19.0.1.1 pre-migration, backfill `NULL` `create_date` /
`write_date` on `hr_employee` rows with `COALESCE(write_date, NOW())`
(and symmetrically for the other column).

## Why

The Odoo 19.0 `hr_org_chart` controller
([`hr_org_chart.py:35`](https://github.com/odoo/odoo/blob/19.0/addons/hr_org_chart/controllers/hr_org_chart.py))
calls `employee.write_date.timestamp()` unconditionally. When
`hr_employee.write_date` is NULL on a migrated row, the field is
returned as `False` and the controller raises:

```
AttributeError: 'bool' object has no attribute 'timestamp'
```

Reproduced on multiple 18 → 19 customer migrations (see #5621). The
admin-user employee always has audit columns set, so the crash only
shows up when users open a non-admin employee's form view — easy to
miss until production.

The ORM does set both `create_date` and `write_date` on creation, but
legacy databases can still contain NULL rows from:

- records inserted via direct SQL / data-loader scripts;
- modules that historically wrote with `tools.mute_logger` + raw cursor
  inserts;
- data imported from very early Odoo versions that did not always
  populate audit columns.

OpenUpgrade is the right place to normalise this — by the time the user
hits the org-chart endpoint, source data is no longer available.

Fixes #5621.

## How

`fill_hr_employee_audit_dates(env)` in
`openupgrade_scripts/scripts/hr/19.0.1.1/pre-migration.py`, called from
`migrate()`. Two idempotent `UPDATE … WHERE col IS NULL` statements; a
no-op on healthy databases.

## Test plan

- [x] Manual SQL dry-run against a migrated 19.0 lab DB — no-op on a
      clean DB (0 rows affected), syntax verified.
- [x] CI green on OCA runners.