### PR TITLE
[19.0][FIX] stock_account: skip accounts that don't exist yet in company_data

### DIFF
--- a/openupgrade_scripts/scripts/stock_account/19.0.1.1/end-migration.py
+++ b/openupgrade_scripts/scripts/stock_account/19.0.1.1/end-migration.py
@@ -47,12 +47,15 @@ def update_from_coa_generic(env, spec):
         for model_name, field_names in spec.items():
             filtered_records = {}
             for record_id, record_data in template_data[model_name].items():
-                if not any(record_data.get(key) for key in field_names):
+                record = ref_or_id(record_id, model_name)
+                if not record or not any(record_data.get(key) for key in field_names):
+                    # record doesn't exist yet in this company's chart;
+                    # don't partially-create it here, only backfill existing ones
                     continue
                 filtered = {
                     key: value
                     for key, value in record_data.items()
-                    if key in field_names and not ref_or_id(record_id, model_name)[key]
+                    if key in field_names and not record[key]
                 }
                 if filtered:
                     filtered_records[record_id] = filtered


### PR DESCRIPTION
Follow-up to #5885, which fixed the case where a record already exists but the target field is already set. There is still a related bug for records that don't exist yet.

## Problem

While testing this migration against a real customer database (**from Odoo 16**), I hit a crash while migrating a company using the French chart of accounts (fr chart template). The failure happens because the migration tries to attach two optional fields — account_stock_expense_id and account_stock_variation_id — onto a specific account defined by the chart template: the generic "Raw materials and supplies" account (code 310000) and its matching expense account (code 601000, "Inventory item purchases – Raw materials and supplies").

The problem: this customer's company doesn't have those two generic accounts, and never has — going all the way back to their original installation. What they have instead are more specific accounts for the same purpose, split by material category: 311000/312000/317000 (raw materials A/B/C) and 601100/601200/601700 (the matching purchase accounts). This is exactly what Odoo's own French chart template provided by default at the time this company was first set up — it wasn't a customization on their part.

Since then, the official French chart template has evolved: the older per-category accounts (311/312/317, 601.1/601.2/601.7) are no longer part of the standard template, and a single generic pair (310000/601000) was introduced in their place. For a brand-new install today, that generic account gets created as part of the normal chart-of-accounts setup. But for a company migrating from an older version, there is no equivalent account to find because the account structure itself has changed — not because anything is missing or was deleted from their data.

## Bug
`update_from_coa_generic()` in `stock_account/19.0.1.1/end-migration.py` builds `filtered_records[record_id]` based on whether the target field appears unset via `not ref_or_id(record_id, model_name)[key]`. When `ref_or_id()` can't resolve the xmlid to an existing `account.account` (the account hasn't been created yet in this company's chart), indexing `[key]` on the resulting empty recordset is also falsy — so a not-yet-existing account is treated the same as an existing account with the field unset.

`AccountChartTemplate._load_data(company_data)` then creates a new `account.account` row from only the partial `company_data` (just the 2 stock-account fields), missing required fields like `name`/`account_type`, causing:

```
null value in column "name" of relation "account_account" violates not-null constraint
```

## Suggestion

Automatically creating this account during migration would mean introducing a brand-new account into a company's live chart of accounts that they never asked for and never had — purely as a side effect of a version upgrade.

The safer path is to let the migration skip this gap entirely and complete without touching the chart of accounts. Bringing the chart of accounts up to the newer template's structure can then be handled separately.

## Fix

Skip `record_id`s that don't resolve to an existing record instead of partially-creating them. This script is meant to backfill fields on existing accounts, not create new ones.

## Test

Reproduced during a 19.0 migration where `stock_account`'s `end-migration.py` crashed on `AccountChartTemplate._load_data()` with the above error even after #5885; confirmed the crash disappears with this fix applied.

Assisted-by: Claude Sonnet 5