### PR TITLE
[ADD] github action to check PR dependencies

### DIFF
--- a/.github/actions/check-pr-dependency/action.yml
+++ b/.github/actions/check-pr-dependency/action.yml
@@ -1,0 +1,17 @@
+name: 'Check PR dependencies'
+description: 'List PR dependencies in comment, set labels Dependency OK, Blocked by dependency'
+inputs:
+  version:
+    description: 'OpenUpgrade version'
+    required: true
+branding:
+  icon: 'git-merge'
+  color: 'yellow'
+runs:
+  using: "composite"
+  steps:
+    - name: 'Run check'
+      run: |
+        pip install -r ${{ github.action_path }}/requirements.txt
+        python ${{ github.action_path }}/check_dependency.py --version ${{ inputs.version }} --repo ${{ github.repository }} --github-login ${{ github.actor }}
+      shell: sh

--- a/.github/actions/check-pr-dependency/check_dependency.py
+++ b/.github/actions/check-pr-dependency/check_dependency.py
@@ -1,0 +1,157 @@
+import re
+from pathlib import Path
+
+from github import Auth, Github
+from github.PullRequestReview import PullRequestReview
+
+import private_config
+import tools
+
+github_token_file = Path(private_config.GITHUB_TOKEN_PATH)
+with github_token_file.open(mode="r") as file:
+    github_token = file.read()
+
+auth = Auth.Token(github_token)
+
+g = Github(auth=auth)
+repo = g.get_repo("OCA/OpenUpgrade")
+
+# #######################
+# Custom Function
+# #######################
+def module_ok(module_name):
+    return module_coverage[module_name] in ["nothing_to_do", "done"]
+
+def _extract_migration_comment(migration_message):
+    if not migration_message:
+        return "", "", ""
+    text_reg = (
+        r"(?P<before>(\r|\n|.)*)"
+        r"<dependency>"
+        "(?P<current_text>(\n|.)*)"
+        r"<\/dependency>"
+        r"(?P<after>(\r|\n|.)*)"
+    )
+    res = re.match(text_reg, migration_message.body)
+    if not res:
+        return "", "", ""
+    groups = res.groupdict()
+    return groups["before"], groups["current_text"], groups["after"]
+
+
+def _get_comment_or_review(pr, content):
+    comments = [x for x in pr.get_issue_comments() if content in x.body]
+    if comments:
+        return comments[0]
+    reviews = [x for x in pr.get_reviews() if content in x.body]
+    return reviews and reviews[0] or False
+
+
+# ####################################
+# Main Script
+# ####################################
+
+for current_version in private_config.CHECK_DEPENDENCY_VERSIONS:
+    tools._logger.info(f"*************************************************")
+    tools._logger.info(f"Update Dependencies for Version {current_version}")
+    tools._logger.info(f"*************************************************")
+
+    # Get Opened PRs
+    done_prs, opened_prs = tools._get_prs(repo, current_version)
+
+    # Get Done modules
+    module_coverage = tools._get_module_coverage(repo, current_version)
+
+
+    for module_name, pr_number in opened_prs.items():
+        tools._logger.info(f"Handle PR #{pr_number} for module '{module_name}'")
+        manifest = tools._get_manifest_module(repo, current_version, module_name)
+        if not manifest:
+            tools._logger.info(f"the module {module_name} disappeared in the new version.")
+            continue
+
+        depends = manifest.get("depends")
+        pr = repo.get_pull(pr_number)
+
+        migration_message = _get_comment_or_review(pr, "ocabot migration")
+        current_labels = [x.name for x in pr.labels]
+        new_labels = current_labels.copy()
+
+        log_message = f"PR #{pr_number} for {module_name}:"
+        if all([module_ok(x) for x in depends]):
+            # all dependencies are OK, mark the PR as OK.
+            label_to_remove = "Blocked by dependency"
+            label_to_add = "Dependency OK"
+        else:
+            # mark the PR as blocked
+            label_to_remove = "Dependency OK"
+            label_to_add = "Blocked by dependency"
+
+        if label_to_remove in new_labels:
+            log_message += f" Remove '{label_to_remove}'"
+            new_labels.remove(label_to_remove)
+
+        if label_to_add not in new_labels:
+            log_message += f" Set '{label_to_add}'"
+            new_labels.append(label_to_add)
+
+        if new_labels != current_labels:
+            tools._logger.info(log_message)
+            pr.set_labels(*new_labels)
+
+        if not migration_message:
+            tools._logger.warning(f"Migration message not found in {pr.number}")
+            continue
+
+        before_text, current_text, after_text = _extract_migration_comment(
+            migration_message
+        )
+
+        dep_modules_ok = [x for x in depends if x in done_prs]
+        dep_modules_pending = [x for x in depends if x in opened_prs]
+        dep_modules_ko = [
+            x for x in depends if x not in dep_modules_ok + dep_modules_pending
+        ]
+        new_text = ""
+        for dep_module in dep_modules_ok:
+            new_text += f"\n- {dep_module} : #{done_prs[dep_module]}"
+        for dep_module in dep_modules_pending:
+            new_text += f"\n- {dep_module} : #{opened_prs[dep_module]}"
+        for dep_module in dep_modules_ko:
+            new_text += f"\n- {dep_module} : TODO"
+            if module_ok(dep_module):
+                tools._logger.error(f"{dep_module} not found in the issue 'Migration to version {current_version}'")
+
+
+        if new_text:
+            new_text = "Depends on : \n" + new_text
+
+        new_body = ""
+        if not current_text and new_text:
+            tools._logger.info(
+                f"PR#{pr.number} - {pr.title}: ADDING Text in migration message."
+            )
+            if migration_message.user.login != private_config.GITHUB_LOGIN:
+                tools._logger.warning(
+                    f"The message has been written by @{migration_message.user.login}"
+                )
+            new_body = (
+                migration_message.body + "\n\n<dependency>" + new_text + "</dependency>"
+            )
+        elif new_text != current_text:
+            tools._logger.info(
+                f"PR#{pr.number} - {pr.title}: Replacing text in migration message."
+            )
+            if migration_message.user.login != private_config.GITHUB_LOGIN:
+                tools._logger.warning(
+                    f"The message has been written by @{migration_message.user.login}"
+                )
+            new_body = (
+                before_text + "<dependency>" + new_text + "</dependency>" + after_text
+            )
+
+        if new_body:
+            if type(migration_message) is PullRequestReview:
+                tools._logger.warning("Unable to edit the PR due to PyGithub limitation.")
+                continue
+            migration_message.edit(new_body)

--- a/.github/actions/check-pr-dependency/check_dependency.py
+++ b/.github/actions/check-pr-dependency/check_dependency.py
@@ -1,20 +1,25 @@
+import argparse
+import os
 import re
 from pathlib import Path
 
 from github import Auth, Github
 from github.PullRequestReview import PullRequestReview
 
-import private_config
 import tools
 
-github_token_file = Path(private_config.GITHUB_TOKEN_PATH)
-with github_token_file.open(mode="r") as file:
-    github_token = file.read()
+parser = argparse.ArgumentParser()
+parser.add_argument('--version', nargs='+')
+parser.add_argument('--repo', default='OCA/OpenUpgrade')
+parser.add_argument('--github-login', default='ocabot')
+args = parser.parse_args()
 
-auth = Auth.Token(github_token)
+auth = None
+if os.environ.get('GITHUB_TOKEN'):
+    auth = Auth.Token(os.environ.get('GITHUB_TOKEN'))
 
 g = Github(auth=auth)
-repo = g.get_repo("OCA/OpenUpgrade")
+repo = g.get_repo(args.repo)
 
 # #######################
 # Custom Function
@@ -51,7 +56,7 @@ def _get_comment_or_review(pr, content):
 # Main Script
 # ####################################
 
-for current_version in private_config.CHECK_DEPENDENCY_VERSIONS:
+for current_version in map(float, args.version):
     tools._logger.info(f"*************************************************")
     tools._logger.info(f"Update Dependencies for Version {current_version}")
     tools._logger.info(f"*************************************************")
@@ -131,7 +136,7 @@ for current_version in private_config.CHECK_DEPENDENCY_VERSIONS:
             tools._logger.info(
                 f"PR#{pr.number} - {pr.title}: ADDING Text in migration message."
             )
-            if migration_message.user.login != private_config.GITHUB_LOGIN:
+            if migration_message.user.login != args.github_login:
                 tools._logger.warning(
                     f"The message has been written by @{migration_message.user.login}"
                 )
@@ -142,7 +147,7 @@ for current_version in private_config.CHECK_DEPENDENCY_VERSIONS:
             tools._logger.info(
                 f"PR#{pr.number} - {pr.title}: Replacing text in migration message."
             )
-            if migration_message.user.login != private_config.GITHUB_LOGIN:
+            if migration_message.user.login != args.github_login:
                 tools._logger.warning(
                     f"The message has been written by @{migration_message.user.login}"
                 )

--- a/.github/actions/check-pr-dependency/requirements.txt
+++ b/.github/actions/check-pr-dependency/requirements.txt
@@ -1,0 +1,2 @@
+PyGithub
+XlsxWriter

--- a/.github/actions/check-pr-dependency/requirements.txt
+++ b/.github/actions/check-pr-dependency/requirements.txt
@@ -1,2 +1,1 @@
 PyGithub
-XlsxWriter

--- a/.github/actions/check-pr-dependency/tools.py
+++ b/.github/actions/check-pr-dependency/tools.py
@@ -1,0 +1,90 @@
+import logging
+import re
+import sys
+import urllib
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="[%(asctime)s] {%(filename)s:%(lineno)d} %(levelname)s - %(message)s",
+    handlers=[logging.StreamHandler(stream=sys.stdout)],
+)
+
+_logger = logging.getLogger()
+
+
+def _get_prs(repo, version):
+    opened_prs = {}
+    done_prs = {}
+
+    line_reg = (
+        r"- \[(?P<done> |x)\] (\(del\) )?(\(new\) )?"
+        r"(?P<module_name>\w+).*(pull\/|#)(?P<pr_number>\d+)"
+    )
+    issue_title = f"Migration to version {version:.1f}"
+
+    _logger.info(f"Get PRs referenced in '{issue_title}' ...")
+    # Get main issue to have PRs numbers
+    for issue in repo.get_issues():
+        if issue.title == issue_title:
+            for line in issue.body.split("\n"):
+                if not line.startswith("- ["):
+                    continue
+                res = re.match(line_reg, line)
+                if not res:
+                    _logger.debug(f"Unable to parse correctly '{line}'")
+                    continue
+                groups = res.groupdict()
+                pr_number = int(groups["pr_number"])
+                if groups["done"] == "x":
+                    done_prs[groups["module_name"]] = pr_number
+                else:
+                    opened_prs[groups["module_name"]] = pr_number
+    _logger.info(
+        f">> found {len(done_prs)} done PRs" f" and {len(opened_prs)} Opened PRs"
+    )
+    return done_prs, opened_prs
+
+
+def _get_module_coverage(repo, version):
+    file_name = f"modules{(version - 1) * 10:.0f}-{(version) * 10:.0f}.rst"
+    url = (
+        f"https://raw.githubusercontent.com/OCA/OpenUpgrade"
+        f"/{version:.1f}/docsource/"
+        f"{file_name}"
+    )
+    module_coverage = {}
+    _logger.info(f"Get and parse {file_name} to know coverage state ...")
+    page = urllib.request.urlopen(url).read().decode()
+    for line in page.split("\n"):
+        line = line.replace("|del|", "").replace("|new|", "")
+        if not line.startswith("|"):
+            continue
+        res = line.split("|")
+        module_name = res[1].strip()
+        status = res[2].strip()
+        if module_name == "Module":
+            continue
+        if status == "":
+            module_coverage[module_name] = "to_do"
+        elif status == "Nothing to do":
+            module_coverage[module_name] = "nothing_to_do"
+        elif status.startswith("Done"):
+            module_coverage[module_name] = "done"
+        else:
+            continue
+            # TODO:fix me
+            raise Exception("Status '%s' has not been analyzed." % (status))
+    _logger.info(f">> found {len(module_coverage)} modules.")
+    return module_coverage
+
+
+def _get_manifest_module(repo, version, module_name):
+    url = (
+        f"https://raw.githubusercontent.com/odoo/"
+        f"odoo/{version:.1f}/addons/{module_name}/__manifest__.py"
+    )
+    try:
+        page = urllib.request.urlopen(url).read().decode()
+    except urllib.error.HTTPError:
+        return
+    return eval(page)

--- a/.github/workflows/check_pr_dependency.yml
+++ b/.github/workflows/check_pr_dependency.yml
@@ -1,0 +1,19 @@
+name: Check PR dependencies
+
+on:
+  issues:
+    types: [edited]
+
+jobs:
+  check_dependency:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        if: ${{ github.event.issue.state == 'open' && startsWith( github.event.issue.title, 'Migration to version ' ) }}
+      - name: Check dependency
+        if: ${{ github.event.issue.state == 'open' && startsWith( github.event.issue.title, 'Migration to version ' ) }}
+        uses: ./.github/actions/check-pr-dependency
+        with:
+          version: ${{ github.event.issue.milestone.title }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
this adds `check_dependency.py` from https://github.com/grap/openupgrade-extra-tools/tree/master as a github action that runs whenever one of the "Migration to version *" issues is edited (that is: whenever somebody says / ocabot migration something)

I've only added a very light touchup to make it easy to run the script as github action, this way you can keep running it manually if you want.

You can see this work in my [test issue](https://github.com/hbrunn/OpenUpgrade/issues/22) which refers to https://github.com/hbrunn/OpenUpgrade/pull/21, which was updated in the [last run](https://github.com/hbrunn/OpenUpgrade/actions/runs/28015469107/job/82918572168#step:3:39) triggered by me editing the issue manually