### PR TITLE
[19.0][OU-IMP] crm: Add separator to phone and mobile concatenation

### DIFF
--- a/openupgrade_scripts/scripts/crm/19.0.1.9/post-migration.py
+++ b/openupgrade_scripts/scripts/crm/19.0.1.9/post-migration.py
@@ -4,12 +4,18 @@ from openupgradelib import openupgrade
 
 
 def _migrate_lead_mobile(env):
+    openupgrade.copy_columns(env.cr, {"crm_lead": [("phone", None, None)]})
     openupgrade.logged_query(
         env.cr,
         """
         UPDATE crm_lead
-        SET phone = CONCAT(COALESCE(phone, ''), mobile)
+        SET phone = CONCAT(
+            COALESCE(phone, ''),
+            CASE WHEN COALESCE(phone, '') != '' THEN ' // ' ELSE '' END,
+            mobile
+        )
         WHERE COALESCE(mobile, '') != ''
+        AND COALESCE(phone, '') != COALESCE(mobile, '')
         """,
     )
 


### PR DESCRIPTION
Depending on how the user wrote down the phone and mobile fields, after the migration the phone can get ambiguous. Added a separator to avoid it.

@Tecnativa 
@pedrobaeza @eduezerouali-tecnativa 