### PR TITLE
[19.0][MIG] partner_autocomplete: cleanup obsolete res.partner/res.company fields

### DIFF
--- a/openupgrade_scripts/scripts/partner_autocomplete/19.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/partner_autocomplete/19.0.1.1/pre-migration.py
@@ -1,0 +1,45 @@
+# Copyright 2026 ledoent
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+# Fields the 18.0 partner_autocomplete module added that no longer exist
+# anywhere in 19.0 (verified: not defined on res.partner, res.company, or
+# any partner_autocomplete model). Per upgrade_analysis.txt:
+#   res.company.partner_gid    : DEL
+#   res.partner.additional_info: DEL
+#   res.partner.partner_gid    : DEL
+# Odoo's standard registry rebuild does not prune the stale ir_model_fields
+# rows when the donor module is upgraded; the rows + matching ir_ui_view
+# records (also DEL'd in 19.0 per analysis:
+#   view_partner_simple_form_inherit_partner_autocomplete
+#   view_res_partner_form_inherit_partner_autocomplete) survive and trip
+# cross-cutting view validation later in the same migration run
+# (reproduced on l10n_ae/data/account_tax_report_data.xml).
+_obsolete_field_xmlids = [
+    "partner_autocomplete.field_res_company__partner_gid",
+    "partner_autocomplete.field_res_partner__additional_info",
+    "partner_autocomplete.field_res_partner__partner_gid",
+]
+
+_obsolete_view_xmlids = [
+    "partner_autocomplete.view_partner_simple_form_inherit_partner_autocomplete",
+    "partner_autocomplete.view_res_partner_form_inherit_partner_autocomplete",
+]
+
+
+def cleanup_obsolete_partner_autocomplete_records(env):
+    """
+    Drop stale ir_model_fields rows and orphan ir_ui_view records for
+    fields/views the 18.0 partner_autocomplete module added that don't
+    exist in 19.0. See upgrade_analysis_work.txt for the full block.
+    """
+    openupgrade.delete_records_safely_by_xml_id(
+        env,
+        _obsolete_field_xmlids + _obsolete_view_xmlids,
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cleanup_obsolete_partner_autocomplete_records(env)

--- a/openupgrade_scripts/scripts/partner_autocomplete/19.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/partner_autocomplete/19.0.1.1/upgrade_analysis_work.txt
@@ -1,0 +1,38 @@
+---Models in module 'partner_autocomplete'---
+obsolete model res.partner.autocomplete.sync
+
+# NOTHING TO DO: standard module-removal flow handles the table drop
+
+---Fields in module 'partner_autocomplete'---
+partner_autocomplete / res.company              / partner_gid (integer)         : DEL
+partner_autocomplete / res.partner              / additional_info (char)        : DEL
+partner_autocomplete / res.partner              / partner_gid (integer)         : DEL
+
+# DONE: stale ir_model_fields rows and the orphan inheritance views
+# (referenced under XML records below) are deleted in pre-migration
+# via cleanup_obsolete_partner_autocomplete_records. Without this, the
+# rows survive the standard module upgrade and trip cross-cutting view
+# validation when later modules' data XML loads (reproduced on
+# l10n_ae/data/account_tax_report_data.xml:3 with the error
+# 'Field partner_gid does not exist in model res.partner').
+
+partner_autocomplete / res.partner.autocomplete.sync / partner_id (many2one)         : DEL relation: res.partner
+partner_autocomplete / res.partner.autocomplete.sync / synched (boolean)             : DEL
+
+# NOTHING TO DO: covered by the obsolete-model removal above
+
+---XML records in module 'partner_autocomplete'---
+DEL ir.cron: partner_autocomplete.ir_cron_partner_autocomplete
+DEL ir.model.access: partner_autocomplete.access_partner_autocomplete_sync_portal
+DEL ir.model.access: partner_autocomplete.access_partner_autocomplete_sync_system
+DEL ir.model.access: partner_autocomplete.access_partner_autocomplete_sync_user
+
+# NOTHING TO DO: deleted by standard module upgrade
+
+DEL ir.ui.view: partner_autocomplete.view_partner_simple_form_inherit_partner_autocomplete
+DEL ir.ui.view: partner_autocomplete.view_res_partner_form_inherit_partner_autocomplete
+
+# DONE: explicitly deleted in pre-migration. Without this, the views
+# survive the standard upgrade (Odoo only deletes views whose xml_id
+# is in the noupdate-cleanup queue, and these were noupdate=False) and
+# their arch_db retains stale field references that block later loads.


### PR DESCRIPTION
## What

Add ``openupgrade_scripts/scripts/partner_autocomplete/19.0.1.1/``:
- ``pre-migration.py`` with ``cleanup_obsolete_partner_autocomplete_records(env)``
- ``upgrade_analysis_work.txt`` annotating the analysis blocks

The pre-migration deletes the stale ``ir_model_fields`` rows + orphan
inheritance ``ir_ui_view`` records for three fields and two views the 18.0
``partner_autocomplete`` module added that the 19.0 source no longer
defines (per ``upgrade_analysis.txt``):

- ``res.company.partner_gid``
- ``res.partner.additional_info``
- ``res.partner.partner_gid``
- view ``view_partner_simple_form_inherit_partner_autocomplete``
- view ``view_res_partner_form_inherit_partner_autocomplete``

## Why

The directory previously contained only the auto-generated
``upgrade_analysis.txt``. The migration relied on Odoo's standard upgrade
flow to clean up DEL fields and DEL views. That holds for some module
upgrades but not all — in this case the stale ``ir_model_fields`` rows
plus the matching views (whose ``arch_db`` retains
``<field name=\"partner_gid\"/>`` etc.) survive the upgrade. When any
later module's data XML load triggers cross-cutting view validation,
the orphan view tries to render and Odoo raises:

\`\`\`
Field 'partner_gid' does not exist in model 'res.partner'
Field 'additional_info' does not exist in model 'res.partner'
\`\`\`

which aborts the migration. Reproduced on a fresh 18.0 → 19.0 install
(``odoo -i all`` then ``-u all``): the crash hits at module 217/608
``l10n_ae`` while parsing ``account_tax_report_data.xml:3``.

## How

``cleanup_obsolete_partner_autocomplete_records(env)`` lists the five
known-obsolete xml_ids and passes them to
``openupgrade.delete_records_safely_by_xml_id``. That deletes the
``ir_model_data`` backrefs + the underlying ``ir_model_fields`` /
``ir_ui_view`` records together, falling back to ``noupdate=True`` if a
record can't be removed (per the helper's existing behaviour).

The companion ``upgrade_analysis_work.txt`` carries the standard
section structure with one ``# DONE`` block above each DEL group, plus a
``# NOTHING TO DO`` for the obsolete-model entries (the standard
module-removal flow drops those tables) and the DEL access-rights /
cron entries (those are deleted by the standard upgrade).

## Test plan

- [x] Reproduced on a fresh 18.0 CE-all install with the loyalty fix
      (OCA/OpenUpgrade#5629) and the hr cleanup fix
      (OCA/OpenUpgrade#5630) applied. Without this patch, migration
      crashes at module 217/608 (``l10n_ae``).
- [x] With this patch (and the two companions), the migration progresses
      past the partner_autocomplete-related crash. Continued failures
      surface separately (e.g. ``siret`` on ``res.partner`` from
      ``l10n_fr`` — that's a future PR).
- [ ] OCA CI green.

## Related

- OCA/OpenUpgrade#5629 (loyalty mail.template.lang)
- OCA/OpenUpgrade#5630 (hr obsolete hr_contract field cleanup)

This fix is one of a small series surfacing the same class of issue:
modules with DEL field/view entries in their 19.0 analysis whose
standard upgrade flow does not actually prune the stale records.