### PR TITLE
[19.0][REN] sales_team_invoiced_target_domain: Rename to sales_team_invoiced_target_report

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -17,6 +17,8 @@ renamed_modules = {
     "portal_odoo_debranding": "portal_debranding",
     # OCA/website
     "website_odoo_debranding": "website_debranding",
+    # OCA/sale-report
+    "sales_team_invoiced_target_domain": "sales_team_invoiced_target_report",
     # OCA/...
 }
 


### PR DESCRIPTION
Rename `sales_team_invoiced_target_domain` -> `sales_team_invoiced_target_report`

PR OCA/sale-reporting#399
Module [sales_team_invoiced_target_domain](https://github.com/OCA/sale-workflow/tree/17.0/sales_team_invoiced_target_domain)

@Tecnativa
TT64139