### PR TITLE
[19.0][IMP] base: Load additional renames/merges from env.

### DIFF
--- a/openupgrade_scripts/scripts/base/19.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/base/19.0.1.3/pre-migration.py
@@ -170,8 +170,12 @@ def migrate(env, version):
         } AS (SELECT name, state FROM ir_module_module);
         """,
     )
-    openupgrade.update_module_names(env.cr, renamed_modules.items())
-    openupgrade.update_module_names(env.cr, merged_modules.items(), merge_modules=True)
+    openupgrade.update_module_names(
+        env.cr, renamed_modules.items(), environment_namespec=True
+    )
+    openupgrade.update_module_names(
+        env.cr, merged_modules.items(), merge_modules=True, environment_namespec=True
+    )
     openupgrade.clean_transient_models(env.cr)
     openupgrade.rename_xmlids(env.cr, _renamed_xmlids)
     openupgrade.rename_xmlids(env.cr, _merged_xmlids, allow_merge=True)


### PR DESCRIPTION
With this change, merging and renaming private modules no longer needs to be done in a custom module, and now can happen at the same time as OCA modules.
To use this feature:

When running openupgrade, set the OPENUPGRADE_MERGED_MODULES and OPENUPGRADE_RENAMED_MODULES environment variables to raw JSON data containing the private renames/merges in the same format as in apriori.py .
Example OPENUPGRADE_MERGED_MODULES to merge "custom module" into "helpdesk_mgmt".
`{"custom_module":"helpdesk_mgmt"}`


No changes should be made on current workflows if this feature is not used.

Once this PR gets approved i'll backport to all versions of OU

@pedrobaeza @victoralmau 
@tecnativa TT63118