### PR TITLE
[19.0][FIX] openupgrade_framework: survive fresh databases

### DIFF
--- a/openupgrade_framework/odoo_patch/odoo/modules/migration.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/migration.py
@@ -10,6 +10,14 @@ def _get_files(self):
     to_exclude = [("analytic", "1.2")]
     for addon, version in to_exclude:
         self.migrations.get(addon, {}).get("module", {}).pop(version, None)
+    for pkg in self.graph:
+        if pkg.load_version or pkg.name not in self.migrations:
+            continue
+        # No version in the database means no data to migrate, and an empty
+        # installed_version matches every version folder. Keep only the
+        # OpenUpgrade scripts from upgrade_path.
+        self.migrations[pkg.name]["module"] = {}
+        self.migrations[pkg.name]["module_upgrades"] = {}
 
 
 _get_files._original_method = MigrationManager._get_files

--- a/openupgrade_framework/odoo_patch/odoo/modules/module_graph.py
+++ b/openupgrade_framework/odoo_patch/odoo/modules/module_graph.py
@@ -4,6 +4,7 @@ import os
 
 import odoo
 from odoo.modules.module_graph import ModuleGraph
+from odoo.tools.sql import table_exists
 
 
 def _update_from_database(self, *args, **kwargs) -> None:
@@ -14,9 +15,10 @@ def _update_from_database(self, *args, **kwargs) -> None:
     # need to be set to null instead of false. and as this is read before any upgrade
     # scripts run, we do it here. the statement is a bit clunky because it has to work
     # before and after the translate column is converted from boolean to varchar
-    self._cr.execute(
-        "UPDATE ir_model_fields SET translate=NULL where translate::varchar='false'"
-    )
+    if table_exists(self._cr, "ir_model_fields"):
+        self._cr.execute(
+            "UPDATE ir_model_fields SET translate=NULL where translate::varchar='false'"
+        )
 
     if os.environ.get("OPENUPGRADE_USE_DEMO", "") == "yes":
         return


### PR DESCRIPTION
The `ir_model_fields#translate` cleanup ran before the table exists: on a brand new database `base_data.sql` does not create it, the ORM does later on. Guard it with `table_exists()`.

Forcing the upgrade scripts of every module in the graph also ran the module's own historical migration scripts for modules installed from scratch, where `installed_version` is empty and thus every version folder matches. Installing `l10n_ch`, `l10n_in`, `l10n_nl`, `l10n_pl` or `l10n_sg` failed on their 9.0 scripts, which import a function removed from `account` long ago. Keep only the OpenUpgrade scripts from `upgrade_path` for those modules.

Found doing manual analysis from fresh database for https://github.com/OCA/OpenUpgrade/pull/5953.