### PR TITLE
[19.0][OU-IMP] base: Concat phone and mobile

### DIFF
--- a/openupgrade_scripts/scripts/base/19.0.1.3/post-migration.py
+++ b/openupgrade_scripts/scripts/base/19.0.1.3/post-migration.py
@@ -96,6 +96,23 @@ def _init_default_user_group(env):
     )
 
 
+def _migrate_partner_mobile(env):
+    openupgrade.copy_columns(env.cr, {"res_partner": [("phone", None, None)]})
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE res_partner
+        SET phone = CONCAT(
+            COALESCE(phone, ''),
+            CASE WHEN COALESCE(phone, '') != '' THEN ' // ' ELSE '' END,
+            mobile
+        )
+        WHERE COALESCE(mobile, '') != ''
+        AND COALESCE(phone, '') != COALESCE(mobile, '')
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(
@@ -114,3 +131,4 @@ def migrate(env, version):
     _ir_actions_server_html_value(env)
     _ir_filters_user_ids(env)
     _res_lang(env)
+    _migrate_partner_mobile(env)

--- a/openupgrade_scripts/scripts/base/19.0.1.3/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/base/19.0.1.3/upgrade_analysis_work.txt
@@ -243,7 +243,7 @@ base         / res.lang                 / time_format (char)            : type i
 
 base         / res.partner              / mobile (char)                 : DEL
 
-# NOTHING TO DO: possibly some oca module will pick this up again
+# DONE: pos-migration: If the phone field is empty and the mobile field contains a value, populate phone with the mobile number. If both phone and mobile contain different values, concatenate the mobile number to the phone field.
 
 base         / res.partner              / properties (properties)       : NEW hasdefault: compute
 


### PR DESCRIPTION
`mobile` field no longer exist in `res.partner`, let's concatenate the `mobile` value with the `phone` for those users who use `mobile` instead. In case there is no phone avoid adding the " | " in the middle.

@Tecnativa
@pedrobaeza @eduezerouali-tecnativa 