### PR TITLE
[17.0][OU-ADD] project_list: Merged into project

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -68,6 +68,8 @@ merged_modules = {
     # OCA/product-attribute
     "product_catalog": "product",
     "product_catalog_sale": "sale",
+    # OCA/project
+    "project_list": "project",
     # OCA/purchase-workflow
     "purchase_discount": "purchase",
     # OCA/sale-promotion

--- a/openupgrade_scripts/scripts/project/17.0.1.3/pre-migration.py
+++ b/openupgrade_scripts/scripts/project/17.0.1.3/pre-migration.py
@@ -71,11 +71,29 @@ def _set_default_analytic_plan_id(env):
         )
 
 
+def _delete_project_list_views(env):
+    """OCA module project_list got its functionality implemented in core
+    odoo. Its ir.actions.act_window.view records (reassigned to 'project'
+    module by merged_modules in base pre-migration) collide with v17 core's
+    new records on constraint act_window_view_unique_mode_per_action.
+    """
+    openupgrade.delete_records_safely_by_xml_id(
+        env,
+        [
+            "project.open_view_project_all_group_stage_kanban",
+            "project.open_view_project_all_group_stage_tree",
+            "project.open_view_project_all_kanban",
+            "project.open_view_project_all_tree",
+        ],
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     _rename_fields(env)
     _convert_project_task_state(env)
     _set_default_analytic_plan_id(env)
+    _delete_project_list_views(env)
     openupgrade.set_xml_ids_noupdate_value(
         env,
         "project",


### PR DESCRIPTION
OCA module `project_list` (OCA/project) got its functionality implemented in core odoo (OCA/project#1191: "Not needed as included in core"). This adds it to `merged_modules` and includes a pre-migration cleanup of `ir_act_window_view` records to avoid `UniqueViolation` on constraint `act_window_view_unique_mode_per_action` introduced in v17.

## Problem

When migrating a v16 database with `project_list` installed to v17, OpenUpgrade aborts with:

```
2026-07-09 14:36:36,486 1 ERROR devel odoo.sql_db: bad query: INSERT INTO "ir_act_window_view" ("act_window_id", "create_date", "create_uid", "sequence", "view_id", "view_mode", "write_date", "write_uid") VALUES (1268, '2026-07-09 14:36:33.092540', 1, 10, 6871, 'kanban', '2026-07-09 14:36:33.092540', 1) RETURNING "id"
ERROR: duplicate key value violates unique constraint "act_window_view_unique_mode_per_action"
DETAIL:  Key (act_window_id, view_mode)=(1268, kanban) already exists.

2026-07-09 14:36:36,493 1 ERROR devel odoo.modules.registry: Failed to load registry
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 610, in _tag_root
    f(rec)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 464, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5117, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5028, in _load_records_create
    return self.create(values)
  File "<decorator-gen-12>", line 2, in create
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 431, in _model_create_multi
    return create(self, arg)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4656, in create
    records = self._create(data_list)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4844, in _create
    cr.execute(SQL(
  File "/opt/odoo/custom/src/odoo/odoo/sql_db.py", line 342, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "act_window_view_unique_mode_per_action"
DETAIL:  Key (act_window_id, view_mode)=(1268, kanban) already exists.

odoo.tools.convert.ParseError: while parsing /opt/odoo/auto/addons/project/views/project_project_views.xml:634, somewhere inside
<record id="open_view_project_all_group_stage_kanban_view" model="ir.actions.act_window.view">
            <field name="sequence" eval="10"/>
            <field name="view_mode">kanban</field>
            <field name="act_window_id" ref="open_view_project_all_group_stage"/>
            <field name="view_id" ref="project_kanban_view_group_stage"/>
        </record>
```

## Root cause

`project_list` created 4 `ir.actions.act_window.view` records in v16 on core `project` actions `open_view_project_all` and `open_view_project_all_group_stage`. v17 core `project` adds NEW `ir.actions.act_window.view` records for the same actions with the same `view_mode`, and v17 introduces the unique constraint `act_window_view_unique_mode_per_action` (`ir_actions.py:373`). The orphaned rows from `project_list` collide with the new core records.

## Fix

1. **`apriori.py`**: Add `"project_list": "project"` to `merged_modules` so that `update_module_names()` in base pre-migration reassigns the orphaned `ir_model_data` records from `project_list` to `project`.

2. **`project/17.0.1.3/pre-migration.py`**: Add `_delete_project_list_views()` to delete the 4 reassigned `ir_act_window_view` records before core `project` data loading tries to CREATE new ones. Uses `openupgrade.delete_records_safely_by_xml_id()` which is a no-op if the records don't exist (safe when `project_list` was not installed).

The xmlids deleted (`project.open_view_project_all_group_stage_kanban`, `_tree`, `project.open_view_project_all_kanban`, `_tree`) do not match v17 core's xmlids (`project.open_view_project_all_group_stage_kanban_view` with `_view` suffix) — no risk of deleting core records.

@BinhexTeam T12289