### PR TITLE
[ADD] product_sale_tax_price_included: merged into 'account'.

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -98,6 +98,7 @@ merged_modules = {
     "pos_sale_order_load": "pos_sale",
     # OCA/product-attribute
     "stock_account_product_cost_security": "product_cost_security",
+    "product_sale_tax_price_included": "account",
     # OCA/server-tools
     "base_jsonify": "jsonifier",
     # OCA/server-ux


### PR DESCRIPTION
product_sale_tax_price_included is an OCA module that basically provide the new native feature 'tax_string', on product models.

https://github.com/OCA/product-attribute/tree/12.0/product_sale_tax_price_included#product-sale-tax-price-included