### PR TITLE
[19.0][FIX] hr_expense: don't update product uom when product is invoiced

### DIFF
--- a/openupgrade_scripts/scripts/hr_expense/19.0.2.1/noupdate_changes-transformation.xml
+++ b/openupgrade_scripts/scripts/hr_expense/19.0.2.1/noupdate_changes-transformation.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <!--
+    Don't update UOM ids of products
+    -->
+    <xpath
+        expr=
+        "//record[@id='expense_product_communication']/field[@name='uom_id']"
+        position="replace"
+    />
+    <xpath
+        expr="//record[@id='expense_product_gift']/field[@name='uom_id']"
+        position="replace"
+    />
+</odoo>

--- a/openupgrade_scripts/scripts/hr_expense/19.0.2.1/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/19.0.2.1/post-migration.py
@@ -3,6 +3,8 @@
 
 from openupgradelib import openupgrade
 
+from odoo.exceptions import ValidationError
+
 
 def hr_expense_account_move_id(env):
     """
@@ -55,6 +57,20 @@ def hr_expense_state(env):
     records._compute_state()
 
 
+def update_product_uoms(env):
+    """
+    Set updated product uoms if possible
+    """
+    uom = env.ref("uom.product_uom_unit")
+    for xmlid in ("expense_product_communication", "expense_product_gift"):
+        product = env.ref(f"hr_expense.{xmlid}")
+        org_uom = product.uom_id
+        try:
+            product.uom_id = uom
+        except ValidationError:
+            product.uom_id = org_uom
+
+
 deleted_xmlids = [
     "hr_expense.hr_expense_report_comp_rule",
     "hr_expense.ir_rule_hr_expense_sheet_approver",
@@ -66,8 +82,14 @@ deleted_xmlids = [
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.load_data(env, "hr_expense", "19.0.2.1/noupdate_changes.xml")
+    openupgrade.load_data(
+        env,
+        "hr_expense",
+        "19.0.2.1/noupdate_changes.xml",
+        xml_transformation_filename="19.0.2.1/noupdate_changes-transformation.xml",
+    )
     hr_expense_account_move_id(env)
     hr_expense_approval_fields(env)
     hr_expense_state(env)
+    update_product_uoms(env)
     openupgrade.delete_records_safely_by_xml_id(env, deleted_xmlids)

--- a/openupgrade_scripts/scripts/hr_expense/tests/data_hr_expense_migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/tests/data_hr_expense_migration.py
@@ -2,6 +2,9 @@ env = locals().get("env")
 env.ref("hr_expense.team_building_sheet").action_submit_sheet()
 env.ref("hr_expense.office_furniture_sheet").action_submit_sheet()
 env.ref("hr_expense.office_furniture_sheet").action_approve_expense_sheets()
+env.ref("hr_expense.lunch_demo_customer_bill_expense").product_id = env.ref(
+    "hr_expense.expense_product_gift"
+)
 env.ref("hr_expense.customer_meeting_sheet").action_submit_sheet()
 env.ref("hr_expense.customer_meeting_sheet").action_approve_expense_sheets()
 env.ref("hr_expense.customer_meeting_sheet").action_sheet_move_post()

--- a/openupgrade_scripts/scripts/hr_expense/tests/test_hr_expense_migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/tests/test_hr_expense_migration.py
@@ -25,3 +25,18 @@ class TestHrExpenseMigration(TransactionCase):
             self.env.ref("hr_expense.travel_demo_by_car_expense").state,
             "paid",
         )
+
+    def test_product_uoms(self):
+        """
+        Test that expense products' UOMs where updated where possible
+        """
+        self.assertEqual(
+            self.env.ref("hr_expense.expense_product_gift").uom_id,
+            self.env.ref("uom.product_uom_km"),
+            "Gift UOM should not have been changed because it's used in posted move",
+        )
+        self.assertEqual(
+            self.env.ref("hr_expense.expense_product_communication").uom_id,
+            self.env.ref("uom.product_uom_unit"),
+            "Communication UOM should have been updated to unit",
+        )


### PR DESCRIPTION
we can't update product UOMs if the products in question are invoiced

Depends on

- [x] https://github.com/OCA/openupgradelib/pull/452