### PR TITLE
[18.0][OU-FIX] sale_commission_pricelist renamed to sale_commission_pricelist_oca

### DIFF
--- a/openupgrade_scripts/apriori.py
+++ b/openupgrade_scripts/apriori.py
@@ -21,6 +21,7 @@ renamed_modules = {
     "hr_commission": "hr_commission_oca",
     "sale_commission_margin": "sale_commission_margin_oca",
     "sale_commission": "sale_commission_oca",
+    "sale_commission_pricelist": "sale_commission_pricelist_oca",
     "sale_commission_product_criteria": "sale_commission_oca_product_criteria",
     "sale_commission_product_criteria_semaphore": "sale_commission_oca_product_criteria_semaphore",  # noqa: E501
     # OCA/edi


### PR DESCRIPTION
after migration in https://github.com/OCA/commission/pull/638