### PR TITLE
[18.0][OU-IMP] sale_product_configurator_widget_product_label: Merged into sale

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -43,6 +43,7 @@ renamed_modules = {
     # OCA/sale-workflow
     "product_supplierinfo_for_customer_sale": "product_customerinfo_sale",
     "product_supplierinfo_for_customer_elaboration": "product_customerinfo_elaboration",
+    "sale_product_configurator_widget_product_label": "sale",
     "sale_product_set_sale_by_packaging": "product_set_sell_only_by_packaging",
     # OCA/stock-logistics-workflow
     "stock_picking_type_shipping_policy": "stock_picking_type_force_move_type",


### PR DESCRIPTION
This module is no longer necessary because Odoo now uses the widget created in the account module. This change was introduced by https://github.com/odoo/odoo/pull/170610, so this extension is no longer needed.

TT64131
@Tecnativa @pedrobaeza @pilarvargas-tecnativa could you please review this?

Superseded https://github.com/OCA/OpenUpgrade/pull/5905