### PR TITLE
[16.0][FIX] fix pos.session cash register amounts

### DIFF
--- a/openupgrade_scripts/scripts/point_of_sale/16.0.1.0.1/post-migration.py
+++ b/openupgrade_scripts/scripts/point_of_sale/16.0.1.0.1/post-migration.py
@@ -27,11 +27,16 @@ def copy_register_balance(cr):
     openupgrade.logged_query(
         cr,
         """
-        UPDATE pos_session session
-        SET cash_register_balance_end_real=statement.balance_end_real,
-            cash_register_balance_start=statement.balance_start
-        FROM account_bank_statement statement
-        WHERE statement.pos_session_id=session.id
+        update pos_session as ps
+        set
+            cash_register_balance_end_real = coalesce(abs.balance_end_real, 0),
+            cash_register_balance_start = coalesce(abs.balance_start, 0)
+        from pos_session as ps2
+        left outer join account_bank_statement as abs on
+            abs.pos_session_id = ps2.id and
+            abs.journal_id = ps2.cash_journal_id
+        where
+            ps2.id = ps.id
         """,
     )
 


### PR DESCRIPTION
ensure that the `account.bank.statement` record corresponding to the cash journal is used to set the value of the cash register fields, as there can be multiple records linked to the pos.session (one per payment method), and ensure that the values are not null.