### PR TITLE
[FIX] hr_recruitment: fix lift_constraints() constraint drop order for PostgreSQL 17+

### DIFF
--- a/openupgrade_scripts/scripts/hr_recruitment/19.0.1.1/pre-migration.py
+++ b/openupgrade_scripts/scripts/hr_recruitment/19.0.1.1/pre-migration.py
@@ -13,10 +13,20 @@ def hr_candidate2hr_applicant(env):
     """
     openupgrade.merge_models(env.cr, "hr.candidate", "hr.applicant", "candidate_id")
     openupgrade.rename_tables(env.cr, [("hr_candidate", None)])
-    openupgrade.lift_constraints(
-        env.cr, openupgrade.get_legacy_name("hr_candidate"), "id", cascade=True
+    legacy_table = openupgrade.get_legacy_name("hr_candidate")
+    # PostgreSQL >= 17 catalogs NOT NULL as a named constraint and refuses to
+    # drop it while the column is still part of a primary key, even when the
+    # pkey drop is queued in the same ALTER TABLE statement (as
+    # openupgrade.lift_constraints does). Drop the pkey first, on its own, so
+    # the remaining lift_constraints() call only has the not-null constraint
+    # left to lift.
+    env.cr.execute(
+        "alter table {} drop constraint if exists {} cascade".format(
+            legacy_table, legacy_table + "_pkey"
+        )
     )
-    openupgrade.remove_tables_fks(env.cr, [openupgrade.get_legacy_name("hr_candidate")])
+    openupgrade.lift_constraints(env.cr, legacy_table, "id", cascade=True)
+    openupgrade.remove_tables_fks(env.cr, [legacy_table])
 
 
 @openupgrade.migrate()


### PR DESCRIPTION
## Bug

On PostgreSQL 17+, `NOT NULL` is catalogued as a named constraint (`<table>_<column>_not_null`) instead of an implicit attribute flag on `pg_attribute`.

`openupgrade.lift_constraints()` drops all constraints on a column in a single `ALTER TABLE ... DROP CONSTRAINT a, DROP CONSTRAINT b` statement. When the column has both a not-null constraint and a primary key, and the not-null constraint's drop clause is listed before the primary key's, PostgreSQL rejects the statement:

```
ERROR: column "id" is in a primary key
```

PostgreSQL validates each `ALTER TABLE` subcommand against the catalog state *before* the statement runs, not against the pending effects of earlier subcommands in the same statement — so even though the very next clause would drop the primary key, the not-null drop is rejected first.

This surfaced in `hr_recruitment/19.0.1.1/pre-migration.py` when merging `hr.candidate` into `hr.applicant`: after renaming `hr_candidate` to its legacy table, `lift_constraints(cr, legacy_table, "id", cascade=True)` fails on PostgreSQL 17/18 with the error above.

## Fix

Drop the primary key constraint on the legacy table in its own, separate `ALTER TABLE ... DROP CONSTRAINT ... CASCADE` statement *before* calling `lift_constraints()`. By the time `lift_constraints()` runs, only the not-null constraint remains on the column, so there's no ordering conflict.

## Test

Reproduced the failure on a database running PostgreSQL 18.4 during an Odoo 19 upgrade, confirmed the fix resolves it.