### PR TITLE
[19.0][MIG] website_*: trivial submodule annotations

### DIFF
--- a/openupgrade_scripts/scripts/website_blog/19.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_blog/19.0.1.1/upgrade_analysis_work.txt
@@ -1,0 +1,45 @@
+---Models in module 'website_blog'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_blog'---
+website_blog / blog.blog                / is_seo_optimized (boolean)    : is now stored
+website_blog / blog.blog                / sequence (integer)            : NEW hasdefault: default
+website_blog / blog.post                / footer_visible (boolean)      : NEW hasdefault: default
+website_blog / blog.post                / header_visible (boolean)      : NEW hasdefault: default
+website_blog / blog.post                / is_seo_optimized (boolean)    : is now stored
+website_blog / blog.tag                 / is_seo_optimized (boolean)    : is now stored
+
+# NOTHING TO DO
+
+---XML records in module 'website_blog'---
+DEL ir.asset: website_blog.s_blog_posts_000_js
+NEW ir.ui.view: website_blog.blog_post_info
+NEW ir.ui.view: website_blog.dynamic_filter_template_blog_post_single_aside
+NEW ir.ui.view: website_blog.dynamic_filter_template_blog_post_single_badge
+NEW ir.ui.view: website_blog.dynamic_filter_template_blog_post_single_circle
+NEW ir.ui.view: website_blog.dynamic_filter_template_blog_post_single_full
+NEW ir.ui.view: website_blog.s_blog_posts_big_picture
+NEW ir.ui.view: website_blog.s_blog_posts_card
+NEW ir.ui.view: website_blog.s_blog_posts_horizontal
+NEW ir.ui.view: website_blog.s_blog_posts_list
+NEW ir.ui.view: website_blog.s_blog_posts_single_aside
+NEW ir.ui.view: website_blog.s_blog_posts_single_badge
+NEW ir.ui.view: website_blog.s_blog_posts_single_circle
+NEW ir.ui.view: website_blog.s_blog_posts_single_full
+NEW ir.ui.view: website_blog.s_dynamic_snippet_blog_posts_card_preview_data
+NEW ir.ui.view: website_blog.s_dynamic_snippet_blog_posts_horizontal_preview_data
+NEW ir.ui.view: website_blog.s_dynamic_snippet_blog_posts_list_preview_data
+NEW ir.ui.view: website_blog.s_dynamic_snippet_blog_posts_single_aside_preview_data
+NEW ir.ui.view: website_blog.s_dynamic_snippet_blog_posts_single_badge_preview_data
+NEW ir.ui.view: website_blog.s_dynamic_snippet_blog_posts_single_circle_preview_data
+NEW ir.ui.view: website_blog.s_dynamic_snippet_blog_posts_single_full_preview_data
+NEW ir.ui.view: website_blog.s_dynamic_snippet_template_category
+DEL ir.ui.view: website_blog.blog_searchbar_input_snippet_options
+DEL ir.ui.view: website_blog.opt_blog_post_select_to_comment
+DEL ir.ui.view: website_blog.opt_blog_post_select_to_tweet
+DEL ir.ui.view: website_blog.s_blog_posts_options
+DEL ir.ui.view: website_blog.s_dynamic_snippet_options_template
+DEL ir.ui.view: website_blog.snippet_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_crm_iap_reveal/19.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_crm_iap_reveal/19.0.1.1/upgrade_analysis_work.txt
@@ -1,0 +1,10 @@
+---Models in module 'website_crm_iap_reveal'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_crm_iap_reveal'---
+---XML records in module 'website_crm_iap_reveal'---
+NEW ir.model.constraint: website_crm_iap_reveal.constraint_crm_reveal_view_ip_rule_id
+NEW ir.model.constraint: website_crm_iap_reveal.constraint_crm_reveal_view_state_create_date
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_customer/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_customer/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,9 @@
+---Models in module 'website_customer'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_customer'---
+---XML records in module 'website_customer'---
+DEL ir.ui.view: website_customer.snippet_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_event_booth/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_event_booth/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,10 @@
+---Models in module 'website_event_booth'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_event_booth'---
+website_event_booth / website.event.menu       / menu_type (False)             : selection_keys added: [other], removed: [location]
+
+# NOTHING TO DO
+
+---XML records in module 'website_event_booth'---

--- a/openupgrade_scripts/scripts/website_event_booth_sale_exhibitor/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_event_booth_sale_exhibitor/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,10 @@
+---Models in module 'website_event_booth_sale_exhibitor'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_event_booth_sale_exhibitor'---
+website_event_booth_sale_exhibitor / event.booth.registration / sponsor_mobile (char)         : DEL
+
+# NOTHING TO DO
+
+---XML records in module 'website_event_booth_sale_exhibitor'---

--- a/openupgrade_scripts/scripts/website_event_exhibitor/19.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_event_exhibitor/19.0.1.1/upgrade_analysis_work.txt
@@ -1,0 +1,17 @@
+---Models in module 'website_event_exhibitor'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_event_exhibitor'---
+website_event_exhibitor / event.sponsor            / chat_room_id (many2one)       : DEL relation: chat.room
+website_event_exhibitor / event.sponsor            / mobile (char)                 : DEL
+website_event_exhibitor / event.sponsor            / show_on_ticket (boolean)      : NEW hasdefault: default
+website_event_exhibitor / website.event.menu       / menu_type (False)             : selection_keys added: [other], removed: [location, track, track_proposal]
+
+# NOTHING TO DO
+
+---XML records in module 'website_event_exhibitor'---
+DEL ir.model.access: website_event_exhibitor.chat_room_access_event_manager
+DEL ir.ui.view: website_event_exhibitor.snippet_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_event_track/19.0.1.3/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_event_track/19.0.1.3/upgrade_analysis_work.txt
@@ -1,0 +1,19 @@
+---Models in module 'website_event_track'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_event_track'---
+website_event_track / event.track              / _order                        : _order is now 'priority desc, date' ('priority, date')
+website_event_track / event.track              / date (datetime)               : now a function
+website_event_track / event.track              / is_seo_optimized (boolean)    : is now stored
+website_event_track / website.event.menu       / menu_type (False)             : selection_keys added: [exhibitor, other], removed: [location]
+
+# NOTHING TO DO
+
+---XML records in module 'website_event_track'---
+NEW ir.asset: website_event_track.s_searchbar_000_xml
+NEW ir.ui.view: website_event_track.track_list_item
+DEL ir.ui.view: website_event_track.snippet_options
+NEW mail.template: website_event_track.mail_template_data_track_reminder (noupdate)
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_event_track_live/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_event_track_live/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,11 @@
+---Models in module 'website_event_track_live'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_event_track_live'---
+---XML records in module 'website_event_track_live'---
+NEW ir.ui.view: website_event_track_live.event_track_view_list
+NEW ir.ui.view: website_event_track_live.track_list_item
+DEL ir.ui.view: website_event_track_live.tracks_display_list
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_forum/19.0.1.2/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_forum/19.0.1.2/upgrade_analysis_work.txt
@@ -1,0 +1,22 @@
+---Models in module 'website_forum'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_forum'---
+website_forum / forum.forum              / is_seo_optimized (boolean)    : is now stored
+website_forum / forum.forum              / teaser (text)                 : DEL
+website_forum / forum.post               / is_seo_optimized (boolean)    : is now stored
+website_forum / forum.tag                / is_seo_optimized (boolean)    : is now stored
+
+# NOTHING TO DO
+
+---XML records in module 'website_forum'---
+DEL ir.model.access: website_forum.access_forum_post_vote_public
+NEW ir.rule: website_forum.website_forum_post_vote_all (noupdate)
+NEW ir.rule: website_forum.website_forum_post_vote_own (noupdate)
+DEL ir.ui.view: website_forum.forum_searchbar_input_snippet_options
+DEL ir.ui.view: website_forum.snippet_options
+DEL ir.ui.view: website_forum.user_profile_sub_nav
+DEL ir.ui.view: website_forum.view_users_form_forum
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_hr_recruitment/19.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_hr_recruitment/19.0.1.1/upgrade_analysis_work.txt
@@ -1,0 +1,18 @@
+---Models in module 'website_hr_recruitment'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_hr_recruitment'---
+website_hr_recruitment / hr.job                   / is_seo_optimized (boolean)    : is now stored
+
+# NOTHING TO DO
+
+---XML records in module 'website_hr_recruitment'---
+NEW ir.ui.view: website_hr_recruitment.job_filter_base
+NEW ir.ui.view: website_hr_recruitment.job_filter_base_mobile
+NEW ir.ui.view: website_hr_recruitment.job_filter_by_industries
+NEW ir.ui.view: website_hr_recruitment.job_reset_filters
+DEL ir.ui.view: website_hr_recruitment.jobs_searchbar_input_snippet_options
+DEL ir.ui.view: website_hr_recruitment.snippet_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_mail_group/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_mail_group/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,10 @@
+---Models in module 'website_mail_group'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_mail_group'---
+---XML records in module 'website_mail_group'---
+DEL ir.asset: website_mail_group.s_group_000_js
+DEL ir.ui.view: website_mail_group.s_group_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_mass_mailing/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_mass_mailing/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,15 @@
+---Models in module 'website_mass_mailing'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_mass_mailing'---
+---XML records in module 'website_mass_mailing'---
+DEL ir.asset: website_mass_mailing.s_popup_000_js
+NEW ir.ui.view: website_mass_mailing.s_newsletter_benefits_popup
+NEW ir.ui.view: website_mass_mailing.s_newsletter_box
+NEW ir.ui.view: website_mass_mailing.s_newsletter_centered
+NEW ir.ui.view: website_mass_mailing.s_newsletter_grid
+DEL ir.ui.view: website_mass_mailing.newsletter_subscribe_options
+DEL ir.ui.view: website_mass_mailing.newsletter_subscribe_options_common
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_mass_mailing_sms/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_mass_mailing_sms/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,12 @@
+---Models in module 'website_mass_mailing_sms'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_mass_mailing_sms'---
+---XML records in module 'website_mass_mailing_sms'---
+NEW ir.ui.view: website_mass_mailing_sms.s_newsletter_sms_notifications
+NEW ir.ui.view: website_mass_mailing_sms.s_newsletter_subscribe_form
+NEW ir.ui.view: website_mass_mailing_sms.snippets
+DEL ir.ui.view: website_mass_mailing_sms.newsletter_subscribe_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_partner/19.0.0.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_partner/19.0.0.1/upgrade_analysis_work.txt
@@ -1,0 +1,14 @@
+---Models in module 'website_partner'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_partner'---
+website_partner / res.partner              / is_seo_optimized (boolean)    : is now stored
+
+# NOTHING TO DO
+
+---XML records in module 'website_partner'---
+NEW mail.message.subtype: website_partner.mt_partner_published (noupdate)
+NEW mail.message.subtype: website_partner.mt_partner_unpublished (noupdate)
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_profile/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_profile/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,11 @@
+---Models in module 'website_profile'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_profile'---
+---XML records in module 'website_profile'---
+DEL ir.ui.view: website_profile.user_biography_editor
+DEL ir.ui.view: website_profile.user_profile_edit_content
+DEL ir.ui.view: website_profile.user_profile_edit_main
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_project/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_project/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,11 @@
+---Models in module 'website_project'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_project'---
+website_project / project.task             / email_from (char)             : module is now 'project' ('website_project')
+website_project / project.task             / partner_phone (char)          : module is now 'project' ('website_project')
+
+# NOTHING TO DO
+
+---XML records in module 'website_project'---

--- a/openupgrade_scripts/scripts/website_sale_collect/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale_collect/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,10 @@
+---Models in module 'website_sale_collect'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_sale_collect'---
+website_sale_collect / payment.provider         / custom_mode (False)           : selection_keys added: [cash_on_delivery] (most likely nothing to do)
+
+# NOTHING TO DO
+
+---XML records in module 'website_sale_collect'---

--- a/openupgrade_scripts/scripts/website_sale_collect_wishlist/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale_collect_wishlist/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,9 @@
+---Models in module 'website_sale_collect_wishlist'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_sale_collect_wishlist'---
+---XML records in module 'website_sale_collect_wishlist'---
+NEW ir.ui.view: website_sale_collect_wishlist.unavailable_products_warning
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_sale_comparison/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale_comparison/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,10 @@
+---Models in module 'website_sale_comparison'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_sale_comparison'---
+---XML records in module 'website_sale_comparison'---
+DEL ir.ui.view: website_sale_comparison.product_product
+DEL ir.ui.view: website_sale_comparison.snippet_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_sale_loyalty/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale_loyalty/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,11 @@
+---Models in module 'website_sale_loyalty'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_sale_loyalty'---
+---XML records in module 'website_sale_loyalty'---
+NEW ir.ui.view: website_sale_loyalty.cart_lines_quantity
+DEL ir.ui.view: website_sale_loyalty.snippet_options
+DEL ir.ui.view: website_sale_loyalty.website_sale_coupon_cart_hide_qty
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_sale_mondialrelay/19.0.0.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale_mondialrelay/19.0.0.1/upgrade_analysis_work.txt
@@ -1,0 +1,15 @@
+---Models in module 'website_sale_mondialrelay'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_sale_mondialrelay'---
+---XML records in module 'website_sale_mondialrelay'---
+NEW ir.ui.view: website_sale_mondialrelay.address_on_checkout
+NEW ir.ui.view: website_sale_mondialrelay.website_sale_mondialrelay_address_card
+NEW ir.ui.view: website_sale_mondialrelay.website_sale_mondialrelay_billing_address_list
+DEL ir.ui.view: website_sale_mondialrelay.res_config_settings_view_form
+DEL ir.ui.view: website_sale_mondialrelay.website_sale_mondialrelay_address_kanban
+DEL ir.ui.view: website_sale_mondialrelay.website_sale_mondialrelay_address_on_payment
+DEL ir.ui.view: website_sale_mondialrelay.website_sale_mondialrelay_billing_address_row
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_sale_slides/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale_slides/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,14 @@
+---Models in module 'website_sale_slides'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_sale_slides'---
+website_sale_slides / product.template         / service_tracking (False)      : selection_keys added: [partnership, repair] (most likely nothing to do)
+
+# NOTHING TO DO
+
+---XML records in module 'website_sale_slides'---
+DEL ir.ui.view: website_sale_slides.snippet_options
+DEL product.category: website_sale_slides.product_category_courses
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_sale_stock/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale_stock/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,10 @@
+---Models in module 'website_sale_stock'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_sale_stock'---
+website_sale_stock / product.ribbon           / assign (False)                : NEW selection_keys: ['manual', 'new', 'out_of_stock', 'sale'], mode: modify
+
+# NOTHING TO DO
+
+---XML records in module 'website_sale_stock'---

--- a/openupgrade_scripts/scripts/website_sale_wishlist/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_sale_wishlist/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,17 @@
+---Models in module 'website_sale_wishlist'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_sale_wishlist'---
+website_sale_wishlist / website                  / wishlist_gap (char)           : NEW hasdefault: default
+website_sale_wishlist / website                  / wishlist_grid_columns (integer): NEW hasdefault: default
+website_sale_wishlist / website                  / wishlist_mobile_columns (integer): NEW hasdefault: default
+website_sale_wishlist / website                  / wishlist_opt_products_design_classes (char): NEW hasdefault: default
+
+# NOTHING TO DO
+
+---XML records in module 'website_sale_wishlist'---
+NEW ir.ui.view: website_sale_wishlist.empty_wishlist_svg
+DEL ir.ui.view: website_sale_wishlist.snippet_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_slides_forum/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_slides_forum/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,9 @@
+---Models in module 'website_slides_forum'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_slides_forum'---
+---XML records in module 'website_slides_forum'---
+DEL ir.ui.view: website_slides_forum.snippet_options
+
+# NOTHING TO DO

--- a/openupgrade_scripts/scripts/website_slides_survey/19.0.1.0/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/website_slides_survey/19.0.1.0/upgrade_analysis_work.txt
@@ -1,0 +1,11 @@
+---Models in module 'website_slides_survey'---
+
+# NOTHING TO DO
+
+---Fields in module 'website_slides_survey'---
+---XML records in module 'website_slides_survey'---
+NEW ir.ui.view: website_slides_survey.courses_search_bar_inherit_survey
+NEW ir.ui.view: website_slides_survey.courses_search_results_inherit_survey
+DEL ir.ui.view: website_slides_survey.courses_home_inherit_survey
+
+# NOTHING TO DO


### PR DESCRIPTION
Annotation-only coverage for 26 `website_*` submodules. Split from #5633 to separate trivial annotations from the 5 modules that need pre-migration scripts (now #5633b).