### PR TITLE
[19.0][OU-IMP] website: preserve footer color combination

### DIFF
--- a/openupgrade_scripts/scripts/website/19.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/website/19.0.1.0/end-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2026 Tecnativa - Pilar Vargas
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+def preserve_footer_color_combination(env):
+    for website in env["website"].search([]):
+        env["website.assets"].with_context(
+            website_id=website.id
+        ).make_scss_customization(
+            "/website/static/src/scss/options/colors/user_color_palette.scss",
+            {"footer": 5},
+        )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    preserve_footer_color_combination(env)


### PR DESCRIPTION
Odoo changed the default footer color combination from 5 to 2 in odoo/odoo@62cad846a5c8adf52fc0450bc3f5cfd0492d0622.

Explicitly set combination 5 for existing websites to preserve their previous appearance after migration.

@Tecnativa TT63973

@pedrobaeza please review