### PR TITLE
[15.0][OU-IMP] website: reset unmodified COW templates to upstream

### DIFF
--- a/openupgrade_scripts/scripts/website/15.0.1.0/end-migration.py
+++ b/openupgrade_scripts/scripts/website/15.0.1.0/end-migration.py
@@ -1,0 +1,9 @@
+# Copyright 2026 Tecnativa - Cristina Hidalgo
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.cow_templates_replicate_upstream(env.cr)

--- a/openupgrade_scripts/scripts/website/15.0.1.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/website/15.0.1.0/pre-migration.py
@@ -4,3 +4,4 @@ from openupgradelib import openupgrade
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.set_xml_ids_noupdate_value(env, "website", ["action_website"], False)
+    openupgrade.cow_templates_mark_if_equal_to_upstream(env.cr)


### PR DESCRIPTION
Call `cow_templates_mark_if_equal_to_upstream()` in the pre-migration and `cow_templates_replicate_upstream()` in the end-migration. A website that enables an optional template through the Customize widget but never edits it keeps a COW copy; until now that copy was never resynced on migration, so it kept the origin `arch_db` and `inherit_id`. When a module migration re-targets which template the view inherits from, the stale copy points at the old parent and breaks rendering, as seen with `website_sale_product_attribute_filter_category` when `website_sale` moved a template between versions.

`cow_templates_replicate_upstream()` also propagates inherit_id since OCA/openupgradelib#463.

@Tecnativa TT64160
@pedrobaeza @pilarvargas-tecnativa 