### PR TITLE
[19.0][OU-IMP] base: Call disable_invalid_filters

### DIFF
--- a/openupgrade_scripts/scripts/base/19.0.1.3/end-migration.py
+++ b/openupgrade_scripts/scripts/base/19.0.1.3/end-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2026 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.disable_invalid_filters(env)


### PR DESCRIPTION
It's missing in this version.

@Tecnativa 