### PR TITLE
[DOCS][IMP] run_migration: Recommended command

### DIFF
--- a/docsource/040_run_migration.rst
+++ b/docsource/040_run_migration.rst
@@ -53,10 +53,10 @@ backup of your live database before you start this process!
 
 Edit the configuration files and command line parameters to point to the
 database you are going to upgrade. The recommended command line parameters are the
-``--upgrade-path=<path_to_openupgrade>/openupgrade_scripts/scripts --update all --stop-after-init --load=base,web,openupgrade_framework`` flags.
+``--update all --stop-after-init --load=base,web,openupgrade_framework`` flags.
 
 For versions earlier than 14.0 that are running the OpenUpgrade fork rather
-than Odoo itself, you do not pass the `load` parameter nor `upgrade-path` parameters.
+than Odoo itself, you do not pass the `load` parameter.
 
 Configuration options
 .....................


### PR DESCRIPTION
The `--upgrade-path` option is automatically added in https://github.com/OCA/OpenUpgrade/blob/439f5a570b06d8486328a88ace98c992ba12b9b6/openupgrade_framework/__init__.py#L9-L16.

I have always been using the `--upgrade-path` option because it is the "Recommended command", and then a few days ago @HekkiMelody points me out this piece of code :eyes:
Should we change the "Recommended command"?