### PR TITLE
[19.0][IMP] check_dependency: don't set blocked label when dependencies are added in same PR

### DIFF
--- a/.github/actions/check-pr-dependency/check_dependency.py
+++ b/.github/actions/check-pr-dependency/check_dependency.py
@@ -25,7 +25,7 @@ repo = g.get_repo(args.repo)
 # Custom Function
 # #######################
 def module_ok(module_name):
-    return module_coverage[module_name] in ["nothing_to_do", "done"]
+    return module_coverage[module_name] in ["nothing_to_do", "done"] or opened_prs.get(module_name) == pr_number
 
 def _extract_migration_comment(migration_message):
     if not migration_message:


### PR DESCRIPTION
see ie https://github.com/OCA/OpenUpgrade/pull/5772, here I'd expect the Dependency OK label