### PR TITLE
[18.0][OU-FIX] sale_product_configurator_widget_product_label: Move from renamed_modules to merged_modules

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -43,7 +43,6 @@ renamed_modules = {
     # OCA/sale-workflow
     "product_supplierinfo_for_customer_sale": "product_customerinfo_sale",
     "product_supplierinfo_for_customer_elaboration": "product_customerinfo_elaboration",
-    "sale_product_configurator_widget_product_label": "sale",
     "sale_product_set_sale_by_packaging": "product_set_sell_only_by_packaging",
     # OCA/stock-logistics-workflow
     "stock_picking_type_shipping_policy": "stock_picking_type_force_move_type",
@@ -98,6 +97,7 @@ merged_modules = {
     # OCA/sale-workflow
     "sale_order_qty_change_no_recompute": "sale",
     "sale_partner_shipping_invoice_domain": "sale_commercial_partner",
+    "sale_product_configurator_widget_product_label": "sale",
     # OCA/server-brand
     "hr_expense_remove_mobile_link": "hr_expense",
     # OCA/stock-logistics-workflow


### PR DESCRIPTION
https://github.com/OCA/OpenUpgrade/pull/5906#issuecomment-5316304781

@Tecnativa @pedrobaeza @hhgabelgaard could you please review this?