### PR TITLE
[17.0][FIX] openupgrade_framework: Allow missing path_info

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
+++ b/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py
@@ -94,7 +94,7 @@ def _inverse_arch(self):
     """
     if "install_filename" in self._context:
         path_info = get_resource_from_path(self._context["install_filename"])
-        if path_info[0] == "openupgrade_scripts":
+        if path_info and path_info[0] == "openupgrade_scripts":
             # Needs to override the context to remove the install_filename
             self = self.with_context(  # pylint: disable=context-overridden
                 {k: v for k, v in self._context.items() if k != "install_filename"}


### PR DESCRIPTION
For avoiding this error when using `load_data` openupgradelib method:

```
    ...
    File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5094, in _load_records
    data['record']._load_records_write(data['values'])
    File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_ui_view.py", line 2171, in _load_records_write
    super(View, self)._load_records_write(values)
    File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5025, in _load_records_write
    self.write(values)
    ...
    File "/opt/odoo/auto/addons/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_ui_view.py", line 97, in _inverse_arch
    if path_info[0] == "openupgrade_scripts":
TypeError: 'NoneType' object is not subscriptable
```

@Tecnativa 