### PR TITLE
[14.0][OU-FIX] sale_timesheet: Add timesheet_product_id column only if it does not exist

### DIFF
--- a/openupgrade_scripts/scripts/sale_timesheet/14.0.1.0/post-migration.py
+++ b/openupgrade_scripts/scripts/sale_timesheet/14.0.1.0/post-migration.py
@@ -22,7 +22,8 @@ def _fill_project_timesheet_product(env):
         env.cr,
         """UPDATE project_project pp
         SET timesheet_product_id = %s
-        WHERE pp.pricing_type IS NOT NULL AND pp.allow_timesheets""",
+        WHERE pp.pricing_type IS NOT NULL AND pp.allow_timesheets
+        AND timesheet_product_id IS NULL""",
         (product.id,),
     )
 

--- a/openupgrade_scripts/scripts/sale_timesheet/14.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/sale_timesheet/14.0.1.0/pre-migration.py
@@ -35,5 +35,6 @@ def migrate(env, version):
     openupgrade.rename_fields(env, _field_renames)
     map_pricing_type(env)
     openupgrade.logged_query(
-        env.cr, "ALTER TABLE project_project ADD timesheet_product_id int4"
+        env.cr,
+        "ALTER TABLE project_project ADD COLUMN IF NOT EXISTS timesheet_product_id int4",
     )


### PR DESCRIPTION
In the Enterprise edition, this field is added by the [industry_fsm](https://github.com/odoo/enterprise/blob/b27b98153f966c36700d154bdad4603eb85ecb32/industry_fsm/models/project.py#L28) module. To prevent an SQL error when the column already exists, add the IF NOT EXISTS clause.

@pedrobaeza @MiquelRForgeFlow @hbrunn could you please review this?