### PR TITLE
[FIX] stock_account: skip accounts that don't exist yet in company_data

### DIFF
--- a/openupgrade_scripts/scripts/stock_account/19.0.1.1/end-migration.py
+++ b/openupgrade_scripts/scripts/stock_account/19.0.1.1/end-migration.py
@@ -47,10 +47,15 @@ def update_from_coa_generic(env, spec):
         for model_name, field_names in spec.items():
             filtered_records = {}
             for record_id, record_data in template_data[model_name].items():
+                record = ref_or_id(record_id, model_name)
+                if not record:
+                    # record doesn't exist yet in this company's chart;
+                    # don't partially-create it here, only backfill existing ones
+                    continue
                 filtered = {
                     key: value
                     for key, value in record_data.items()
-                    if key in field_names and not ref_or_id(record_id, model_name)[key]
+                    if key in field_names and not record[key]
                 }
                 if filtered:
                     filtered_records[record_id] = filtered


### PR DESCRIPTION
## Bug

Follow-up to #5885, which fixed the case where a record already exists but the target field is already set. There is still a related bug for records that don't exist yet.

`update_from_coa_generic()` in `stock_account/19.0.1.1/end-migration.py` builds `filtered_records[record_id]` based on whether the target field appears unset via `not ref_or_id(record_id, model_name)[key]`. When `ref_or_id()` can't resolve the xmlid to an existing `account.account` (the account hasn't been created yet in this company's chart), indexing `[key]` on the resulting empty recordset is also falsy — so a not-yet-existing account is treated the same as an existing account with the field unset.

`AccountChartTemplate._load_data(company_data)` then creates a new `account.account` row from only the partial `company_data` (just the 2 stock-account fields), missing required fields like `name`/`account_type`, causing:

```
null value in column "name" of relation "account_account" violates not-null constraint
```

## Fix

Skip `record_id`s that don't resolve to an existing record instead of partially-creating them. This script is meant to backfill fields on existing accounts, not create new ones.

## Test

Reproduced during a 19.0 migration where `stock_account`'s `end-migration.py` crashed on `AccountChartTemplate._load_data()` with the above error even after #5885; confirmed the crash disappears with this fix applied.