### PR TITLE
[19.0][OU-FIX] hr_expense: Compute expense state by SQL

### DIFF
--- a/openupgrade_scripts/scripts/hr_expense/19.0.2.1/end-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/19.0.2.1/end-migration.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Tecnativa - Pedro M. Baeza
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+def _set_hr_expense_state(env):
+    """Recompute hr.expense#state for records in states 'done', 'reported'.
+
+    Done here because `_get_invoice_in_payment_state` should return the proper state.
+    """
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE hr_expense
+        SET state = COALESCE(approval_state, 'draft')
+        WHERE account_move_id IS NULL
+            AND state IN ('done', 'reported')
+        """,
+    )
+    in_payment_state = env["account.move"]._get_invoice_in_payment_state()
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE hr_expense he
+        SET state = CASE
+            WHEN he.payment_mode = 'company_account' THEN 'paid'
+            WHEN am.state = 'draft' OR am.payment_state = 'not_paid' THEN 'posted'
+            WHEN am.payment_state = 'in_payment'
+                OR (
+                    am.payment_state = 'partial'
+                    AND ROUND(am.amount_residual, 0) != 0
+                ) THEN %s
+        ELSE 'paid'
+        END
+        FROM account_move am
+        WHERE he.account_move_id = am.id
+            AND he.state IN ('done', 'approved', 'reported')
+        """,
+        (in_payment_state,),
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    _set_hr_expense_state(env)

--- a/openupgrade_scripts/scripts/hr_expense/19.0.2.1/post-migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/19.0.2.1/post-migration.py
@@ -26,7 +26,8 @@ def hr_expense_approval_fields(env):
     """
     Fill hr.expense#approval_{date,state} and manager_id from hr.expense.sheet
     """
-    env.cr.execute(
+    openupgrade.logged_query(
+        env.cr,
         """
         UPDATE hr_expense
         SET
@@ -42,19 +43,8 @@ def hr_expense_approval_fields(env):
         hr_expense_sheet
         WHERE
         hr_expense.former_sheet_id=hr_expense_sheet.id
-        """
+        """,
     )
-
-
-def hr_expense_state(env):
-    """
-    Recompute hr.expense#state for records in states 'approved', 'done', 'reported'
-    """
-    env.cr.execute(
-        "SELECT id FROM hr_expense WHERE state IN ('approved', 'done', 'reported')"
-    )
-    records = env["hr.expense"].browse(_id for (_id,) in env.cr.fetchall())
-    records._compute_state()
 
 
 def update_product_uoms(env):
@@ -90,6 +80,5 @@ def migrate(env, version):
     )
     hr_expense_account_move_id(env)
     hr_expense_approval_fields(env)
-    hr_expense_state(env)
     update_product_uoms(env)
     openupgrade.delete_records_safely_by_xml_id(env, deleted_xmlids)

--- a/openupgrade_scripts/scripts/hr_expense/tests/test_hr_expense_migration.py
+++ b/openupgrade_scripts/scripts/hr_expense/tests/test_hr_expense_migration.py
@@ -1,9 +1,10 @@
-from odoo.tests import TransactionCase
+from odoo.tests import TransactionCase, tagged
 
 from odoo.addons.openupgrade_framework import openupgrade_test
 
 
 @openupgrade_test
+@tagged("post_install")
 class TestHrExpenseMigration(TransactionCase):
     def test_hr_expense_state(self):
         """


### PR DESCRIPTION
Doing it by ORM is not advised due to performance, but also because some business constraints can be triggered, like in this case `_check_can_approve`, provoking a crash in the migration.

There's also a problem in executing it in post-migration instead of end-migration: if the extra modules changing
`_get_invoice_in_payment_state` are not yet loaded, you won't get `in_payment` state, so the logic has been converted to SQL, and move to end-migration.

@Tecnativa TT61992