### PR TITLE
[16.0][IMP] account: migrate bank statement chatter attachments to attachment_ids

### DIFF
--- a/openupgrade_scripts/scripts/account/16.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/account/16.0.1.2/post-migration.py
@@ -32,6 +32,23 @@ _deleted_xml_records = [
 ]
 
 
+def _fill_account_bank_statement_attachment_ids(env):
+    """The chatter attachments of the bank statements are now linked through
+    the new `attachment_ids` many2many field, so we fill it with the existing ones.
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        INSERT INTO account_bank_statement_ir_attachment_rel
+            (account_bank_statement_id, ir_attachment_id)
+        SELECT ia.res_id, ia.id
+        FROM account_bank_statement abs
+            JOIN ir_attachment ia ON abs.id = ia.res_id
+        WHERE ia.res_model = 'account.bank.statement'
+        """,
+    )
+
+
 def _compute_remaining_account_payment_amount_company_currency_signed(env):
     """Those payment with different currency than the company ones are not easily
     computed by SQL, so we use ORM for these cases, but they should luckily be few.
@@ -50,6 +67,7 @@ def migrate(env, version):
         env,
         _deleted_xml_records,
     )
+    _fill_account_bank_statement_attachment_ids(env)
     _compute_remaining_account_payment_amount_company_currency_signed(env)
     # credit_limit converted to company dependent
     old_column = openupgrade.get_legacy_name("credit_limit")

--- a/openupgrade_scripts/scripts/account/16.0.1.2/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/16.0.1.2/upgrade_analysis_work.txt
@@ -97,7 +97,7 @@ account      / account.bank.statement   / _order                        : _order
 # NOTHING TO DO
 
 account      / account.bank.statement   / attachment_ids (many2many)    : NEW relation: ir.attachment
-# Put in this field existing chatter attachments?
+# DONE: post-migration: fill this field with the existing chatter attachments
 
 account      / account.bank.statement   / cashbox_end_id (many2one)     : DEL relation: account.bank.statement.cashbox
 account      / account.bank.statement   / cashbox_start_id (many2one)   : DEL relation: account.bank.statement.cashbox


### PR DESCRIPTION
In Odoo 16, account.bank.statement gains a new attachment_ids many2many field to ir.attachment. Add a post-migration query that links the existing chatter attachments (ir.attachment with res_model = 'account.bank.statement') into this field.

cc @Tecnativa TT63091

ping @pedrobaeza @sergio-teruel  