### PR TITLE
[19.0][OU-IMP] hr: Set salary_distribution

### DIFF
--- a/openupgrade_scripts/scripts/hr/19.0.1.1/post-migration.py
+++ b/openupgrade_scripts/scripts/hr/19.0.1.1/post-migration.py
@@ -101,6 +101,21 @@ def hr_employee_bank_account_ids(env):
     openupgrade.m2o_to_x2m(
         env.cr, env["hr.employee"], "hr_employee", "bank_account_ids", "bank_account_id"
     )
+    # Set salary distribution to avoid error on _compute_primary_bank_account_id
+    env.cr.execute(
+        """
+        UPDATE hr_employee
+        SET salary_distribution = json_build_object(
+            bank_account_id::text,
+            json_build_object(
+                'amount', 100.0,
+                'sequence', 1,
+                'amount_is_percentage', true
+            )
+        )
+        WHERE bank_account_id IS NOT NULL
+        """
+    )
 
 
 def hr_employee_notes(env):

--- a/openupgrade_scripts/scripts/hr/19.0.1.1/upgrade_analysis_work.txt
+++ b/openupgrade_scripts/scripts/hr/19.0.1.1/upgrade_analysis_work.txt
@@ -135,6 +135,8 @@ hr           / hr.employee              / resource_calendar_id (many2one): not s
 # DONE: post-migration: copied to hr.version when an employee does not have a contract
 
 hr           / hr.employee              / salary_distribution (json)    : NEW hasdefault: compute
+# DONE: post-migration: set to {"<bank_account_id>": {'amount', 100.0, 'sequence', 1, 'amount_is_percentage', true}}
+
 hr           / hr.employee              / sinid (char)                  : DEL
 
 # NOTHING TO DO


### PR DESCRIPTION
After migration if you try to enter in a employee with `bank_account_ids` it will raise the next error:
```
File "/opt/odoo/auto/addons/hr/models/hr_employee.py", line 1828, in _compute_primary_bank_account_id
primary_account = min(
                                  ^^^^
File "/opt/odoo/auto/addons/hr/models/hr_employee.py", line 1830, in <lambda>
 key=lambda acc: employee.salary_distribution.get(str(acc.id), {}).get("sequence", float("inf")),
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'bool' object has no attribute 'get'
```
Force the compute of `salary_distribution` to avoid it

@Tecnativa TT62941