### PR TITLE
[18.0][OU-IMP] account: create batch payment sequence

### DIFF
--- a/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/post-migration.py
@@ -208,12 +208,29 @@ def _handle_outstanding_accounts(env):
             )
 
 
+def _create_batch_payment_sequence(env):
+    """Creates a Batch Payment Number Sequence for every company that does not
+    have one yet. This covers companies that existed before the ``account``
+    module was installed.
+
+    From https://github.com/odoo/odoo/pull/273905.
+    The sequence is now created when installing the module, but still isn't when
+    migrating from a lower version.
+    This causes errors after migration when making a batch payment.
+    """
+    to_create_seqs = env["res.company"].search(
+        [("batch_payment_sequence_id", "=", False)]
+    )
+    to_create_seqs._create_batch_payment_sequence()
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     handle_lock_dates(env)
     link_payments_to_moves(env)
     account_account_code_fields(env)
     _handle_outstanding_accounts(env)
+    _create_batch_payment_sequence(env)
     openupgrade.m2o_to_x2m(
         env.cr, env["account.account"], "account_account", "company_ids", "company_id"
     )

--- a/openupgrade_scripts/scripts/account/18.0.1.3/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/account/18.0.1.3/upgrade_analysis_work.txt
@@ -215,9 +215,11 @@ account      / res.company              / account_journal_payment_debit_account_
 
 account      / res.company              / account_price_include (selection): NEW required, selection_keys: ['tax_excluded', 'tax_included'], hasdefault: default
 account      / res.company              / autopost_bills (boolean)      : NEW hasdefault: default
-account      / res.company              / batch_payment_sequence_id (many2one): NEW relation: ir.sequence
 account      / res.company              / display_invoice_tax_company_currency (boolean): NEW hasdefault: default
 # NOTHING TO DO: new features
+
+account      / res.company              / batch_payment_sequence_id (many2one): NEW relation: ir.sequence
+# DONE: post-migration: sequence created if it doesn't exist yet
 
 account      / res.company              / country_code (char)           : module is now 'base' ('account')
 # NOTHING TO DO


### PR DESCRIPTION
When no batch payment sequence exists for a company, an error occurs when trying to do a batch payment.
With https://github.com/odoo/odoo/pull/273905, Odoo now creates the sequence on account module installation.
But it isn't created when migrating from a 17.0 to a 18.0 database.
This change would now create the missing sequences during the migration.