### PR TITLE
[FIX] stock_account: avoid creating blank account.account records

### DIFF
--- a/openupgrade_scripts/scripts/stock_account/19.0.1.1/end-migration.py
+++ b/openupgrade_scripts/scripts/stock_account/19.0.1.1/end-migration.py
@@ -45,15 +45,16 @@ def update_from_coa_generic(env, spec):
 
         company_data = {}
         for model_name, field_names in spec.items():
-            company_data[model_name] = {
-                record_id: {
+            filtered_records = {}
+            for record_id, record_data in template_data[model_name].items():
+                filtered = {
                     key: value
                     for key, value in record_data.items()
                     if key in field_names and not ref_or_id(record_id, model_name)[key]
                 }
-                for record_id, record_data in template_data[model_name].items()
-                if any(record_data.get(key) for key in field_names)
-            }
+                if filtered:
+                    filtered_records[record_id] = filtered
+            company_data[model_name] = filtered_records
         AccountChartTemplate._load_data(company_data)
 
 


### PR DESCRIPTION
## Bug

`update_from_coa_generic()` in `stock_account/19.0.1.1/end-migration.py` decided whether to include a record in `company_data` based on the raw chart template data (the outer `any(record_data.get(key) for key in field_names)` check), while the actual values to load were filtered separately based on whether the *existing* account already had the field set (`not ref_or_id(record_id, model_name)[key]`).

When an account already had `account_stock_expense_id`/`account_stock_variation_id` set on the existing record, the inner per-record dict ended up empty (`{}`) — but the record was still included in `company_data` because the outer check only looked at the raw template data.

`AccountChartTemplate._load_data(company_data)` then tried to load that empty vals dict. Since the xmlid didn't yet resolve to an existing record, it was treated as "to create", producing a new `account.account` row with only ORM defaults (no `name`, `account_type`, etc.), which crashes with:

```
null value in column "name" of relation "account_account" violates not-null constraint
```

## Fix

Only include a record in `company_data` when the filtered per-record dict is actually non-empty, instead of relying on a separate check against the raw template data.

## Test

Reproduced during a 19.0 migration where `stock_account`'s `end-migration.py` crashed on `AccountChartTemplate._load_data()` with the above error; confirmed the crash disappears with this fix applied.