### PR TITLE
[19.0][OU-FIX] mrp/purchase_stock: Don't change routes configuration

### DIFF
--- a/openupgrade_scripts/scripts/mrp/19.0.2.0/noupdate_changes-transformation.xml
+++ b/openupgrade_scripts/scripts/mrp/19.0.2.0/noupdate_changes-transformation.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <!-- don't change Manufacture route -->
+    <record id="route_warehouse0_manufacture" position="replace" />
+</odoo>

--- a/openupgrade_scripts/scripts/mrp/19.0.2.0/post-migration.py
+++ b/openupgrade_scripts/scripts/mrp/19.0.2.0/post-migration.py
@@ -84,7 +84,12 @@ def mrp_workcenter_capacity_product_uom_id(env):
 
 @openupgrade.migrate()
 def migrate(env, version):
-    openupgrade.load_data(env, "mrp", "19.0.2.0/noupdate_changes.xml")
+    openupgrade.load_data(
+        env,
+        "mrp",
+        "19.0.2.0/noupdate_changes.xml",
+        xml_transformation_filename="19.0.2.0/noupdate_changes-transformation.xml",
+    )
     openupgrade.m2o_to_x2m(
         env.cr,
         env["mrp.production"],

--- a/openupgrade_scripts/scripts/purchase_stock/19.0.1.2/noupdate_changes-transformation.xml
+++ b/openupgrade_scripts/scripts/purchase_stock/19.0.1.2/noupdate_changes-transformation.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <!-- don't change Buy route -->
+    <record id="route_warehouse0_buy" position="replace" />
+</odoo>

--- a/openupgrade_scripts/scripts/purchase_stock/19.0.1.2/post-migration.py
+++ b/openupgrade_scripts/scripts/purchase_stock/19.0.1.2/post-migration.py
@@ -13,4 +13,9 @@ def migrate(env, version):
         "reference_ids",
         "group_id",
     )
-    openupgrade.load_data(env, "purchase_stock", "19.0.1.2/noupdate_changes.xml")
+    openupgrade.load_data(
+        env,
+        "purchase_stock",
+        "19.0.1.2/noupdate_changes.xml",
+        xml_transformation_filename="19.0.1.2/noupdate_changes-transformation.xml",
+    )


### PR DESCRIPTION
In https://github.com/odoo/odoo/commit/72fffcac7720f857e90ded7c6a204c11, Odoo has changed the preference of the routes to warehouse level, but on migrated DBs, there may be more than one warehouse, and the check is not set for all the warehouses right now.

Although this can be done in migration scripts, it's safer to simply keep it as it was, because when you have both Buy/Manufacture, there will be a change of behavior, selecting by priority the incorrect route.

@Tecnativa TT61992