### PR TITLE
[19.0][OU-IMP] website: reset unmodified COW templates to upstream

### DIFF
--- a/openupgrade_scripts/scripts/website/19.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/website/19.0.1.0/end-migration.py
@@ -17,3 +17,4 @@ def preserve_footer_color_combination(env):
 @openupgrade.migrate()
 def migrate(env, version):
     preserve_footer_color_combination(env)
+    openupgrade.cow_templates_replicate_upstream(env.cr)

--- a/openupgrade_scripts/scripts/website/19.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/website/19.0.1.0/pre-migration.py
@@ -40,3 +40,4 @@ def qweb_templates_remove_inherit_id(env):
 def migrate(env, version):
     website_menu_url(env)
     qweb_templates_remove_inherit_id(env)
+    openupgrade.cow_templates_mark_if_equal_to_upstream(env.cr)


### PR DESCRIPTION
Call `cow_templates_mark_if_equal_to_upstream()` in the pre-migration and `cow_templates_replicate_upstream()` in the end-migration. A website that enables an optional template through the Customize widget but never edits it keeps a COW copy; until now that copy was never resynced on migration, so it kept the origin `arch_db` and `inherit_id`. When a module migration re-targets which template the view inherits from, the stale copy points at the old parent and breaks rendering, as happened with `website_sale_product_attribute_filter_category` on 18.0 -> 19.0 (crashed `/shop`).

`cow_templates_replicate_upstream()` also propagates `inherit_id` since OCA/openupgradelib#463.

@Tecnativa TT64160
@pedrobaeza @pilarvargas-tecnativa 