### PR TITLE
[15.0][OU-FIX] remove merge of stock_orderpoint_manual_procurement into stock

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -106,7 +106,6 @@ merged_modules = {
     "stock_inventory_valuation_pivot": "stock_account",
     # OCA/stock-logistics-warehouse
     "stock_inventory_exclude_sublocation": "stock",
-    "stock_orderpoint_manual_procurement": "stock",
     # OCA/stock-logistics-workflow
     "stock_deferred_assign": "stock",
     "stock_move_assign_picking_hook": "stock",


### PR DESCRIPTION
As migrated in v. 18.0 https://github.com/OCA/stock-logistics-orderpoint/pull/46