### PR TITLE
[16.0][OU-IMP] website: reset unmodified COW templates to upstream

### DIFF
--- a/openupgrade_scripts/scripts/website/16.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/website/16.0.1.0/end-migration.py
@@ -115,3 +115,4 @@ def migrate(env, version):
     convert_custom_qweb_templates_bootstrap_4to5(env)
     convert_field_html_string_bootstrap_4to5(env)
     rename_t_group_website_restricted_editor(env)
+    openupgrade.cow_templates_replicate_upstream(env.cr)

--- a/openupgrade_scripts/scripts/website/16.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/website/16.0.1.0/pre-migration.py
@@ -149,3 +149,4 @@ def migrate(env, version):
     _fill_homepage_url(env)
     _mig_s_progress_steps_contents(env)
     _reset_customize_show_in_website_views(env)
+    openupgrade.cow_templates_mark_if_equal_to_upstream(env.cr)


### PR DESCRIPTION
Call `cow_templates_mark_if_equal_to_upstream()` in the pre-migration and `cow_templates_replicate_upstream()` in the end-migration. A website that enables an optional template through the Customize widget but never edits it keeps a COW copy; until now that copy was never resynced on migration, so it kept the origin `arch_db` and `inherit_id`. When a module migration re-targets which template the view inherits from, the stale copy points at the old parent and breaks rendering, as seen with `website_sale_product_attribute_filter_category` when `website_sale` moved a template between versions.

`cow_templates_replicate_upstream()` also propagates `inherit_id` since OCA/openupgradelib#463.

@Tecnativa TT64160
@pedrobaeza @pilarvargas-tecnativa 