### PR TITLE
[18.0][FIX] mrp: location_dest_id with the MRP module installed.

### DIFF
--- a/openupgrade_scripts/scripts/mrp/18.0.2.0/pre-migration.py
+++ b/openupgrade_scripts/scripts/mrp/18.0.2.0/pre-migration.py
@@ -29,8 +29,32 @@ def mrp_workorder_sequence(env):
     )
 
 
+def fill_mrp_stock_move_location_dest_id(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE stock_move sm
+        SET location_dest_id = mp.location_dest_id
+        FROM mrp_production mp
+        WHERE sm.production_id = mp.id
+            AND mp.location_dest_id IS NOT NULL
+        """,
+    )
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE stock_move sm
+        SET location_dest_id = mp.production_location_id
+        FROM mrp_production mp
+        WHERE sm.raw_material_production_id = mp.id
+            AND mp.production_location_id IS NOT NULL;
+        """,
+    )
+
+
 @openupgrade.migrate()
 def migrate(env, version):
     openupgrade.add_columns(env, add_columns)
     openupgrade.copy_columns(env.cr, copy_columns)
     mrp_workorder_sequence(env)
+    fill_mrp_stock_move_location_dest_id(env)


### PR DESCRIPTION
## **Summary**

This PR fixes the pre-migration script for the MRP module in version 18 by adjusting the calculation of `location_dest_id` to consider inheritance and the custom logic applied by the Manufacturing (MRP) module.

## Problem Description

The current pre-migration script for the stock module to v18 renames `location_dest_id` to `location_final_id` and recalculates `location_dest_id` using the standard `stock.move` queries (based on `_compute_location_dest_id()`).

However, this logic is incomplete when the mrp module is installed, since this module overrides the `_compute_location_dest_id()` method. Currently, there is no mechanism in place to handle this scenario, resulting in an incorrect `location_dest_id` in stock movements generated from a production order.

## To Reproduce

1. Perform a database migration from v17 to v18 with MRP installed.
2. Examine an existing manufacturing order (MO) in the source version:
<img width="2959" height="1512" alt="Selección_430" src="https://github.com/user-attachments/assets/3c616ac0-ec9d-41e6-82b9-83ea4b97f2b8" />

4. Verify the stock movements generated by that MO:
<img width="2982" height="629" alt="Selección_429" src="https://github.com/user-attachments/assets/e113d281-b6e5-49a7-806a-10ef54774e37" />

5. In v18, review the stock movement history. You will notice that `location_dest_id` has not been migrated correctly. The expected behavior, following the logic for creating an MO in v18, should be different:
<img width="2668" height="818" alt="Selección_432" src="https://github.com/user-attachments/assets/904aeae0-04de-4c6d-936d-e1dbb6ec2962" />




@HaraldPanten @ValentinVinagre 
I-8773