### PR TITLE
[19.0][OU-FIX] hr: finish migration

### DIFF
--- a/openupgrade_scripts/scripts/hr/19.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/hr/19.0.1.1/post-migration.py
@@ -70,11 +70,13 @@ def fill_hr_version(env):
         (
             employee_id, date_version, contract_date_start,
             last_modified_uid, last_modified_date, hr_responsible_id,
+            resource_calendar_id,
             {", ".join(fields)}
         )
         SELECT
             id, create_date, create_date,
             write_uid, write_date, {env.ref("base.user_admin").id},
+            resource_calendar_id,
             {", ".join(fields)}
         FROM hr_employee
         WHERE id NOT IN (

--- a/openupgrade_scripts/scripts/hr/19.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/hr/19.0.1.1/upgrade_analysis_work.txt
@@ -132,6 +132,8 @@ hr           / hr.employee              / private_zip (char)            : now re
 # DONE: copied to hr.version in post-migration
 
 hr           / hr.employee              / resource_calendar_id (many2one): not stored anymore
+# DONE: post-migration: copied to hr.version when an employee does not have a contract
+
 hr           / hr.employee              / salary_distribution (json)    : NEW hasdefault: compute
 hr           / hr.employee              / sinid (char)                  : DEL
 


### PR DESCRIPTION
Copied the `resource_calendar_id` field to `hr.version` when an employee does not have a contract, to prevent the field value from being lost.

Complementary to https://github.com/OCA/OpenUpgrade/pull/5566

@Tecnativa @pedrobaeza @MiquelRForgeFlow  @hbrunn could you please review this?