### PR TITLE
[19.0][OU-ADD] apriori: website_odoo_debranding renamed to website_debranding

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -11,6 +11,8 @@ renamed_modules = {
     # odoo/enterprise
     # OCA/timesheet
     "project_timesheet_time_control": "hr_timesheet_time_control",
+    # OCA/website
+    "website_odoo_debranding": "website_debranding",
     # OCA/...
 }
 


### PR DESCRIPTION
`website_odoo_debranding` renamed to `website_debranding`

Related to https://github.com/OCA/website/pull/1135 + https://github.com/OCA/brand/pull/274 + https://github.com/OCA/server-brand/pull/109

@Tecnativa TT64028