### PR TITLE
[FIX] project_todo: delete stale preload server action in pre-migration

### DIFF
--- a/openupgrade_scripts/scripts/project_todo/19.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/project_todo/19.0.1.0/pre-migration.py
@@ -1,0 +1,10 @@
+from openupgradelib import openupgrade
+
+deleted_xmlids = [
+    "project_todo.project_task_preload_action_todo",
+]
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.delete_records_safely_by_xml_id(env, deleted_xmlids)


### PR DESCRIPTION
## Summary

`upgrade_analysis.txt` for `project_todo` 19.0.1.0 already flags `ir.actions.server: project_todo.project_task_preload_action_todo` as removed, but no migration script actually deletes it. The stale record retains `path = 'to-dos'` in `ir_actions`, which collides with the new `path` field set on `project_task_action_todo` (an `ir.actions.act_window`) — `path` is unique across all `ir.actions` rows.

This breaks module loading on migration to 19.0 with:

```
odoo.tools.convert.ParseError: while parsing project_todo/views/project_task_views.xml
Path to show in the URL must be unique! Please choose another one.
```

## Fix

Add `pre-migration.py` deleting the obsolete `project_todo.project_task_preload_action_todo` xmlid via `openupgrade.delete_records_safely_by_xml_id`, so it is removed before the module's own view data (and the new `path` value) is loaded — matching the pattern used in other modules (e.g. `hr_fleet`).

## Test plan

- [x] Reproduced the `ParseError` on a database migrating to 19.0 with `project_todo` installed
- [x] Confirmed two conflicting rows in `ir_actions.path = 'to-dos'`: the `ir.actions.act_window` (`project_task_action_todo`) and the stale `ir.actions.server` (`project_task_preload_action_todo`)
- [x] Applied the `pre-migration.py` fix and confirmed the module loads successfully