### PR TITLE
[18.0][OU-FIX] l10n_it: remove xmlid for taxes as they would be partially duplicated with possible critics errors during migration

### DIFF
--- a/openupgrade_scripts/scripts/l10n_it/18.0.0.9/pre-migration.py
+++ b/openupgrade_scripts/scripts/l10n_it/18.0.0.9/pre-migration.py
@@ -1,0 +1,27 @@
+from openupgradelib import openupgrade
+
+# List of XML IDs of tax reports defined in l10n_it
+# These include the generic VAT report and the annual reports
+ITALIAN_REPORT_XML_IDS = [
+    "l10n_it.tax_report_vat",
+    "l10n_it.tax_annual_report_vat_va",
+    "l10n_it.tax_annual_report_vat_ve",
+    "l10n_it.tax_annual_report_vat_vf",
+    "l10n_it.tax_annual_report_vat_vh",
+    "l10n_it.tax_annual_report_vat_vj",
+    "l10n_it.tax_annual_report_vat_vl",
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """
+    Remove existing reports and related records to avoid duplications.
+    """
+    if not version:
+        return
+
+    # Try standard cleanup first, this usually isn't enough
+    openupgrade.delete_records_safely_by_xml_id(
+        env, ITALIAN_REPORT_XML_IDS, delete_childs=True
+    )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,1 @@
-openupgradelib @ git+https://github.com/OCA/openupgradelib.git@master
+openupgradelib @ git+https://github.com/OCA/openupgradelib@refs/pull/455/head#subdirectory=openupgradelib


### PR DESCRIPTION
During migration from 17.0 of l10n_it the records with option `auto_sequence="1"` re-create theirs xmlids and sometimes they conflict with the existing records.

This PR remove completely them, to let Odoo re-create them safely.

This PR is for Italian module, maybe it could be a need of other localization modules too.