### PR TITLE
[19.0][MIG] l10n_fr: cleanup obsolete res.partner.siret + orphan form view

### DIFF
--- a/openupgrade_scripts/scripts/l10n_fr/19.0.2.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/l10n_fr/19.0.2.1/pre-migration.py
@@ -1,0 +1,42 @@
+# Copyright 2026 ledoent
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+# The 18.0 l10n_fr module added res.partner.siret (a French SIRET tax
+# identifier) plus a partner form inheritance view that exposed it. Both
+# are DEL'd per upgrade_analysis.txt:
+#   res.partner.siret (char)             : DEL
+#   ir.ui.view: res_partner_form_l10n_fr : DEL
+# Odoo's standard module upgrade does not actually prune the stale
+# ir_model_fields row + the orphan view; both survive and trip
+# cross-cutting view validation when later modules' data XML loads
+# (reproduced on l10n_ae/data/account_tax_report_data.xml:3 with the
+# error 'Field "siret" does not exist in model "res.partner"').
+_obsolete_field_xmlids = [
+    "l10n_fr.field_res_partner__siret",
+]
+
+_obsolete_view_xmlid = "l10n_fr.res_partner_form_l10n_fr"
+
+
+def cleanup_obsolete_l10n_fr_siret(env):
+    """
+    Drop the stale res.partner.siret field metadata and the orphan
+    partner-form inheritance view. See upgrade_analysis_work.txt.
+
+    The view has a child view in l10n_fr_account (also named
+    res_partner_form_l10n_fr) that inherits from this one — so pass
+    delete_childs=True so the helper cascades and doesn't fall back to
+    setting noupdate=True (which would leave the orphan in place and
+    still trip view validation downstream).
+    """
+    openupgrade.delete_records_safely_by_xml_id(env, _obsolete_field_xmlids)
+    openupgrade.delete_records_safely_by_xml_id(
+        env, [_obsolete_view_xmlid], delete_childs=True
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cleanup_obsolete_l10n_fr_siret(env)

--- a/openupgrade_scripts/scripts/l10n_fr/19.0.2.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/l10n_fr/19.0.2.1/upgrade_analysis_work.txt
@@ -1,0 +1,31 @@
+---Models in module 'l10n_fr'---
+
+# NOTHING TO DO
+
+---Fields in module 'l10n_fr'---
+l10n_fr      / res.partner              / siret (char)                  : DEL
+
+# DONE: stale ir_model_fields row and the orphan inheritance view
+# (res_partner_form_l10n_fr, referenced under XML records below) are
+# deleted in pre-migration via cleanup_obsolete_l10n_fr_siret. Without
+# this, the rows survive the standard upgrade and trip cross-cutting
+# view validation when later modules' data XML loads (reproduced on
+# l10n_ae/data/account_tax_report_data.xml:3 with the error
+# 'Field "siret" does not exist in model "res.partner"').
+
+---XML records in module 'l10n_fr'---
+NEW ir.ui.view: l10n_fr.view_partner_form_inherit_l10n_fr
+
+# NOTHING TO DO: created by the 19.0 module on install/upgrade
+
+DEL ir.ui.view: l10n_fr.res_partner_form_l10n_fr
+
+# DONE: explicitly deleted in pre-migration (see field cleanup above).
+
+res.country.group: l10n_fr.fr_and_mc (noupdate) (noupdate switched)
+
+# NOTHING TO DO: noupdate flag flip is handled by the standard upgrade
+
+DEL res.country.group: l10n_fr.dom-tom [renamed to base module]
+
+# NOTHING TO DO: rename handled in apriori (or follow-up if not)


### PR DESCRIPTION
## What

Add ``openupgrade_scripts/scripts/l10n_fr/19.0.2.1/``:
- ``pre-migration.py`` with ``cleanup_obsolete_l10n_fr_siret(env)``
- ``upgrade_analysis_work.txt`` annotating the analysis blocks

The pre-migration deletes the stale ``ir_model_fields`` row for
``res.partner.siret`` plus the orphan inheritance view
``res_partner_form_l10n_fr``. Both are marked DEL in the existing
``upgrade_analysis.txt`` but were not actually pruned by Odoo's standard
upgrade flow.

## Why

The 18.0 ``l10n_fr`` module added ``res.partner.siret`` (the French
SIRET tax identifier) plus a partner form inheritance view that exposed
it. In 19.0 both are removed from source. The directory previously
contained only the auto-generated ``upgrade_analysis.txt``, so the
migration relied on Odoo's standard upgrade flow to drop the DEL field
and DEL view. That doesn't actually happen — the rows survive and the
view's ``arch_db`` retains ``<field name=\"siret\"/>``, which causes
cross-cutting view validation to raise:

\`\`\`
Field \"siret\" does not exist in model \"res.partner\"
\`\`\`

when any later module's data XML load triggers the validation.
Reproduced on a fresh 18.0 → 19.0 install (``odoo -i all`` then
``-u all``): the crash hits at module 217/608 (``l10n_ae``) while
parsing ``l10n_ae/data/account_tax_report_data.xml:3``, **after** the
loyalty (OCA/OpenUpgrade#5629), hr (#5630), and partner_autocomplete
(#5631) companion fixes are applied.

## How

``cleanup_obsolete_l10n_fr_siret(env)`` lists the two known-obsolete
xml_ids and passes them to ``openupgrade.delete_records_safely_by_xml_id``.
That deletes the ``ir_model_data`` backrefs + the underlying
``ir_model_fields`` / ``ir_ui_view`` records together, falling back to
``noupdate=True`` if a record can't be removed (per the helper's
existing behaviour).

The companion ``upgrade_analysis_work.txt`` annotates the field DEL and
the view DEL blocks with ``# DONE`` comments cross-referencing the
helper, and marks the remaining XML-records entries as
``# NOTHING TO DO`` (the standard upgrade handles them: NEW view is
auto-created, noupdate flip is standard, dom-tom group rename is in
apriori).

## Test plan

- [x] Reproduced on a fresh 18.0 CE-all install with the three
      companion fixes applied. Without this patch, migration crashes at
      module 217/608 (``l10n_ae``) on the siret field reference.
- [x] With this patch: the migration progresses past the
      l10n_fr-related crash. (Any subsequent failure is a different
      module's analogous gap.)
- [ ] OCA CI green.

## Related

- OCA/OpenUpgrade#5629 (loyalty mail.template.lang)
- OCA/OpenUpgrade#5630 (hr obsolete hr_contract field cleanup)
- OCA/OpenUpgrade#5631 (partner_autocomplete obsolete fields)
- OCA/OpenUpgrade#5628 (hr null write_date backfill)

This fix continues the pattern surfaced by the comprehensive
CE-install benchmark: modules whose 19.0 ``upgrade_analysis.txt`` lists
DEL entries that Odoo's standard upgrade flow doesn't actually prune.

A separate small PR may be needed for ``l10n_fr_account`` which also
DEL's a partner-form view (``res_partner_form_l10n_fr``) on the same
analysis — that script directory similarly contains only the
auto-generated analysis file.