### PR TITLE
[19.0][OU-IMP] sale_product_configurator_widget_product_label: Merged into sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -58,6 +58,7 @@ merged_modules = {
     "purchase_order_qty_change_no_recompute": "purchase",
     # OCA/sale-workflow
     "sale_order_warn_message": "sale",
+    "sale_product_configurator_widget_product_label": "sale",
     # OCA/stock-logistics-workflow
     "stock_picking_show_return": "stock",
     # OCA/vertical-association


### PR DESCRIPTION
This module is no longer necessary because Odoo now uses the widget created in the `account` module. This change was introduced by https://github.com/odoo/odoo/pull/170610, so this extension is no longer needed.

TT64131
@Tecnativa @pedrobaeza @pilarvargas-tecnativa could you please review this?