### PR TITLE
[18.0][OU-FIX] hr_expense: Restrict translations deletions to specific fields

### DIFF
--- a/openupgrade_scripts/scripts/hr_expense/18.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/18.0.2.0/post-migration.py
@@ -6,9 +6,12 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.load_data(env, "hr_expense", "18.0.2.0/noupdate_changes.xml")
-    xml_ids = [
-        "hr_expense_template_register",
-        "product_product_no_cost",
-        "mt_expense_approved",
-    ]
-    openupgrade.delete_record_translations(env.cr, "hr_expense", xml_ids)
+    openupgrade.delete_record_translations(
+        env.cr, "hr_expense", ["hr_expense_template_register"], ["arch_db"]
+    )
+    openupgrade.delete_record_translations(
+        env.cr, "hr_expense", ["product_product_no_cost"], ["name"]
+    )
+    openupgrade.delete_record_translations(
+        env.cr, "hr_expense", ["mt_expense_approved"], ["description"]
+    )


### PR DESCRIPTION
We only reset the translations of the fields touched by noupdate changes.

@Tecnativa 