### PR TITLE
[17.0][FIX] stock: picked not synchronized between stock.move and stock.move.line

### DIFF
--- a/openupgrade_scripts/scripts/stock/17.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/stock/17.0.1.1/pre-migration.py
@@ -71,6 +71,17 @@ def prefill_picked(env):
             AND sm.id = sm2.id
         """,
     )
+    # Need to set sms picked to False when the related smls are not picked
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE stock_move sm
+        SET picked=False
+        FROM stock_move_line sml
+        WHERE sml.move_id = sm.id
+          AND NOT sml.picked
+        """,
+    )
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
When the stock.move has stock.move.line related, the value of the stock.move was not set to False but it can have stock.move.line with the falsy value, so check if the value of the lines are False so set the value of the move.

cc @Tecnativa TT63355

ping @pedrobaeza @carlosdauden 

